### PR TITLE
add generation of Flow typdefs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ src/**/*.js
 __tests__/**/*.js
 **/*.js.map
 **/*.d.ts
+
+**/*.flow*

--- a/__tests__/Transaction.test.ts
+++ b/__tests__/Transaction.test.ts
@@ -1,4 +1,4 @@
-import {BaseClient, unaryCall} from "../src/BaseClient";
+import {BaseClient} from "../src/BaseClient";
 import {grpc} from "@improbable-eng/grpc-web";
 import {Ed25519PrivateKey} from "../src/Keys";
 import {AccountCreateTransaction} from "../src/account/AccountCreateTransaction";
@@ -18,7 +18,7 @@ class MockClient extends BaseClient {
         );
     }
 
-    public [unaryCall]<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(): Promise<Rs> {
+    public _unaryCall<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(): Promise<Rs> {
         throw new Error('should not be called');
     }
 }

--- a/index-node.ts
+++ b/index-node.ts
@@ -1,4 +1,4 @@
-import {BaseClient, ClientConfig, unaryCall} from "./src/BaseClient";
+import {BaseClient, ClientConfig} from "./src/BaseClient";
 import {grpc as grpc_web} from "@improbable-eng/grpc-web";
 
 import * as grpc from "grpc";
@@ -28,7 +28,7 @@ export class Client extends BaseClient {
         }), {});
     }
 
-    public [unaryCall]<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(url: string, request: Rq, method: UnaryMethodDefinition<Rq, Rs>): Promise<Rs> {
+    public _unaryCall<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(url: string, request: Rq, method: UnaryMethodDefinition<Rq, Rs>): Promise<Rs> {
         return new Promise<Rs>((resolve, reject) =>
             this.nodeClients[url].makeUnaryRequest(
                 // this gRPC client takes the full path

--- a/index-web.ts
+++ b/index-web.ts
@@ -1,4 +1,4 @@
-import {BaseClient, ClientConfig, unaryCall} from "./src/BaseClient";
+import {BaseClient, ClientConfig} from "./src/BaseClient";
 import {grpc} from "@improbable-eng/grpc-web";
 import ProtobufMessage = grpc.ProtobufMessage;
 import UnaryOutput = grpc.UnaryOutput;
@@ -20,7 +20,7 @@ export class Client extends BaseClient {
         super(nodes, operator);
     }
 
-    public [unaryCall]<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(url: string, request: Rq, method: grpc.UnaryMethodDefinition<Rq, Rs>): Promise<Rs> {
+    public _unaryCall<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(url: string, request: Rq, method: grpc.UnaryMethodDefinition<Rq, Rs>): Promise<Rs> {
         return new Promise((resolve, reject) => grpc.unary(method, {
             host: url,
             request,

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
   "scripts": {
     "prepare": "scripts/compile-protos.sh && tsc",
     "test": "jest",
+    "generate-flow-types": "scripts/generate-flow-types.sh",
+    "prepublishOnly": "npm run generate-flow-types",
     "create-account-test": "node examples/create-account.js",
     "lint": "eslint **/*.ts examples/*.js"
   },
@@ -32,6 +34,7 @@
     "@types/jest": "^24.0.18",
     "@types/node": "^12.7.5",
     "eslint": "^6.3.0",
+    "flowgen": "^1.10.0",
     "jest": "^24.9.0",
     "ts-jest": "^24.0.2",
     "ts-protoc-gen": "^0.11.0",

--- a/scripts/generate-flow-types.sh
+++ b/scripts/generate-flow-types.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -m
+
+run_flowgen() {
+  output=$( flowgen $f -o "${f%.ts}".js.flow 2>&1 )
+  echo "$output"
+}
+
+for f in index-*.ts exports.ts src/*.ts src/**/*.ts; do
+  run_flowgen "$f" &
+done
+
+for job in $(jobs -p)
+do
+    wait "$job"
+done

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -48,10 +48,6 @@ export type ClientConfig = {
     operator: Operator;
 };
 
