### PR TITLE
Fix file create and file append validation

### DIFF
--- a/src/file/FileAppendTransaction.ts
+++ b/src/file/FileAppendTransaction.ts
@@ -24,6 +24,12 @@ export class FileAppendTransaction extends TransactionBuilder {
         if (file == null || contents == null) {
             errors.push("FileAppendTransaction must have a file id and contents set");
         }
+
+        const contentsBytes = this._body.getContents_asU8();
+
+        if (contentsBytes.byteLength > 4096) {
+            errors.push("FileAppendTransaction contents must not exceed 4kb");
+        }
     }
 
     public setFileId(fileId: FileIdLike): this {

--- a/src/file/FileCreateTransaction.ts
+++ b/src/file/FileCreateTransaction.ts
@@ -41,8 +41,16 @@ export class FileCreateTransaction extends TransactionBuilder {
     }
 
     protected _doValidate(errors: string[]): void {
-        if (this._body.getKeys() == null) {
+        const contents = this._body.getContents();
+
+        if (this._body.getContents() == null) {
             errors.push("FileCreateTransaction must have a file set");
+        }
+
+        const contentsBytes = this._body.getContents_asU8();
+
+        if (contentsBytes.byteLength > 4096) {
+            errors.push("FileCreateTransaction contents must not exceed 4kb");
         }
     }
 


### PR DESCRIPTION
Properly checks if contents are null on `FileCreateTransaction` and validates that contents do no exceed 4kb in `FileCreateTransaction` and `FileAppendTransaction`