### PR TITLE
Move automatic signing and update tests

### DIFF
--- a/__tests__/account/AccountCreateTransaction.test.ts
+++ b/__tests__/account/AccountCreateTransaction.test.ts
@@ -14,8 +14,7 @@ describe('AccountCreateTransaction', () => {
             })
             .setKey(privateKey.publicKey)
             .setTransactionFee(Hbar.of(1))
-            .build()
-            .sign(privateKey);
+            .build();
 
         const bodybytes = "Cg4KCAjcyQcQ258JEgIYAxICGAMYgMLXLyICCHhaPwoiEiDgyOwnWKWHn/rCJqE8DFFreZ5y41FBoN2Cj5TTeYiktzD//////////384//////////9/SgUI0MjhAw==";
 
@@ -26,11 +25,11 @@ describe('AccountCreateTransaction', () => {
             sigmap: {
                 sigpairList: [
                     {
-                        "contract": "",
-                        "ecdsa384": "",
-                        "ed25519": "Vueml5zTmYI2f9O2kcw6/zKFaIPn5WCOKD/jvhwO+EFN55yepuYa566qbD8Z274nncCi/aqVrr/M6NIu91OnAQoOCggI3MkHENufCRICGAMSAhgDGIDC1y8iAgh4Wj8KIhIg4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLcw//////////9/OP//////////f0oFCNDI4QM=",
-                        "pubkeyprefix": "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
-                        "rsa3072": ""
+                        contract: "",
+                        ecdsa384: "",
+                        ed25519: "Vueml5zTmYI2f9O2kcw6/zKFaIPn5WCOKD/jvhwO+EFN55yepuYa566qbD8Z274nncCi/aqVrr/M6NIu91OnAQoOCggI3MkHENufCRICGAMSAhgDGIDC1y8iAgh4Wj8KIhIg4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLcw//////////9/OP//////////f0oFCNDI4QM=",
+                        pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                        rsa3072: ""
                     }
                 ]
             },

--- a/__tests__/contract/ContractBytecodeQuery.test.ts
+++ b/__tests__/contract/ContractBytecodeQuery.test.ts
@@ -20,7 +20,15 @@ describe("ContractBytecodeQuery", () => {
                     payment: {
                         body: undefined,
                         bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeHIUChIKBwoCGAIQxwEKBwoCGAMQyAE=",
-                        sigmap: undefined,
+                        sigmap: {
+                            sigpairList: [{
+                                contract: "",
+                                ecdsa384: "",
+                                ed25519: "1W86WCxMfK1Pv83GbBxXIDzpTLgwsLzOO/Nccs9QEV6ej/kp3QbJGtgO64gTXrdje6lyTdbuaLFYxxHXtje2CgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhyFAoSCgcKAhgCEMcBCgcKAhgDEMgB",
+                                pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                                rsa3072: "",
+                              }]
+                        },
                         sigs: undefined
                     },
                     responsetype: 0

--- a/__tests__/contract/ContractCallQuery.test.ts
+++ b/__tests__/contract/ContractCallQuery.test.ts
@@ -21,7 +21,15 @@ describe("ContractCallQuery", () => {
                     payment: {
                         body: undefined,
                         bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeHIUChIKBwoCGAIQxwEKBwoCGAMQyAE=",
-                        sigmap: undefined,
+                        sigmap: {
+                            sigpairList: [{
+                                contract: "",
+                                ecdsa384: "",
+                                ed25519: "1W86WCxMfK1Pv83GbBxXIDzpTLgwsLzOO/Nccs9QEV6ej/kp3QbJGtgO64gTXrdje6lyTdbuaLFYxxHXtje2CgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhyFAoSCgcKAhgCEMcBCgcKAhgDEMgB",
+                                pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                                rsa3072: ""
+                            }]
+                        },
                         sigs: undefined
                     },
                     responsetype: 0

--- a/__tests__/contract/ContractCreateTransaction.test.ts
+++ b/__tests__/contract/ContractCreateTransaction.test.ts
@@ -16,23 +16,20 @@ describe("ContractCreateTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build()
-            .sign(privateKey);
+            .build();
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({
             body: undefined,
             bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeEI3CgIYBBoiEiDgyOwnWKWHn/rCJqE8DFFreZ5y41FBoN2Cj5TTeYiktyBkKOgHMgIYA0IECIDqSQ==",
             sigmap: {
-                sigpairList: [
-                    {
-                        contract: "",
-                        ecdsa384: "",
-                        ed25519: "tIaKEQ3Slu4LCmZDWmEjeSrOnG43bj1PI0HbTnswHtjCEGnnnqnAZ1S3nvmbzzBVZx4xgYjzi1ORz1Xpf22ZAgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhCNwoCGAQaIhIg4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLcgZCjoBzICGANCBAiA6kk=",
-                        pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
-                        rsa3072: ""
-                    }
-                ]
+                sigpairList: [{
+                    contract: "",
+                    ecdsa384: "",
+                    ed25519: "tIaKEQ3Slu4LCmZDWmEjeSrOnG43bj1PI0HbTnswHtjCEGnnnqnAZ1S3nvmbzzBVZx4xgYjzi1ORz1Xpf22ZAgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhCNwoCGAQaIhIg4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLcgZCjoBzICGANCBAiA6kk=",
+                    pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                    rsa3072: ""
+                }]
             },
             sigs: undefined
         });

--- a/__tests__/contract/ContractDeleteTransaction.test.ts
+++ b/__tests__/contract/ContractDeleteTransaction.test.ts
@@ -11,8 +11,7 @@ describe("ContractDeleteTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build()
-            .sign(privateKey);
+            .build();
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/contract/ContractExecuteTransaction.test.ts
+++ b/__tests__/contract/ContractExecuteTransaction.test.ts
@@ -14,8 +14,7 @@ describe("ContractExecuteTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build()
-            .sign(privateKey);
+            .build();
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/contract/ContractInfoQuery.test.ts
+++ b/__tests__/contract/ContractInfoQuery.test.ts
@@ -21,7 +21,15 @@ describe("ContractInfoQuery", () => {
                     payment: {
                         body: undefined,
                         bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeHIUChIKBwoCGAIQxwEKBwoCGAMQyAE=",
-                        sigmap: undefined,
+                        sigmap: {
+                            sigpairList: [{
+                                  contract: "",
+                                  ecdsa384: "",
+                                  ed25519: "1W86WCxMfK1Pv83GbBxXIDzpTLgwsLzOO/Nccs9QEV6ej/kp3QbJGtgO64gTXrdje6lyTdbuaLFYxxHXtje2CgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhyFAoSCgcKAhgCEMcBCgcKAhgDEMgB",
+                                  pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                                  rsa3072: "",
+                            }]
+                        },
                         sigs: undefined
                     },
                     responsetype: 0

--- a/__tests__/contract/ContractRecordsQuery.test.ts
+++ b/__tests__/contract/ContractRecordsQuery.test.ts
@@ -22,7 +22,15 @@ describe("ContractRecordsQuery", () => {
                     payment: {
                         body: undefined,
                         bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeHIUChIKBwoCGAIQxwEKBwoCGAMQyAE=",
-                        sigmap: undefined,
+                        sigmap: {
+                            sigpairList: [{
+                                  contract: "",
+                                  ecdsa384: "",
+                                  ed25519: "1W86WCxMfK1Pv83GbBxXIDzpTLgwsLzOO/Nccs9QEV6ej/kp3QbJGtgO64gTXrdje6lyTdbuaLFYxxHXtje2CgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhyFAoSCgcKAhgCEMcBCgcKAhgDEMgB",
+                                  pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                                  rsa3072: "",
+                            }]
+                        },
                         sigs: undefined
                     },
                     responsetype: 0

--- a/__tests__/contract/ContractUpdateTransaction.test.ts
+++ b/__tests__/contract/ContractUpdateTransaction.test.ts
@@ -16,23 +16,20 @@ describe("ContractUpdateTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build()
-            .sign(privateKey);
+            .build();
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({
             body: undefined,
             bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeEpECgIYAxIMCIeHq+wFEMDeioQBGiISIODI7CdYpYef+sImoTwMUWt5nnLjUUGg3YKPlNN5iKS3MgIYAzoECIDqSUICGAU=",
             sigmap: {
-                sigpairList: [
-                    {
-                        contract: "",
-                        ecdsa384: "",
-                        ed25519: "3wq0YLANRbRWyMvhQErqFchjWfr6x2Ew2o0LYI8haJHmERblnRqXv9aWFBXVDe2BihSb4C/X18KhC1xWCCR3CQoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhKRAoCGAMSDAiHh6vsBRDA3oqEARoiEiDgyOwnWKWHn/rCJqE8DFFreZ5y41FBoN2Cj5TTeYiktzICGAM6BAiA6klCAhgF",
-                        pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
-                        rsa3072: ""
-                    }
-                ]
+                sigpairList: [{
+                    contract: "",
+                    ecdsa384: "",
+                    ed25519: "3wq0YLANRbRWyMvhQErqFchjWfr6x2Ew2o0LYI8haJHmERblnRqXv9aWFBXVDe2BihSb4C/X18KhC1xWCCR3CQoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhKRAoCGAMSDAiHh6vsBRDA3oqEARoiEiDgyOwnWKWHn/rCJqE8DFFreZ5y41FBoN2Cj5TTeYiktzICGAM6BAiA6klCAhgF",
+                    pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                    rsa3072: "",
+                }]
             },
             sigs: undefined
         });

--- a/__tests__/file/FileAppendTransaction.test.ts
+++ b/__tests__/file/FileAppendTransaction.test.ts
@@ -18,7 +18,15 @@ describe("FileAppendTransaction", () => {
         expect(tx).toStrictEqual({
             body: undefined,
             bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeIIBFRICGAUiD04YrIrLKJnq2p3aJnWrWg==",
-            sigmap: undefined,
+            sigmap: {
+                sigpairList: [{
+                      contract: "",
+                      ecdsa384: "",
+                      ed25519: "U+rHe8KHX5uFILbvdYSSEqB8RdMlMq25G1ckP6YvsmFOguC/A+tmQaf8UEEsIElCzabo6y+Hf3xB6IMUNxylBAoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHiCARUSAhgFIg9OGKyKyyiZ6tqd2iZ1q1o=",
+                      pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                      rsa3072: "",
+                }]
+            },
             sigs: undefined
         });
     });

--- a/__tests__/file/FileContentsQuery.test.ts
+++ b/__tests__/file/FileContentsQuery.test.ts
@@ -28,7 +28,15 @@ describe("FileContentsQuery", () => {
                     payment: {
                         body: undefined,
                         bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeHIUChIKBwoCGAIQxwEKBwoCGAMQyAE=",
-                        sigmap: undefined,
+                        sigmap: {
+                            sigpairList: [{
+                                contract: "",
+                                ecdsa384: "",
+                                ed25519: "1W86WCxMfK1Pv83GbBxXIDzpTLgwsLzOO/Nccs9QEV6ej/kp3QbJGtgO64gTXrdje6lyTdbuaLFYxxHXtje2CgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhyFAoSCgcKAhgCEMcBCgcKAhgDEMgB",
+                                pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                                rsa3072: ""
+                            }]
+                        },
                         sigs: undefined
                     },
                     responsetype: 0

--- a/__tests__/file/FileCreateTransaction.test.ts
+++ b/__tests__/file/FileCreateTransaction.test.ts
@@ -19,7 +19,15 @@ describe("FileCreateTransaction", () => {
         expect(tx).toStrictEqual({
             body: undefined,
             bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeIoBRRILCO/urAcQwPvU8wEaJAoiEiDgyOwnWKWHn/rCJqE8DFFreZ5y41FBoN2Cj5TTeYiktyIQThisisthefilecontentsA==",
-            sigmap: undefined,
+            sigmap: {
+            sigpairList: [{
+                contract: "",
+                ecdsa384: "",
+                ed25519: "76ilivBgtIJ3/FkcbWYxz4ndfYwzY8q8nKXBeX8k1nlWyHr007Bo+gRK3J3FvaVN2NJ45tyW4pWeYoGiu6EyDwoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHiKAUUSCwjv7qwHEMD71PMBGiQKIhIg4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLciEE4YrIrLYXn4pXnKJ7Xp7bA=",
+                pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                rsa3072: "",
+               }],
+            },
             sigs: undefined
         });
     });

--- a/__tests__/file/FileDeleteTransaction.test.ts
+++ b/__tests__/file/FileDeleteTransaction.test.ts
@@ -17,7 +17,15 @@ describe("FileDeleteTransaction", () => {
         expect(tx).toStrictEqual({
             body: undefined,
             bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeJIBBBICGAU=",
-            sigmap: undefined,
+            sigmap: {
+                sigpairList: [{
+                      contract: "",
+                      ecdsa384: "",
+                      ed25519: "0jJ2AZn6SwAuQ1t4aF6BajIzMo+acjjahE3MedPKVtcNArkz9skOVPjIvbbIvOWyUVJzVh0/E+AUK2DJB0kqCgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHiSAQQSAhgF",
+                      pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                      rsa3072: ""
+                }]
+            },
             sigs: undefined
         });
     });

--- a/__tests__/file/FileInfoQuery.test.ts
+++ b/__tests__/file/FileInfoQuery.test.ts
@@ -29,7 +29,15 @@ describe("FileInfoQuery", () => {
                     payment: {
                         body: undefined,
                         bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeHIUChIKBwoCGAIQxwEKBwoCGAMQyAE=",
-                        sigmap: undefined,
+                        sigmap: {
+                            sigpairList: [{
+                                  contract: "",
+                                  ecdsa384: "",
+                                  ed25519: "1W86WCxMfK1Pv83GbBxXIDzpTLgwsLzOO/Nccs9QEV6ej/kp3QbJGtgO64gTXrdje6lyTdbuaLFYxxHXtje2CgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHhyFAoSCgcKAhgCEMcBCgcKAhgDEMgB",
+                                  pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                                  rsa3072: "",
+                            }]
+                        },
                         sigs: undefined
                     },
                     responsetype: 0

--- a/__tests__/file/FileUpdateTransaction.test.ts
+++ b/__tests__/file/FileUpdateTransaction.test.ts
@@ -20,7 +20,15 @@ describe("FileUpdateTransaction", () => {
         expect(tx).toStrictEqual({
             body: undefined,
             bodybytes: "Cg4KCAjcyQcQ258JEgIYAxICGAMYwIQ9IgIIeJoBSQoCGAUSCwjv7qwHEMD71PMBGiQKIhIg4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLciEE4YrIrLYXn4pXnKJ7Xp7bA=",
-            sigmap: undefined,
+            sigmap: {
+                sigpairList: [{
+                    contract: "",
+                    ecdsa384: "",
+                    ed25519: "DHcTKXIBZbXzY2kkuAQrMFVF8Y3mqIo93uqYKB+34ah8EDOjeCwuR87GQ7ycpRbjWmT0IPeTK4D79eIoz1dyDgoOCggI3MkHENufCRICGAMSAhgDGMCEPSICCHiaAUkKAhgFEgsI7+6sBxDA+9TzARokCiISIODI7CdYpYef+sImoTwMUWt5nnLjUUGg3YKPlNN5iKS3IhBOGKyKy2F5+KV5yie16e2w",
+                    pubkeyprefix: "4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=",
+                    rsa3072: "",
+                }]
+            },
             sigs: undefined
         });
     });

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -124,12 +124,6 @@ export class Transaction {
     }
 
     public async execute(): Promise<TransactionId> {
-        const sigMap = this._inner.getSigmap();
-
-        if (!sigMap || sigMap.getSigpairList().length === 0) {
-            await this.signWith(this._client.operatorPublicKey, this._client.operatorSigner);
-        }
-
         handlePrecheck(await this._client._unaryCall(this._nodeUrl, this._inner, this._method));
 
         return this.getTransactionId();

--- a/src/TransactionBuilder.ts
+++ b/src/TransactionBuilder.ts
@@ -110,9 +110,12 @@ export abstract class TransactionBuilder {
 
         this.validate();
 
-        const txn = new Transaction_();
-        txn.setBodybytes(this._inner.serializeBinary());
+        const protoTx = new Transaction_();
+        protoTx.setBodybytes(this._inner.serializeBinary());
 
-        return new Transaction(this._client, url, txn, this._inner, this._method);
+        const txn = new Transaction(this._client, url, protoTx, this._inner, this._method);
+        txn.signWith(this._client.operatorPublicKey, this._client.operatorSigner);
+
+        return txn;
     }
 }


### PR DESCRIPTION
Signing now happens in the `TransactionBuilder` when `.build()` is called
instead of `.execute()` on `Transction`. This allows easier user of SDK.