-export const randomNode = Symbol();
-export const getNode = Symbol();
-export const unaryCall = Symbol();
-
 export abstract class BaseClient {
     public readonly operator: Operator;
     private readonly operatorAcct: AccountId;
@@ -167,7 +163,7 @@ export abstract class BaseClient {
         const balanceQuery = new CryptoGetAccountBalanceQuery();
         balanceQuery.setAccountid(getProtoAccountId(this.operatorAcct));
 
-        const [url, nodeAccountID] = this[randomNode]();
+        const [url, nodeAccountID] = this._randomNode();
 
         const paymentTxn = new CryptoTransferTransaction(this)
             .addSender(this.operatorAcct, 0)
@@ -182,16 +178,32 @@ export abstract class BaseClient {
         const query = new Query();
         query.setCryptogetaccountbalance(balanceQuery);
 
-        return this[unaryCall](url, query, CryptoService.cryptoGetBalance)
+        return this._unaryCall(url, query, CryptoService.cryptoGetBalance)
             .then(handleQueryPrecheck((resp) => resp.getCryptogetaccountbalance()))
             .then((response) => new BigNumber(response.getBalance()));
     }
 
-    public [randomNode](): Node {
+    /**
+     * NOT A STABLE API
+     *
+     * This method is public for access by other classes in the SDK but is not intended to be
+     * part of the stable/public API. Usage may be broken in releases with backwards-compatible
+     * version bumps.
+     */
+    // we're not using symbols because Flow doesn't support computed class properties and it's
+    // much nicer to just use `flowgen` rather than maintaining our own redundant definitions files
+    public _randomNode(): Node {
         return this.nodes[Math.floor(Math.random() * this.nodes.length)];
     }
 
-    public [getNode](node: string | AccountId): Node {
+    /**
+     * NOT A STABLE API
+     *
+     * This method is public for access by other classes in the SDK but is not intended to be
+     * part of the stable/public API. Usage may be broken in releases with backwards-compatible
+     * version bumps.
+     */
+    public _getNode(node: string | AccountId): Node {
         const maybeNode = this.nodes.find(([url, accountId]) => url === node || (
             typeof node === 'object'
                 && accountId.account == node.account
@@ -206,5 +218,12 @@ export abstract class BaseClient {
         throw new Error(`could not find node: ${JSON.stringify(node)}`);
     }
 
-    public abstract [unaryCall]<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(url: string, request: Rq, method: UnaryMethodDefinition<Rq, Rs>): Promise<Rs>;
+    /**
+     * NOT A STABLE API
+     *
+     * This method is public for access by other classes in the SDK but is not intended to be
+     * part of the stable/public API. Usage may be broken in releases with backwards-compatible
+     * version bumps.
+     */
+    public abstract _unaryCall<Rq extends ProtobufMessage, Rs extends ProtobufMessage>(url: string, request: Rq, method: UnaryMethodDefinition<Rq, Rs>): Promise<Rs>;
 }

--- a/src/QueryBuilder.ts
+++ b/src/QueryBuilder.ts
@@ -1,4 +1,4 @@
-import {BaseClient, Node, randomNode, unaryCall} from "./BaseClient";
+import {BaseClient, Node} from "./BaseClient";
 import {QueryHeader, ResponseType} from "./generated/QueryHeader_pb";
 import {Query} from "./generated/Query_pb";
 import {Response} from "./generated/Response_pb";
@@ -100,7 +100,7 @@ export abstract class QueryBuilder<T> {
 
         const [url] = this.getNode();
 
-        const response = await this.client[unaryCall](url, query, this.getMethod());
+        const response = await this.client._unaryCall(url, query, this.getMethod());
 
         const responseHeader = getResponseHeader(response);
         throwIfExceptional(responseHeader.getNodetransactionprecheckcode());
@@ -110,7 +110,7 @@ export abstract class QueryBuilder<T> {
 
     private getNode(): Node {
         if (!this.node) {
-            this.node = this.client[randomNode]();
+            this.node = this.client._randomNode();
         }
 
         return this.node;
@@ -131,7 +131,7 @@ export abstract class QueryBuilder<T> {
 
         this.validate();
 
-        const response = await this.client[unaryCall](nodeUrl, this.inner, this.getMethod());
+        const response = await this.client._unaryCall(nodeUrl, this.inner, this.getMethod());
 
         const responseHeader = getResponseHeader(response);
         throwIfExceptional(responseHeader.getNodetransactionprecheckcode());

--- a/src/TransactionBuilder.ts
+++ b/src/TransactionBuilder.ts
@@ -1,4 +1,4 @@
-import {BaseClient, getNode, Node, randomNode} from "./BaseClient";
+import {BaseClient, Node} from "./BaseClient";
 import {TransactionBody} from "./generated/TransactionBody_pb";
 import {
     getProtoAccountId,
@@ -8,7 +8,7 @@ import {
     runValidation,
     tinybarToString
 } from "./util";
-import {newTxn, Transaction} from "./Transaction";
+import {Transaction} from "./Transaction";
 import {Transaction as Transaction_} from "./generated/Transaction_pb";
 import {grpc} from "@improbable-eng/grpc-web";
 import {TransactionResponse} from "./generated/TransactionResponse_pb";
@@ -69,8 +69,8 @@ export abstract class TransactionBuilder {
     protected getNode(): Node {
         if (!this.node) {
             this.node = this.nodeAccountId
-                ? this.client[getNode](this.nodeAccountId)
-                : this.client[randomNode]();
+                ? this.client._getNode(this.nodeAccountId)
+                : this.client._randomNode();
         }
 
         return this.node;
@@ -115,6 +115,6 @@ export abstract class TransactionBuilder {
         const txn = new Transaction_();
         txn.setBodybytes(this.inner.serializeBinary());
 
-        return Transaction[newTxn](this.client, url, txn, this.inner, this.method);
+        return new Transaction(this.client, url, txn, this.inner, this.method);
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1202,7 +1202,7 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@~2.20.0:
+commander@^2.11.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
   integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
@@ -2032,6 +2032,21 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.1.tgz#69e57caa8f0eacbc281d2e2cb458d46fdb449e08"
   integrity sha512-a1hQMktqW9Nmqr5aktAux3JMNqaucxGcjtjWnZLHX7yyPCmlSV3M54nGYbqT8K+0GhF3NBgmJCc3ma+WOgX8Jg==
 
+flowgen@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/flowgen/-/flowgen-1.10.0.tgz#a041ae31d543d22166e7ba7c296b8445deb3c2e4"
+  integrity sha512-3lsoaa1vxGXhnkHuoE4mLPJi/klvpR3ID8R9CFJ/GBNi+cxJXecWQaUPrWMdNI5tGs8Y+7wrIZaCVFKFLQiGOg==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/highlight" "^7.0.0"
+    commander "^2.11.0"
+    lodash "^4.17.4"
+    paralleljs "^0.2.1"
+    prettier "^1.16.4"
+    shelljs "^0.8.3"
+    typescript "^3.4"
+    typescript-compiler "^1.4.1-2"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -2138,7 +2153,7 @@ glob-parent@^5.0.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
+glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4:
   version "7.1.4"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.4.tgz#aa608a2f6c577ad357e1ae5a5c26d9a8d1969255"
   integrity sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==
@@ -3862,6 +3877,11 @@ pako@~1.0.5:
   resolved "https://registry.yarnpkg.com/pako/-/pako-1.0.10.tgz#4328badb5086a426aa90f541977d4955da5c9732"
   integrity sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==
 
+paralleljs@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/paralleljs/-/paralleljs-0.2.1.tgz#ebca745d3e09c01e2bebcc14858891ff4510e926"
+  integrity sha1-68p0XT4JwB4r68wUhYiR/0UQ6SY=
+
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -4029,7 +4049,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.18.2:
+prettier@^1.16.4, prettier@^1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.18.2.tgz#6823e7c5900017b4bd3acf46fe9ac4b4d7bda9ea"
   integrity sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw==
@@ -4226,6 +4246,13 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
+rechoir@^0.6.2:
+  version "0.6.2"
+  resolved "https://registry.yarnpkg.com/rechoir/-/rechoir-0.6.2.tgz#85204b54dba82d5742e28c96756ef43af50e3384"
+  integrity sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=
+  dependencies:
+    resolve "^1.1.6"
+
 regenerator-runtime@^0.13.2:
   version "0.13.3"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.3.tgz#7cf6a77d8f5c6f60eb73c5fc1955b2ceb01e6bf5"
@@ -4353,7 +4380,7 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@1.x, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0:
+resolve@1.x, resolve@^1.1.6, resolve@^1.10.0, resolve@^1.11.0, resolve@^1.3.2, resolve@^1.4.0, resolve@^1.5.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.12.0.tgz#3fc644a35c84a48554609ff26ec52b66fa577df6"
   integrity sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==
@@ -4517,6 +4544,15 @@ shebang-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/shebang-regex/-/shebang-regex-1.0.0.tgz#da42f49740c0b42db2ca9728571cb190c98efea3"
   integrity sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
+shelljs@^0.8.3:
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/shelljs/-/shelljs-0.8.3.tgz#a7f3319520ebf09ee81275b2368adb286659b097"
+  integrity sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==
+  dependencies:
+    glob "^7.0.0"
+    interpret "^1.0.0"
+    rechoir "^0.6.2"
 
 shellwords@^0.1.1:
   version "0.1.1"
@@ -5039,7 +5075,12 @@ type-fest@^0.6.0:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.6.0.tgz#8d2a2370d3df886eb5c90ada1c5bf6188acf838b"
   integrity sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
 
-typescript@^3.6.2:
+typescript-compiler@^1.4.1-2:
+  version "1.4.1-2"
+  resolved "https://registry.yarnpkg.com/typescript-compiler/-/typescript-compiler-1.4.1-2.tgz#ba4f7db22d91534a1929d90009dce161eb72fd3f"
+  integrity sha1-uk99si2RU0oZKdkACdzhYety/T8=
+
+typescript@^3.4, typescript@^3.6.2:
   version "3.6.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
   integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==


### PR DESCRIPTION
I'm not super happy with this solution as it currently is because it sprays `.flow` files all throughout the file structure (see below). To be fair, Typescript does this too, but Webstorm collapses the files together.
![image](https://user-images.githubusercontent.com/3198595/65365298-29592f00-dbcd-11e9-8561-33151b2902a5.png)
