### PR TITLE
provide `Hbar` wrapper which applies tinybar conversions

### DIFF
--- a/__tests__/Hbar.test.js.ts
+++ b/__tests__/Hbar.test.js.ts
@@ -1,0 +1,73 @@
+import {Hbar, HbarUnit, hbarUnits, tinybarConversions} from "../src/Hbar";
+import BigNumber from "bignumber.js";
+
+describe('Hbar', () => {
+    const fiftyGTinybar = new BigNumber(5_000_000_000);
+    const fiftyHbar = Hbar.fromTinybar(fiftyGTinybar); // 50 hbar
+
+    const hundredHbar = Hbar.from(new BigNumber(10_000_000_000), 'tinybar');
+    const zeroHbar = Hbar.from(0, 'tinybar');
+
+    it('factory method checks', () => {
+        expect(fiftyHbar.asTinybar()).toStrictEqual(fiftyGTinybar);
+        expect(fiftyHbar.value()).toStrictEqual(new BigNumber(50));
+
+        expect(Hbar.from('50').asTinybar()).toStrictEqual(fiftyGTinybar);
+        expect(Hbar.fromTinybar('5000000000').asTinybar()).toStrictEqual(fiftyGTinybar);
+    });
+
+    it.each(
+        [
+            [50_000_000, 'microbar'],
+            ['50000000', 'microbar'],
+            [50_000, 'millibar'],
+            ['50000', 'millibar'],
+            [50, 'hbar'],
+            ['50', 'hbar'],
+            [0.05, 'kilobar'],
+            ['0.05', 'kilobar'],
+            [0.00005, 'megabar'],
+            ['0.00005', 'megabar'],
+            [0.00000005, 'gigabar'],
+            ['0.00000005', 'gigabar']
+        ] as [number, HbarUnit][])(
+        'value conversions are correct/50 hbar',
+        (amount, unit) => {
+            expect(Hbar.from(amount, unit))
+                .toStrictEqual(fiftyHbar);
+
+            expect(fiftyHbar.as(unit)).toStrictEqual(new BigNumber(amount));
+        });
+
+    it('arithmetic works correctly', () => {
+        expect(fiftyHbar.plus(fiftyHbar)).toStrictEqual(hundredHbar);
+        expect(fiftyHbar.plus(fiftyGTinybar, 'tinybar')).toStrictEqual(hundredHbar);
+
+        expect(fiftyHbar.minus(fiftyHbar)).toStrictEqual(zeroHbar);
+        expect(fiftyHbar.minus(fiftyGTinybar, 'tinybar')).toStrictEqual(zeroHbar);
+
+        expect(fiftyHbar.negated().asTinybar()).toStrictEqual(fiftyGTinybar.negated());
+        expect(fiftyHbar.negated().isNegative()).toBe(true);
+    });
+
+    it('comparison works correctly', () => {
+        expect(fiftyHbar.isEqualTo(fiftyHbar)).toBe(true);
+        expect(fiftyHbar.isEqualTo(fiftyGTinybar, 'tinybar')).toBe(true);
+        expect(fiftyHbar.isEqualTo(50, 'hbar')).toBe(true);
+
+        expect(fiftyHbar.isEqualTo(hundredHbar)).toBe(false);
+        expect(fiftyHbar.isEqualTo(zeroHbar)).toBe(false);
+        expect(fiftyHbar.isEqualTo(100, 'hbar')).toBe(false);
+        expect(fiftyHbar.isEqualTo(500, 'hbar')).toBe(false);
+
+        expect(fiftyHbar.comparedTo(fiftyHbar)).toStrictEqual(0);
+        expect(fiftyHbar.comparedTo(hundredHbar)).toStrictEqual(-1);
+        expect(fiftyHbar.comparedTo(zeroHbar)).toStrictEqual(1);
+    });
+
+    it('hbarUnits matches tinyBarConversions', () => {
+        expect([...hbarUnits].sort()).toStrictEqual(Object.keys(tinybarConversions).sort());
+    });
+});
+
+

--- a/exports.ts
+++ b/exports.ts
@@ -19,3 +19,5 @@ export {
 } from './src/Keys';
 
 export * from './src/typedefs';
