### PR TITLE
Update `Transaction`, `TransactionBuilder`, and `QueryBuilder`

### DIFF
--- a/__tests__/MockClient.ts
+++ b/__tests__/MockClient.ts
@@ -23,7 +23,7 @@ class MockClient extends BaseClient {
 
 export const mockClient = new MockClient();
 
-export const mockTransaction = new CryptoTransferTransaction(mockClient)
+export const mockTransaction = new CryptoTransferTransaction()
     .addSender({ shard: 0, realm: 0, account: 2}, 100)
     .addRecipient({ shard: 0, realm: 0, account: 3}, 100)
     .setTransactionFee(8000000)
@@ -33,4 +33,4 @@ export const mockTransaction = new CryptoTransferTransaction(mockClient)
         validStartSeconds: 124124,
         validStartNanos: 151515
     })
-    .build();
+    .build(mockClient);

--- a/__tests__/Transaction.test.ts
+++ b/__tests__/Transaction.test.ts
@@ -4,11 +4,11 @@ import { mockClient, privateKey } from "./MockClient";
 
 describe("Transaction", () => {
     it("serializes and deserializes correctly", () => {
-        const transaction = new AccountCreateTransaction(mockClient)
+        const transaction = new AccountCreateTransaction()
             .setKey(privateKey.publicKey)
             .setInitialBalance(1e3)
             .setTransactionFee(1e6)
-            .build();
+            .build(mockClient);
 
         const txnBytes = transaction.toBytes();
 

--- a/__tests__/account/AccountCreateTransaction.test.ts
+++ b/__tests__/account/AccountCreateTransaction.test.ts
@@ -5,7 +5,7 @@ import { TransactionBody } from "../../src/generated/TransactionBody_pb";
 
 describe('AccountCreateTransaction', () => {
     it('serializes correctly', () => {
-        const transaction = new AccountCreateTransaction(mockClient)
+        const transaction = new AccountCreateTransaction()
             // deterministic values
             .setTransactionId({
                 account: { shard: 0, realm: 0, account: 3 },
@@ -14,7 +14,7 @@ describe('AccountCreateTransaction', () => {
             })
             .setKey(privateKey.publicKey)
             .setTransactionFee(Hbar.of(1))
-            .build();
+            .build(mockClient);
 
         const bodybytes = "Cg4KCAjcyQcQ258JEgIYAxICGAMYgMLXLyICCHhaPwoiEiDgyOwnWKWHn/rCJqE8DFFreZ5y41FBoN2Cj5TTeYiktzD//////////384//////////9/SgUI0MjhAw==";
 

--- a/__tests__/account/AccountUpdateTransaction.test.ts
+++ b/__tests__/account/AccountUpdateTransaction.test.ts
@@ -5,7 +5,7 @@ import { TransactionBody } from "../../src/generated/TransactionBody_pb";
 
 describe('AccountUpdateTransaction', () => {
     it('serializes correctly', () => {
-        const transaction = new AccountUpdateTransaction(mockClient)
+        const transaction = new AccountUpdateTransaction()
             // deterministic values
             .setTransactionId({
                 account: { shard: 0, realm: 0, account: 3 },
@@ -15,7 +15,7 @@ describe('AccountUpdateTransaction', () => {
             .setAccountId({ account: 3 })
             .setKey(privateKey.publicKey)
             .setTransactionFee(Hbar.of(1))
-            .build();
+            .build(mockClient);
 
         const bodybytes = "Cg4KCAjcyQcQ258JEgIYAxICGAMYgMLXLyICCHh6KBICGAMaIhIg4MjsJ1ilh5/6wiahPAxRa3mecuNRQaDdgo+U03mIpLc=";
 

--- a/__tests__/contract/ContractBytecodeQuery.test.ts
+++ b/__tests__/contract/ContractBytecodeQuery.test.ts
@@ -3,7 +3,7 @@ import { mockClient, mockTransaction } from "../MockClient";
 
 describe("ContractBytecodeQuery", () => {
     it("serializes and deserializes correctly; ContractBytecodeQuery", () => {
-        const transaction = new ContractBytecodeQuery(mockClient)
+        const transaction = new ContractBytecodeQuery()
             .setContractId({ shard: 0, realm: 0, contract: 3 })
             .setPayment(mockTransaction.toProto());
 

--- a/__tests__/contract/ContractCallQuery.test.ts
+++ b/__tests__/contract/ContractCallQuery.test.ts
@@ -3,7 +3,7 @@ import { mockClient, mockTransaction } from "../MockClient";
 
 describe("ContractCallQuery", () => {
     it("serializes and deserializes correctly; ContractCallQuery", () => {
-        const transaction = new ContractCallQuery(mockClient)
+        const transaction = new ContractCallQuery()
             .setContractId({ shard: 0, realm: 0, contract: 3 })
             .setPayment(mockTransaction.toProto());
 

--- a/__tests__/contract/ContractCreateTransaction.test.ts
+++ b/__tests__/contract/ContractCreateTransaction.test.ts
@@ -3,7 +3,7 @@ import { mockClient, privateKey } from "../MockClient";
 
 describe("ContractCreateTransaction", () => {
     it("serializes and deserializes correctly; ContractCreateTransaction", () => {
-        const transaction = new ContractCreateTransaction(mockClient)
+        const transaction = new ContractCreateTransaction()
             .setAdminkey(privateKey.publicKey)
             .setInitialBalance(1e3)
             .setBytecodeFile({ shard: 0, realm: 0, file: 4 })
@@ -16,7 +16,7 @@ describe("ContractCreateTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/contract/ContractDeleteTransaction.test.ts
+++ b/__tests__/contract/ContractDeleteTransaction.test.ts
@@ -3,7 +3,7 @@ import { mockClient, privateKey } from "../MockClient";
 
 describe("ContractDeleteTransaction", () => {
     it("serializes and deserializes correctly; ContractDeleteTransaction", () => {
-        const transaction = new ContractDeleteTransaction(mockClient)
+        const transaction = new ContractDeleteTransaction()
             .setContractId({ shard: 0, realm: 0, contract: 5 })
             .setTransactionFee(1e6)
             .setTransactionId({
@@ -11,7 +11,7 @@ describe("ContractDeleteTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/contract/ContractExecuteTransaction.test.ts
+++ b/__tests__/contract/ContractExecuteTransaction.test.ts
@@ -3,7 +3,7 @@ import { mockClient, privateKey } from "../MockClient";
 
 describe("ContractExecuteTransaction", () => {
     it("serializes and deserializes correctly; ContractExecuteTransaction", () => {
-        const transaction = new ContractExecuteTransaction(mockClient)
+        const transaction = new ContractExecuteTransaction()
             .setContractId({ shard: 0, realm: 0, contract: 5 })
             .setGas(141)
             .setAmount(10000)
@@ -14,7 +14,7 @@ describe("ContractExecuteTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/contract/ContractInfoQuery.test.ts
+++ b/__tests__/contract/ContractInfoQuery.test.ts
@@ -3,7 +3,7 @@ import { mockClient, mockTransaction } from "../MockClient";
 
 describe("ContractInfoQuery", () => {
     it("serializes and deserializes correctly; ContractInfoQuery", () => {
-        const transaction = new ContractInfoQuery(mockClient)
+        const transaction = new ContractInfoQuery()
             .setContractId({ shard: 0, realm: 0, contract: 3 })
             .setPayment(mockTransaction.toProto());
 

--- a/__tests__/contract/ContractRecordsQuery.test.ts
+++ b/__tests__/contract/ContractRecordsQuery.test.ts
@@ -3,7 +3,7 @@ import { mockClient, mockTransaction } from "../MockClient";
 
 describe("ContractRecordsQuery", () => {
     it("serializes and deserializes correctly; ContractRecordsQuery", () => {
-        const transaction = new ContractRecordsQuery(mockClient)
+        const transaction = new ContractRecordsQuery()
             .setContractId({ shard: 0, realm: 0, contract: 3 })
             .setPayment(mockTransaction.toProto());
 

--- a/__tests__/contract/ContractUpdateTransaction.test.ts
+++ b/__tests__/contract/ContractUpdateTransaction.test.ts
@@ -3,7 +3,7 @@ import { mockClient, privateKey } from "../MockClient";
 
 describe("ContractUpdateTransaction", () => {
     it("serializes and deserializes correctly; ContractUpdateTransaction", () => {
-        const transaction = new ContractUpdateTransaction(mockClient)
+        const transaction = new ContractUpdateTransaction()
             .setContractId({ shard: 0, realm: 0, contract: 3 })
             .setAdminkey(privateKey.publicKey)
             .setFileId({ shard: 0, realm: 0, file: 5 })
@@ -16,7 +16,7 @@ describe("ContractUpdateTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/file/FileAppendTransaction.test.ts
+++ b/__tests__/file/FileAppendTransaction.test.ts
@@ -3,7 +3,7 @@ import { FileAppendTransaction } from "../../src/exports";
 
 describe("FileAppendTransaction", () => {
     it("serializes and deserializes correctly; FileAppendTransaction", () => {
-        const transaction = new FileAppendTransaction(mockClient)
+        const transaction = new FileAppendTransaction()
             .setFileId({ shard: 0, realm: 0, file: 5 })
             .setContents("This is some random data")
             .setTransactionFee(1e6)
@@ -12,7 +12,7 @@ describe("FileAppendTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/file/FileContentsQuery.test.ts
+++ b/__tests__/file/FileContentsQuery.test.ts
@@ -3,7 +3,7 @@ import { FileContentsQuery } from "../../src/exports";
 
 describe("FileContentsQuery", () => {
     it("serializes and deserializes correctly; FileContentsQuery", () => {
-        const query = new FileContentsQuery(mockClient)
+        const query = new FileContentsQuery()
             .setFileId({ shard: 0, realm: 0, file: 5 })
             .setPayment(mockTransaction.toProto());
 

--- a/__tests__/file/FileCreateTransaction.test.ts
+++ b/__tests__/file/FileCreateTransaction.test.ts
@@ -3,7 +3,7 @@ import { mockClient, privateKey } from "../MockClient";
 
 describe("FileCreateTransaction", () => {
     it("serializes and deserializes correctly; FileCreateTransaction", () => {
-        const transaction = new FileCreateTransaction(mockClient)
+        const transaction = new FileCreateTransaction()
             .setContents("This is the file contents")
             .setExpirationTime(new Date(15415151511))
             .addKey(privateKey.publicKey)
@@ -13,7 +13,7 @@ describe("FileCreateTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/file/FileDeleteTransaction.test.ts
+++ b/__tests__/file/FileDeleteTransaction.test.ts
@@ -3,7 +3,7 @@ import { mockClient } from "../MockClient";
 
 describe("FileDeleteTransaction", () => {
     it("serializes and deserializes correctly; FileDeleteTransaction", () => {
-        const transaction = new FileDeleteTransaction(mockClient)
+        const transaction = new FileDeleteTransaction()
             .setFileId({ shard: 0, realm: 0, file: 5 })
             .setTransactionFee(1e6)
             .setTransactionId({
@@ -11,7 +11,7 @@ describe("FileDeleteTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/__tests__/file/FileInfoQuery.test.ts
+++ b/__tests__/file/FileInfoQuery.test.ts
@@ -3,7 +3,7 @@ import { FileInfoQuery } from "../../src/exports";
 
 describe("FileInfoQuery", () => {
     it("serializes and deserializes correctly; FileInfoQuery", () => {
-        const query = new FileInfoQuery(mockClient)
+        const query = new FileInfoQuery()
             .setFileId({ shard: 0, realm: 0, file: 5 })
             .setPayment(mockTransaction.toProto());
 

--- a/__tests__/file/FileUpdateTransaction.test.ts
+++ b/__tests__/file/FileUpdateTransaction.test.ts
@@ -3,7 +3,7 @@ import { FileUpdateTransaction } from "../../src/exports";
 
 describe("FileUpdateTransaction", () => {
     it("serializes and deserializes correctly; FileUpdateTransaction", () => {
-        const transaction = new FileUpdateTransaction(mockClient)
+        const transaction = new FileUpdateTransaction()
             .setFileId({ shard: 0, realm: 0, file: 5 })
             .setContents("This is the file contents")
             .setExpirationTime(new Date(15415151511))
@@ -14,7 +14,7 @@ describe("FileUpdateTransaction", () => {
                 validStartSeconds: 124124,
                 validStartNanos: 151515
             })
-            .build();
+            .build(mockClient);
 
         const tx = transaction.toProto().toObject();
         expect(tx).toStrictEqual({

--- a/src/account/AccountCreateTransaction.ts
+++ b/src/account/AccountCreateTransaction.ts
@@ -3,7 +3,6 @@ import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
 import { CryptoCreateTransactionBody } from "../generated/CryptoCreate_pb";
-import { BaseClient } from "../BaseClient";
 import { newDuration } from "../util";
 import { CryptoService } from "../generated/CryptoService_pb_service";
 import { Hbar } from "../Hbar";
@@ -15,8 +14,8 @@ import { PublicKey } from "../crypto/PublicKey";
 export class AccountCreateTransaction extends TransactionBuilder {
     private _body: CryptoCreateTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         const body = new CryptoCreateTransactionBody();
         this._body = body;
         this._inner.setCryptocreateaccount(body);

--- a/src/account/AccountInfoQuery.ts
+++ b/src/account/AccountInfoQuery.ts
@@ -4,7 +4,6 @@ import { grpc } from "@improbable-eng/grpc-web";
 import { Query } from "../generated/Query_pb";
 import { Response } from "../generated/Response_pb";
 import { CryptoService } from "../generated/CryptoService_pb_service";
-import { BaseClient } from "../BaseClient";
 import { QueryHeader } from "../generated/QueryHeader_pb";
 import { Key } from "../generated/BasicTypes_pb";
 import { Hbar } from "../Hbar";
@@ -30,9 +29,9 @@ export type AccountInfo = {
 export class AccountInfoQuery extends QueryBuilder<AccountInfo> {
     private readonly _builder: CryptoGetInfoQuery;
 
-    public constructor(client: BaseClient) {
+    public constructor() {
         const header = new QueryHeader();
-        super(client, header);
+        super(header);
         this._builder = new CryptoGetInfoQuery();
         this._builder.setHeader(header);
         this._inner.setCryptogetinfo(this._builder);

--- a/src/account/AccountUpdateTransaction.ts
+++ b/src/account/AccountUpdateTransaction.ts
@@ -3,7 +3,6 @@ import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
 import { CryptoUpdateTransactionBody } from "../generated/CryptoUpdate_pb";
-import { BaseClient } from "../BaseClient";
 import { newDuration } from "../util";
 import { CryptoService } from "../generated/CryptoService_pb_service";
 import { Hbar } from "../Hbar";
@@ -15,8 +14,8 @@ import { AccountIdLike, accountIdToProto } from "./AccountId";
 export class AccountUpdateTransaction extends TransactionBuilder {
     private _body: CryptoUpdateTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         const body = new CryptoUpdateTransactionBody();
         this._body = body;
         this._inner.setCryptoupdateaccount(body);

--- a/src/account/CryptoTransferTransaction.ts
+++ b/src/account/CryptoTransferTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 import {
     AccountAmount,
     CryptoTransferTransactionBody,
@@ -18,8 +17,8 @@ import { AccountIdLike, accountIdToProto } from "./AccountId";
 export class CryptoTransferTransaction extends TransactionBuilder {
     private readonly _body: CryptoTransferTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new CryptoTransferTransactionBody();
         this._body.setTransfers(new TransferList());
         this._inner.setCryptotransfer(this._body);

--- a/src/contract/ContractBytecodeQuery.ts
+++ b/src/contract/ContractBytecodeQuery.ts
@@ -1,5 +1,4 @@
 import { QueryBuilder } from "../QueryBuilder";
-import { BaseClient } from "../BaseClient";
 import { QueryHeader } from "../generated/QueryHeader_pb";
 import { Query } from "../generated/Query_pb";
 import { grpc } from "@improbable-eng/grpc-web";
@@ -10,9 +9,9 @@ import { ContractIdLike, contractIdToProto } from "./ContractId";
 
 export class ContractBytecodeQuery extends QueryBuilder<Uint8Array> {
     private readonly _builder: ContractGetBytecodeQuery;
-    public constructor(client: BaseClient) {
+    public constructor() {
         const header = new QueryHeader();
-        super(client, header);
+        super(header);
         this._builder = new ContractGetBytecodeQuery();
         this._builder.setHeader(header);
         this._inner.setContractgetbytecode(this._builder);

--- a/src/contract/ContractCallQuery.ts
+++ b/src/contract/ContractCallQuery.ts
@@ -1,5 +1,4 @@
 import { QueryBuilder } from "../QueryBuilder";
-import { BaseClient } from "../BaseClient";
 import { QueryHeader } from "../generated/QueryHeader_pb";
 import { Query } from "../generated/Query_pb";
 import { grpc } from "@improbable-eng/grpc-web";
@@ -11,9 +10,9 @@ import { ContractCallLocalQuery } from "../generated/ContractCallLocal_pb";
 
 export class ContractCallQuery extends QueryBuilder<ContractFunctionResult> {
     private readonly _builder: ContractCallLocalQuery;
-    public constructor(client: BaseClient) {
+    public constructor() {
         const header = new QueryHeader();
-        super(client, header);
+        super(header);
         this._builder = new ContractCallLocalQuery();
         this._builder.setHeader(header);
         this._inner.setContractcalllocal(this._builder);

--- a/src/contract/ContractCreateTransaction.ts
+++ b/src/contract/ContractCreateTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 import { ContractCreateTransactionBody } from "../generated/ContractCreate_pb";
 import { newDuration } from "../util";
 import BigNumber from "bignumber.js";
@@ -17,8 +16,8 @@ import { AccountId, accountIdToProto } from "../account/AccountId";
 export class ContractCreateTransaction extends TransactionBuilder {
     private readonly _body: ContractCreateTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new ContractCreateTransactionBody();
         this._inner.setContractcreateinstance(this._body);
     }

--- a/src/contract/ContractDeleteTransaction.ts
+++ b/src/contract/ContractDeleteTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 import { SmartContractService } from "../generated/SmartContractService_pb_service";
 
 import { ContractDeleteTransactionBody } from "../generated/ContractDelete_pb";
@@ -11,8 +10,8 @@ import { ContractIdLike, contractIdToProto } from "./ContractId";
 export class ContractDeleteTransaction extends TransactionBuilder {
     private readonly _body: ContractDeleteTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new ContractDeleteTransactionBody();
         this._inner.setContractdeleteinstance(this._body);
     }

--- a/src/contract/ContractExecuteTransaction.ts
+++ b/src/contract/ContractExecuteTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 import { SmartContractService } from "../generated/SmartContractService_pb_service";
 
 import { ContractCallTransactionBody } from "../generated/ContractCall_pb";
@@ -12,8 +11,8 @@ import { ContractIdLike, contractIdToProto } from "./ContractId";
 export class ContractExecuteTransaction extends TransactionBuilder {
     private readonly _body: ContractCallTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new ContractCallTransactionBody();
         this._inner.setContractcall(this._body);
     }

--- a/src/contract/ContractInfoQuery.ts
+++ b/src/contract/ContractInfoQuery.ts
@@ -1,5 +1,4 @@
 import { QueryBuilder } from "../QueryBuilder";
-import { BaseClient } from "../BaseClient";
 import { ContractGetInfoQuery } from "../generated/ContractGetInfo_pb";
 import { QueryHeader } from "../generated/QueryHeader_pb";
 import { Query } from "../generated/Query_pb";
@@ -24,9 +23,9 @@ export type ContractInfo = {
 
 export class ContractInfoQuery extends QueryBuilder<ContractInfo> {
     private readonly _builder: ContractGetInfoQuery;
-    public constructor(client: BaseClient) {
+    public constructor() {
         const header = new QueryHeader();
-        super(client, header);
+        super(header);
         this._builder = new ContractGetInfoQuery();
         this._builder.setHeader(header);
         this._inner.setContractgetinfo(this._builder);

--- a/src/contract/ContractRecordsQuery.ts
+++ b/src/contract/ContractRecordsQuery.ts
@@ -1,5 +1,4 @@
 import { QueryBuilder } from "../QueryBuilder";
-import { BaseClient } from "../BaseClient";
 import { QueryHeader } from "../generated/QueryHeader_pb";
 import { Query } from "../generated/Query_pb";
 import { grpc } from "@improbable-eng/grpc-web";
@@ -16,9 +15,9 @@ export type ContractRecord = {
 
 export class ContractRecordsQuery extends QueryBuilder<ContractRecord> {
     private readonly _builder: ContractGetRecordsQuery;
-    public constructor(client: BaseClient) {
+    public constructor() {
         const header = new QueryHeader();
-        super(client, header);
+        super(header);
         this._builder = new ContractGetRecordsQuery();
         this._builder.setHeader(header);
         this._inner.setContractgetrecords(this._builder);

--- a/src/contract/ContractUpdateTransaction.ts
+++ b/src/contract/ContractUpdateTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 import { SmartContractService } from "../generated/SmartContractService_pb_service";
 
 import { ContractUpdateTransactionBody } from "../generated/ContractUpdate_pb";
@@ -16,8 +15,8 @@ import { PublicKey } from "../crypto/PublicKey";
 export class ContractUpdateTransaction extends TransactionBuilder {
     private readonly _body: ContractUpdateTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new ContractUpdateTransactionBody();
         this._inner.setContractupdateinstance(this._body);
     }

--- a/src/file/FileAppendTransaction.ts
+++ b/src/file/FileAppendTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 
 import { FileService } from "../generated/FileService_pb_service";
 import { FileAppendTransactionBody } from "../generated/FileAppend_pb";
@@ -11,8 +10,8 @@ import { FileIdLike, fileIdToProto } from "../file/FileId";
 export class FileAppendTransaction extends TransactionBuilder {
     private readonly _body: FileAppendTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new FileAppendTransactionBody();
         this._inner.setFileappend(this._body);
     }

--- a/src/file/FileContentsQuery.ts
+++ b/src/file/FileContentsQuery.ts
@@ -1,5 +1,4 @@
 import { QueryBuilder } from "../QueryBuilder";
-import { BaseClient } from "../BaseClient";
 import { QueryHeader } from "../generated/QueryHeader_pb";
 import { FileGetContentsQuery } from "../generated/FileGetContents_pb";
 import { grpc } from "@improbable-eng/grpc-web";
@@ -16,9 +15,9 @@ export type FileContents = {
 export class FileContentsQuery extends QueryBuilder<FileContents> {
     private readonly _builder: FileGetContentsQuery;
 
-    public constructor(client: BaseClient) {
+    public constructor() {
         const header = new QueryHeader();
-        super(client, header);
+        super(header);
         this._builder = new FileGetContentsQuery();
         this._builder.setHeader(header);
         this._inner.setFilegetcontents(this._builder);

--- a/src/file/FileCreateTransaction.ts
+++ b/src/file/FileCreateTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 
 import { FileService } from "../generated/FileService_pb_service";
 import { FileCreateTransactionBody } from "../generated/FileCreate_pb";
@@ -13,8 +12,8 @@ import { Ed25519PublicKey } from "../crypto/Ed25519PublicKey";
 export class FileCreateTransaction extends TransactionBuilder {
     private readonly _body: FileCreateTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new FileCreateTransactionBody();
         this.setExpirationTime(Date.now() + 7890000000);
         this._inner.setFilecreate(this._body);

--- a/src/file/FileDeleteTransaction.ts
+++ b/src/file/FileDeleteTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 
 import { FileService } from "../generated/FileService_pb_service";
 import { FileDeleteTransactionBody } from "../generated/FileDelete_pb";
@@ -11,8 +10,8 @@ import { FileIdLike, fileIdToProto } from "../file/FileId";
 export class FileDeleteTransaction extends TransactionBuilder {
     private readonly _body: FileDeleteTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new FileDeleteTransactionBody();
         this._inner.setFiledelete(this._body);
     }

--- a/src/file/FileInfoQuery.ts
+++ b/src/file/FileInfoQuery.ts
@@ -4,7 +4,6 @@ import { grpc } from "@improbable-eng/grpc-web";
 import { Query } from "../generated/Query_pb";
 import { FileGetInfoQuery } from "../generated/FileGetInfo_pb";
 import { QueryHeader } from "../generated/QueryHeader_pb";
-import { BaseClient } from "../BaseClient";
 import { Response } from "../generated/Response_pb";
 import { getSdkKeys } from "../util";
 import { FileIdLike, fileIdToProto, fileIdToSdk } from "../file/FileId";
@@ -22,9 +21,9 @@ export type FileInfo = {
 export class FileInfoQuery extends QueryBuilder<FileInfo> {
     private readonly _builder: FileGetInfoQuery;
 
-    public constructor(client: BaseClient) {
+    public constructor() {
         const header = new QueryHeader();
-        super(client, header);
+        super(header);
         this._builder = new FileGetInfoQuery();
         this._builder.setHeader(header);
         this._inner.setFilegetinfo(this._builder);

--- a/src/file/FileUpdateTransaction.ts
+++ b/src/file/FileUpdateTransaction.ts
@@ -2,7 +2,6 @@ import { TransactionBuilder } from "../TransactionBuilder";
 import { Transaction } from "../generated/Transaction_pb";
 import { TransactionResponse } from "../generated/TransactionResponse_pb";
 import { grpc } from "@improbable-eng/grpc-web";
-import { BaseClient } from "../BaseClient";
 
 import { FileService } from "../generated/FileService_pb_service";
 import { KeyList } from "../generated/BasicTypes_pb";
@@ -14,8 +13,8 @@ import { PublicKey } from "../crypto/PublicKey";
 export class FileUpdateTransaction extends TransactionBuilder {
     private readonly _body: FileUpdateTransactionBody;
 
-    public constructor(client: BaseClient) {
-        super(client);
+    public constructor() {
+        super();
         this._body = new FileUpdateTransactionBody();
         this._inner.setFileupdate(this._body);
     }


### PR DESCRIPTION
User changes: 
- The `client` will no longer be supplied in the constructor of various transactions or queries. Instead the client could be optionally passed into the `TransactionBuilder.build()` method to automatically sign the transaction, or the client is required be passed directly into `Transaction.execute()` and `QueryBuilder.execute()`. 
- Note: `TransactionBuilder.build()` will fail if a client is not provided *and* an explicit node account id is not set using `TransactionBuilder.setNodeAccountId()` method. 
- Removed `Transaction.executeForReceipt()`. Instead the user is now required to execute the transaction using `Transaction.execute()`, and then call `Transaction.waitForReceipt()` to explicitly wait for the receipt of the transaction which could take several minutes to complete. This two stage process is now required for users to determine where the error came from; executing the transaction or waiting for the receipt of the transaction.