+
+export {Hbar, HbarUnit, hbarUnits, hbarUnitSymbols} from './src/Hbar';

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "tweetnacl": "^1.0.1"
   },
   "devDependencies": {
-    "@launchbadge/eslint-config": "^0.11.6",
+    "@launchbadge/eslint-config": "^0.12.1",
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.5",
     "eslint": "^6.3.0",

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -14,6 +14,7 @@ import BigNumber from "bignumber.js";
 import {CryptoService} from "./generated/CryptoService_pb_service";
 
 import {AccountId, TransactionId} from "./typedefs";
+import {Hbar} from "./Hbar";
 import UnaryMethodDefinition = grpc.UnaryMethodDefinition;
 
 export type Signer = (msg: Uint8Array) => Uint8Array | Promise<Uint8Array>;
@@ -94,7 +95,7 @@ export abstract class BaseClient {
      * @param recipient
      * @param amount
      */
-    public transferCryptoTo(recipient: AccountId, amount: number | BigNumber): Promise<TransactionId> {
+    public transferCryptoTo(recipient: AccountId, amount: number | BigNumber | Hbar): Promise<TransactionId> {
         const txn = new CryptoTransferTransaction(this)
             .addSender(this.operatorAcct, amount)
             .addRecipient(recipient, amount)

--- a/src/Hbar.ts
+++ b/src/Hbar.ts
@@ -1,0 +1,124 @@
+import BigNumber from "bignumber.js";
+import {checkNumber} from "./util";
+
+const hbarAsTinybar = new BigNumber(100_000_000);
+
+/** Multipliers of tinybar to other denominations */
+export const tinybarConversions = {
+    tinybar: 1,
+    microbar: 100,
+    millibar: 100_000,
+    hbar: hbarAsTinybar,
+    kilobar: hbarAsTinybar.multipliedBy(1000),
+    megabar: hbarAsTinybar.multipliedBy(1_000_000),
+    gigabar: hbarAsTinybar.multipliedBy(1_000_000_000),
+};
+
+function convertToTinybar(amount: BigNumber.Value, unit: HbarUnit): BigNumber {
+    const bnAmount = amount instanceof BigNumber ? amount : new BigNumber(amount);
+    return bnAmount.multipliedBy(tinybarConversions[unit]);
+}
+
+export type HbarUnit = keyof typeof tinybarConversions;
+
+/** The possible denominations of hbar in order by magnitude */
+export const hbarUnits: HbarUnit[] = [
+    'tinybar', 'microbar', 'millibar', 'hbar', 'kilobar', 'megabar', 'gigabar'
+];
+
+/** Symbols for denominations of hbar for use in UIs */
+export const hbarUnitSymbols = {
+    tinybar: 'tℏ',
+    microbar: 'μℏ',
+    millibar: 'mℏ',
+    hbar: 'ℏ',
+    kilobar: 'kℏ',
+    megabar: 'Mℏ',
+    gigabar: 'Gℏ',
+};
+
+export class Hbar {
+    /** The Hbar value in tinybar, used natively by the SDK and Hedera itself */
+    private readonly tinybar: BigNumber;
+
+    private constructor(tinybar: BigNumber) {
+        checkNumber(tinybar);
+        this.tinybar = tinybar;
+    }
+
+    /**
+     * Calculate the Hbar amount given a raw value and a unit
+     * (assumes value is in hbar if not provided)
+     */
+    public static from(amount: number | BigNumber | string, unit: HbarUnit = 'hbar'): Hbar {
+        return new Hbar(convertToTinybar(amount, unit));
+    }
+
+    /** Get Hbar from a tinybar amount, may be a string */
+    public static fromTinybar(amount: number | BigNumber | string): Hbar {
+        const bnAmount = amount instanceof BigNumber ? amount : new BigNumber(amount);
+        return new Hbar(bnAmount);
+    }
+
+    public value(): BigNumber {
+        return this.as('hbar');
+    }
+
+    public asTinybar(): BigNumber {
+        return this.as('tinybar');
+    }
+
+    public as(unit: HbarUnit): BigNumber {
+        if (unit === 'tinybar') { return this.tinybar; }
+
+        return this.tinybar.dividedBy(tinybarConversions[unit]);
+    }
+
+    public plus(hbar: Hbar): Hbar;
+    public plus(amount: number | BigNumber, unit: HbarUnit): Hbar;
+    public plus(amount: Hbar | number | BigNumber, unit?: HbarUnit): Hbar {
+        if (amount instanceof Hbar) {
+            return new Hbar(this.tinybar.plus(amount.tinybar));
+        } else {
+            return new Hbar(this.tinybar.plus(convertToTinybar(amount, unit!)));
+        }
+    }
+
+    public minus(hbar: Hbar): Hbar;
+    public minus(amount: number | BigNumber, unit: HbarUnit): Hbar;
+    public minus(amount: Hbar | number | BigNumber, unit?: HbarUnit): Hbar {
+        if (amount instanceof Hbar) {
+            return new Hbar(this.tinybar.minus(amount.tinybar));
+        } else {
+            return new Hbar(this.tinybar.minus(convertToTinybar(amount, unit!)));
+        }
+    }
+
+    public isEqualTo(hbar: Hbar): boolean;
+    public isEqualTo(amount: number | BigNumber, unit: HbarUnit): boolean;
+    public isEqualTo(amount: Hbar | number | BigNumber, unit?: HbarUnit): boolean {
+        if (amount instanceof Hbar) {
+            return this.tinybar.isEqualTo(amount.tinybar);
+        } else {
+            return this.tinybar.isEqualTo(convertToTinybar(amount, unit!));
+        }
+    }
+
+    public comparedTo(hbar: Hbar): number;
+    public comparedTo(amount: number | BigNumber, unit: HbarUnit): number;
+    public comparedTo(amount: Hbar | number | BigNumber, unit?: HbarUnit): number {
+        if (amount instanceof Hbar) {
+            return this.tinybar.comparedTo(amount.tinybar);
+        } else {
+            return this.tinybar.comparedTo(convertToTinybar(amount, unit!));
+        }
+    }
+    
+    public negated(): Hbar {
+        return new Hbar(this.tinybar.negated());
+    }
+
+    public isNegative(): boolean {
+        return this.tinybar.isNegative();
+    }
+}

--- a/src/TransactionBuilder.ts
+++ b/src/TransactionBuilder.ts
@@ -1,6 +1,12 @@
 import {BaseClient, getNode, Node, randomNode} from "./BaseClient";
 import {TransactionBody} from "./generated/TransactionBody_pb";
-import {getProtoAccountId, getProtoTxnId, newDuration, newTxnId} from "./util";
+import {
+    getProtoAccountId,
+    getProtoTxnId,
+    newDuration,
+    newTxnId,
+    toPositiveTinybarString
+} from "./util";
 import {newTxn, Transaction} from "./Transaction";
 import {Transaction as Transaction_} from "./generated/Transaction_pb";
 import {grpc} from "@improbable-eng/grpc-web";
@@ -8,6 +14,7 @@ import {TransactionResponse} from "./generated/TransactionResponse_pb";
 import BigNumber from "bignumber.js";
 
 import {AccountId, TransactionId} from "./typedefs";
+import {Hbar} from "./Hbar";
 import UnaryMethodDefinition = grpc.UnaryMethodDefinition;
 
 /**
@@ -38,8 +45,8 @@ export abstract class TransactionBuilder {
         return this;
     }
 
-    public setTransactionFee(fee: number | BigNumber): this {
-        this.inner.setTransactionfee(String(fee));
+    public setTransactionFee(fee: number | BigNumber | Hbar): this {
+        this.inner.setTransactionfee(toPositiveTinybarString(fee));
         return this;
     }
 

--- a/src/account/AccountCreateTransaction.ts
+++ b/src/account/AccountCreateTransaction.ts
@@ -4,10 +4,11 @@ import {TransactionResponse} from "../generated/TransactionResponse_pb";
 import {grpc} from "@improbable-eng/grpc-web";
 import {CryptoCreateTransactionBody} from "../generated/CryptoCreate_pb";
 import {BaseClient} from "../BaseClient";
-import {checkNumber, newDuration} from "../util";
+import {checkNumber, newDuration, toPositiveTinybarString} from "../util";
 import {PublicKey} from "../Keys";
 import BigNumber from "bignumber.js";
 import {CryptoService} from "../generated/CryptoService_pb_service";
+import {Hbar} from "../Hbar";
 import UnaryMethodDefinition = grpc.UnaryMethodDefinition;
 
 export class AccountCreateTransaction extends TransactionBuilder {
@@ -38,9 +39,8 @@ export class AccountCreateTransaction extends TransactionBuilder {
         return this;
     }
 
-    setInitialBalance(balance: number | BigNumber): this {
-        checkNumber(balance);
-        this.body.setInitialbalance(String(balance));
+    setInitialBalance(balance: number | BigNumber | Hbar): this {
+        this.body.setInitialbalance(toPositiveTinybarString(balance));
         return this;
     }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,6 +7,7 @@ import {TransactionResponse} from "./generated/TransactionResponse_pb";
 import {Response} from "./generated/Response_pb";
 import BigNumber from "bignumber.js";
 import {throwIfExceptional} from "./errors";
+import {Hbar} from "./Hbar";
 
 export function orThrow<T>(val?: T, msg = 'value must not be null'): T {
     if (val === undefined || val === null) {
@@ -125,6 +126,33 @@ export function checkNumber(amount: number | BigNumber): void {
         throw new Error('`amount` as BigNumber must be an integer in the range [-2^63, 2^63)');
     } else if (typeof amount === 'number' && !Number.isSafeInteger(amount)) {
         throw new TypeError('`amount` as number must be in the range [-2^53, 2^53 - 1)');
+    }
+}
+
+export function toTinybarString(amount: number | BigNumber | Hbar): string {
+    if (amount instanceof Hbar) {
+        return String(amount.asTinybar());
+    } else {
+        checkNumber(amount);
+        return String(amount);
+    }
+}
+
+export function toPositiveTinybarString(amount: number | BigNumber | Hbar): string {
+    if (amount instanceof Hbar) {
+        if (amount.isNegative()) {
+            throw new Error(`amount must not be negative: ${amount.asTinybar()}`)
+        }
+
+        return String(amount.asTinybar());
+    } else {
+        checkNumber(amount);
+
+        if ((amount instanceof BigNumber && amount.isNegative()) || amount < 0) {
+            throw new Error(`amount must not be negative: ${amount}`)
+        }
+
+        return String(amount);
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -306,14 +306,14 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^13.0.0"
 
-"@launchbadge/eslint-config@^0.11.6":
-  version "0.11.7"
-  resolved "https://registry.yarnpkg.com/@launchbadge/eslint-config/-/eslint-config-0.11.7.tgz#d0bd4737fcebaf5ce41d337050ad1fb3453c7c4e"
-  integrity sha512-Bho5T5AQspDdFiL7EVz9qojDf/XINV7j5DDGnKoRrrzZ+lEd/0UQmodk2NITVcOMwY1a5rctH5iPO6kRvcUgxQ==
+"@launchbadge/eslint-config@^0.12.1":
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/@launchbadge/eslint-config/-/eslint-config-0.12.1.tgz#11fa0280a1bebb20804a0d68e6d8f5165aebf86a"
+  integrity sha512-1DhQbI9gl/Mr80p6HJYiIL0/8cSKv7DJJ8QhEnubFd1B+Hr1+aiOtvuj6PvATRJLYtwDxjUCKegglALus8qrlA==
   dependencies:
-    "@lwc/eslint-plugin-lwc" "^0.7.0"
-    "@typescript-eslint/eslint-plugin" "^2.2.0"
-    "@typescript-eslint/parser" "^2.2.0"
+    "@lwc/eslint-plugin-lwc" "^0.8.0"
+    "@typescript-eslint/eslint-plugin" "^2.3.0"
+    "@typescript-eslint/parser" "^2.3.0"
     "@vue/eslint-config-prettier" "^5.0.0"
     "@vue/eslint-config-typescript" "^4.0.0"
     eslint-import-resolver-typescript "^1.1.1"
@@ -321,15 +321,15 @@
     eslint-plugin-compat "^3.3.0"
     eslint-plugin-import "^2.18.2"
     eslint-plugin-jest "^22.17.0"
-    eslint-plugin-prettier "^3.1.0"
-    eslint-plugin-unicorn "^10.0.0"
+    eslint-plugin-prettier "^3.1.1"
+    eslint-plugin-unicorn "^11.0.0"
     eslint-plugin-vue "^5.2.3"
     prettier "^1.18.2"
 
-"@lwc/eslint-plugin-lwc@^0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.7.0.tgz#95f3be7896e1a06432842ff917052bd6d7893711"
-  integrity sha512-vjOQ0zH5F0iOi2VHu68D7jB2r9Phm+SaqN+rz1pcmSavtoXsoqkLR25Snu0q+KRZRgHHSMEezL2GaE6KhHP95Q==
+"@lwc/eslint-plugin-lwc@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@lwc/eslint-plugin-lwc/-/eslint-plugin-lwc-0.8.0.tgz#40ed5b9809434f3bd901309359273d19c6c3e888"
+  integrity sha512-HV5gEcB9PuusAGgMtPWFEzal8cw3LmpXgVUOIpHQ1a/yoNyn9Jofo8eur51yjgTSjHJGH0iqmjSLxmcvc1IAYA==
 
 "@types/babel__core@^7.1.0":
   version "7.1.3"
@@ -439,6 +439,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-11.11.6.tgz#df929d1bb2eee5afdda598a41930fe50b43eaa6a"
   integrity sha512-Exw4yUWMBXM3X+8oqzJNRqZSwUAaS4+7NdvHqQuFi/d+synz++xmX3QIf+BFqneW8N31R8Ky+sikfZUXq07ggQ==
 
+"@types/normalize-package-data@^2.4.0":
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz#e486d0d97396d79beedd0a6e33f4534ff6b4973e"
+  integrity sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -467,12 +472,12 @@
     regexpp "^2.0.1"
     tsutils "^3.7.0"
 
-"@typescript-eslint/eslint-plugin@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.2.0.tgz#cba8caa6ad8df544c46bca674125a31af8c9ac2f"
-  integrity sha512-rOodtI+IvaO8USa6ValYOrdWm9eQBgqwsY+B0PPiB+aSiK6p6Z4l9jLn/jI3z3WM4mkABAhKIqvGIBl0AFRaLQ==
+"@typescript-eslint/eslint-plugin@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.3.0.tgz#6ead12c6b15a9b930430931e396e01a1fe181fcc"
+  integrity sha512-QgO/qmNye+rKsU7dan6pkBTSfpbyrHJidsw9bR3gZCrQNTB9eWQ5+UDkrrev/fu9xg6Qh7ebbx03IVuGnGRmEw==
   dependencies:
-    "@typescript-eslint/experimental-utils" "2.2.0"
+    "@typescript-eslint/experimental-utils" "2.3.0"
     eslint-utils "^1.4.2"
     functional-red-black-tree "^1.0.1"
     regexpp "^2.0.1"
@@ -487,13 +492,13 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-scope "^4.0.0"
 
-"@typescript-eslint/experimental-utils@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.2.0.tgz#31d855fbc425168ecf56960c777aacfcca391cff"
-  integrity sha512-IMhbewFs27Frd/ICHBRfIcsUCK213B8MsEUqvKFK14SDPjPR5JF6jgOGPlroybFTrGWpMvN5tMZdXAf+xcmxsA==
+"@typescript-eslint/experimental-utils@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/experimental-utils/-/experimental-utils-2.3.0.tgz#19a8e1b8fcee7d7469f3b44691d91830568de140"
+  integrity sha512-ry+fgd0Hh33LyzS30bIhX/a1HJpvtnecjQjWxxsZTavrRa1ymdmX7tz+7lPrPAxB018jnNzwNtog6s3OhxPTAg==
   dependencies:
     "@types/json-schema" "^7.0.3"
-    "@typescript-eslint/typescript-estree" "2.2.0"
+    "@typescript-eslint/typescript-estree" "2.3.0"
     eslint-scope "^5.0.0"
 
 "@typescript-eslint/parser@^1.1.0":
@@ -506,14 +511,14 @@
     "@typescript-eslint/typescript-estree" "1.13.0"
     eslint-visitor-keys "^1.0.0"
 
-"@typescript-eslint/parser@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.2.0.tgz#3cd758ed85ae9be06667beb61bbdf8060f274fb7"
-  integrity sha512-0mf893kj9L65O5sA7wP6EoYvTybefuRFavUNhT7w9kjhkdZodoViwVS+k3D+ZxKhvtL7xGtP/y/cNMJX9S8W4A==
+"@typescript-eslint/parser@^2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-2.3.0.tgz#d2df1d4bb8827e36125fb7c6274df1b4d4e614f0"
+  integrity sha512-Dc+LAtHts0yDuusxG0NVjGvrpPy2kZauxqPbfFs0fmcMB4JhNs+WwIDMFGWeKjbGoPt/SIUC9XJ7E0ZD/f8InQ==
   dependencies:
     "@types/eslint-visitor-keys" "^1.0.0"
-    "@typescript-eslint/experimental-utils" "2.2.0"
-    "@typescript-eslint/typescript-estree" "2.2.0"
+    "@typescript-eslint/experimental-utils" "2.3.0"
+    "@typescript-eslint/typescript-estree" "2.3.0"
     eslint-visitor-keys "^1.1.0"
 
 "@typescript-eslint/typescript-estree@1.13.0":
@@ -524,10 +529,10 @@
     lodash.unescape "4.0.1"
     semver "5.5.0"
 
-"@typescript-eslint/typescript-estree@2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.2.0.tgz#1e2aad5ed573f9f7a8e3261eb79404264c4fc57f"
-  integrity sha512-9/6x23A3HwWWRjEQbuR24on5XIfVmV96cDpGR9671eJv1ebFKHj2sGVVAwkAVXR2UNuhY1NeKS2QMv5P8kQb2Q==
+"@typescript-eslint/typescript-estree@2.3.0":
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-2.3.0.tgz#fd8faff7e4c73795c65e5817c52f9038e33ef29d"
+  integrity sha512-WBxfwsTeCOsmQ7cLjow7lgysviBKUW34npShu7dxJYUQCbSG5nfZWZTgmQPKEc+3flpbSM7tjXjQOgETYp+njQ==
   dependencies:
     glob "^7.1.4"
     is-glob "^4.0.1"
@@ -1671,30 +1676,33 @@ eslint-plugin-jest@^22.17.0:
   dependencies:
     "@typescript-eslint/experimental-utils" "^1.13.0"
 
-eslint-plugin-prettier@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.0.tgz#8695188f95daa93b0dc54b249347ca3b79c4686d"
-  integrity sha512-XWX2yVuwVNLOUhQijAkXz+rMPPoCr7WFiAl8ig6I7Xn+pPVhDhzg4DxHpmbeb0iqjO9UronEA3Tb09ChnFVHHA==
+eslint-plugin-prettier@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.1.tgz#507b8562410d02a03f0ddc949c616f877852f2ba"
+  integrity sha512-A+TZuHZ0KU0cnn56/9mfR7/KjUJ9QNVXUhwvRFSR7PGPe0zQR6PTkmyqg1AtUUEOzTqeRsUwyKFh0oVZKVCrtA==
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
-eslint-plugin-unicorn@^10.0.0:
-  version "10.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-10.0.0.tgz#f3815a759f76dd490dbb5a560e3805e0556aff17"
-  integrity sha512-hJaDsoquO+2UMtxmURXA/6VNH+sNS4kyO5aaal8fEis7pdCuErwRsGzhhI9fOYmA7985M3XADPEWmK+29T525w==
+eslint-plugin-unicorn@^11.0.0:
+  version "11.0.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-unicorn/-/eslint-plugin-unicorn-11.0.1.tgz#1bac58a2c388bfe21d36d8e91f4bba136ac18f0a"
+  integrity sha512-uxgA+OS0f/OJGk+Z1eMotuQIPc+n9JSZe9A33X+/1UiKS8gmIE2JeMnZV/CjYh/BPA3LzvJtQexx0p0CLCBOBg==
   dependencies:
+    ci-info "^2.0.0"
     clean-regexp "^1.0.0"
     eslint-ast-utils "^1.1.0"
     import-modules "^1.1.0"
     lodash.camelcase "^4.3.0"
-    lodash.defaultsdeep "^4.6.0"
+    lodash.defaultsdeep "^4.6.1"
     lodash.kebabcase "^4.1.1"
     lodash.snakecase "^4.1.1"
     lodash.topairs "^4.3.0"
     lodash.upperfirst "^4.3.1"
-    regexpp "^2.0.1"
+    read-pkg "^5.2.0"
+    regexpp "^3.0.0"
     reserved-words "^0.1.2"
     safe-regex "^2.0.2"
+    semver "^6.3.0"
 
 eslint-plugin-vue@^5.2.3:
   version "5.2.3"
@@ -3167,6 +3175,11 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lines-and-columns@^1.1.6:
+  version "1.1.6"
+  resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.1.6.tgz#1c00c743b433cd0a4e80758f7b64a57440d9ff00"
+  integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
 load-json-file@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/load-json-file/-/load-json-file-2.0.0.tgz#7947e42149af80d696cbf797bcaabcfe1fe29ca8"
@@ -3213,7 +3226,7 @@ lodash.clone@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.clone/-/lodash.clone-4.5.0.tgz#195870450f5a13192478df4bc3d23d2dea1907b6"
   integrity sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y=
 
-lodash.defaultsdeep@^4.6.0:
+lodash.defaultsdeep@^4.6.1:
   version "4.6.1"
   resolved "https://registry.yarnpkg.com/lodash.defaultsdeep/-/lodash.defaultsdeep-4.6.1.tgz#512e9bd721d272d94e3d3a63653fa17516741ca6"
   integrity sha512-3j8wdDzYuWO3lM3Reg03MuQR957t287Rpcxp1njpEa8oDrikb+FwGdW3n+FELh/A6qib6yPit0j/pv9G/yeAqA==
@@ -3602,7 +3615,7 @@ nopt@^4.0.1:
     abbrev "1"
     osenv "^0.1.4"
 
-normalize-package-data@^2.3.2:
+normalize-package-data@^2.3.2, normalize-package-data@^2.5.0:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/normalize-package-data/-/normalize-package-data-2.5.0.tgz#e66db1838b200c1dfc233225d12cb36520e234a8"
   integrity sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
@@ -3882,6 +3895,16 @@ parse-json@^4.0.0:
   dependencies:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
+
+parse-json@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/parse-json/-/parse-json-5.0.0.tgz#73e5114c986d143efa3712d4ea24db9a4266f60f"
+  integrity sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    error-ex "^1.3.1"
+    json-parse-better-errors "^1.0.1"
+    lines-and-columns "^1.1.6"
 
 parse5@4.0.0:
   version "4.0.0"
@@ -4173,6 +4196,16 @@ read-pkg@^3.0.0:
     normalize-package-data "^2.3.2"
     path-type "^3.0.0"
 
+read-pkg@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/read-pkg/-/read-pkg-5.2.0.tgz#7bf295438ca5a33e56cd30e053b34ee7250c93cc"
+  integrity sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+  dependencies:
+    "@types/normalize-package-data" "^2.4.0"
+    normalize-package-data "^2.5.0"
+    parse-json "^5.0.0"
+    type-fest "^0.6.0"
+
 readable-stream@^2.0.2, readable-stream@^2.0.6, readable-stream@^2.3.3, readable-stream@^2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
@@ -4215,6 +4248,11 @@ regexpp@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-2.0.1.tgz#8d19d31cf632482b589049f8281f93dbcba4d07f"
   integrity sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==
+
+regexpp@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/regexpp/-/regexpp-3.0.0.tgz#dd63982ee3300e67b41c1956f850aa680d9d330e"
+  integrity sha512-Z+hNr7RAVWxznLPuA7DIh8UNX1j9CDrUQxskw9IrBE1Dxue2lyXT+shqEIeLUjrokxIP8CMy1WkjgG3rTsd5/g==
 
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
@@ -4995,6 +5033,11 @@ type-check@~0.3.2:
   integrity sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
   dependencies:
     prelude-ls "~1.1.2"
+
+type-fest@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
+  integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
 typescript@^3.6.2:
   version "3.6.3"


### PR DESCRIPTION
Also, overload all methods which take tinybar amounts to accept `Hbar`.

I'd ultimately like to deprecate the other options somehow and only except values in `Hbar` but not sure when I would wanna do that.

closes #45 

Signed-off-by: Austin Bonander <austin@launchbadge.com>