### PR TITLE
Implement Contract Call encoding

### DIFF
--- a/__tests__/contract/CallParams.test.ts
+++ b/__tests__/contract/CallParams.test.ts
@@ -1,6 +1,5 @@
 import { CallParams, FunctionSelector } from "../../src/exports";
-
-const utf8 = require("utf8");
+import BigNumber from "bignumber.js";
 
 describe("CallParams", () => {
     const uint32 = new Uint8Array(4);
@@ -112,5 +111,51 @@ describe("CallParams", () => {
         expect(sixthParamSecondElLen).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000003");
         expect(sixthParamSecondEl).toStrictEqual("74776f0000000000000000000000000000000000000000000000000000000000");
         expect(finished).toHaveLength(484);
+    });
+
+    it("encodes correctly using correct addParam", () => {
+        const params = new CallParams()
+            .setFunction("f")
+            .addUint32(1515)
+            .addBytes(bytes)
+            .addUint64(uint64)
+            // .addUint64(new BigNumber("2e+63"))
+            .addString(str)
+            .addStringArray(strArray);
+
+        // const finished = params.toProto();
+        // const funcHash              = Buffer.from(finished.slice(0,  4).buffer).toString("hex");
+        // const firstParam            = Buffer.from(finished.slice((32 * 0)  + 4, (32 * 1)  + 4).buffer).toString("hex");
+        // const secondParam           = Buffer.from(finished.slice((32 * 1)  + 4, (32 * 2)  + 4).buffer).toString("hex");
+        // const thirdParam            = Buffer.from(finished.slice((32 * 2)  + 4, (32 * 3)  + 4).buffer).toString("hex");
+        // const forthParam            = Buffer.from(finished.slice((32 * 3)  + 4, (32 * 4)  + 4).buffer).toString("hex");
+        // const fifthParam            = Buffer.from(finished.slice((32 * 4)  + 4, (32 * 5)  + 4).buffer).toString("hex");
+        // const sixthParam            = Buffer.from(finished.slice((32 * 5)  + 4, (32 * 6)  + 4).buffer).toString("hex");
+        // const fourthParamDataLength = Buffer.from(finished.slice((32 * 6)  + 4, (32 * 7)  + 4).buffer).toString("hex");
+        // const fourthParamData       = Buffer.from(finished.slice((32 * 7)  + 4, (32 * 8)  + 4).buffer).toString("hex");
+        // const sixthParamDataLength  = Buffer.from(finished.slice((32 * 8)  + 4, (32 * 9)  + 4).buffer).toString("hex");
+        // const sixthParamFirstElOff  = Buffer.from(finished.slice((32 * 9)  + 4, (32 * 10) + 4).buffer).toString("hex");
+        // const sixthParamSecondElOff = Buffer.from(finished.slice((32 * 10) + 4, (32 * 11) + 4).buffer).toString("hex");
+        // const sixthParamFirstElLen  = Buffer.from(finished.slice((32 * 11) + 4, (32 * 12) + 4).buffer).toString("hex");
+        // const sixthParamFirstEl     = Buffer.from(finished.slice((32 * 12) + 4, (32 * 13) + 4).buffer).toString("hex");
+        // const sixthParamSecondElLen = Buffer.from(finished.slice((32 * 13) + 4, (32 * 14) + 4).buffer).toString("hex");
+        // const sixthParamSecondEl    = Buffer.from(finished.slice((32 * 14) + 4, (32 * 15) + 4).buffer).toString("hex");
+        // expect(funcHash).toStrictEqual("d4dbd767");
+        // expect(firstParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000001020304");
+        // expect(secondParam).toStrictEqual("0001000004000000000800000000000000000000000000000000000000000000");
+        // expect(thirdParam).toStrictEqual("000000000000000000000000000000000000000000000000ffffffff00000000");
+        // expect(forthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000c0");
+        // expect(fifthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000005eb");
+        // expect(sixthParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000100");
+        // expect(fourthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000014");
+        // expect(fourthParamData).toStrictEqual("746869732069732061206772696e3a20f09f9881000000000000000000000000");
+        // expect(sixthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000002");
+        // expect(sixthParamFirstElOff).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000040");
+        // expect(sixthParamSecondElOff).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000080");
+        // expect(sixthParamFirstElLen).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000003");
+        // expect(sixthParamFirstEl).toStrictEqual("6f6e650000000000000000000000000000000000000000000000000000000000");
+        // expect(sixthParamSecondElLen).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000003");
+        // expect(sixthParamSecondEl).toStrictEqual("74776f0000000000000000000000000000000000000000000000000000000000");
+        // expect(finished).toHaveLength(484);
     });
 });

--- a/__tests__/contract/CallParams.test.ts
+++ b/__tests__/contract/CallParams.test.ts
@@ -116,46 +116,16 @@ describe("CallParams", () => {
     it("encodes correctly using correct addParam", () => {
         const params = new CallParams()
             .setFunction("f")
-            .addUint32(1515)
-            .addBytes(bytes)
             .addUint64(uint64)
-            // .addUint64(new BigNumber("2e+63"))
-            .addString(str)
-            .addStringArray(strArray);
+            .addUint64(new BigNumber(2).pow(63));
 
-        // const finished = params.toProto();
-        // const funcHash              = Buffer.from(finished.slice(0,  4).buffer).toString("hex");
-        // const firstParam            = Buffer.from(finished.slice((32 * 0)  + 4, (32 * 1)  + 4).buffer).toString("hex");
-        // const secondParam           = Buffer.from(finished.slice((32 * 1)  + 4, (32 * 2)  + 4).buffer).toString("hex");
-        // const thirdParam            = Buffer.from(finished.slice((32 * 2)  + 4, (32 * 3)  + 4).buffer).toString("hex");
-        // const forthParam            = Buffer.from(finished.slice((32 * 3)  + 4, (32 * 4)  + 4).buffer).toString("hex");
-        // const fifthParam            = Buffer.from(finished.slice((32 * 4)  + 4, (32 * 5)  + 4).buffer).toString("hex");
-        // const sixthParam            = Buffer.from(finished.slice((32 * 5)  + 4, (32 * 6)  + 4).buffer).toString("hex");
-        // const fourthParamDataLength = Buffer.from(finished.slice((32 * 6)  + 4, (32 * 7)  + 4).buffer).toString("hex");
-        // const fourthParamData       = Buffer.from(finished.slice((32 * 7)  + 4, (32 * 8)  + 4).buffer).toString("hex");
-        // const sixthParamDataLength  = Buffer.from(finished.slice((32 * 8)  + 4, (32 * 9)  + 4).buffer).toString("hex");
-        // const sixthParamFirstElOff  = Buffer.from(finished.slice((32 * 9)  + 4, (32 * 10) + 4).buffer).toString("hex");
-        // const sixthParamSecondElOff = Buffer.from(finished.slice((32 * 10) + 4, (32 * 11) + 4).buffer).toString("hex");
-        // const sixthParamFirstElLen  = Buffer.from(finished.slice((32 * 11) + 4, (32 * 12) + 4).buffer).toString("hex");
-        // const sixthParamFirstEl     = Buffer.from(finished.slice((32 * 12) + 4, (32 * 13) + 4).buffer).toString("hex");
-        // const sixthParamSecondElLen = Buffer.from(finished.slice((32 * 13) + 4, (32 * 14) + 4).buffer).toString("hex");
-        // const sixthParamSecondEl    = Buffer.from(finished.slice((32 * 14) + 4, (32 * 15) + 4).buffer).toString("hex");
-        // expect(funcHash).toStrictEqual("d4dbd767");
-        // expect(firstParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000001020304");
-        // expect(secondParam).toStrictEqual("0001000004000000000800000000000000000000000000000000000000000000");
-        // expect(thirdParam).toStrictEqual("000000000000000000000000000000000000000000000000ffffffff00000000");
-        // expect(forthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000c0");
-        // expect(fifthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000005eb");
-        // expect(sixthParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000100");
-        // expect(fourthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000014");
-        // expect(fourthParamData).toStrictEqual("746869732069732061206772696e3a20f09f9881000000000000000000000000");
-        // expect(sixthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000002");
-        // expect(sixthParamFirstElOff).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000040");
-        // expect(sixthParamSecondElOff).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000080");
-        // expect(sixthParamFirstElLen).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000003");
-        // expect(sixthParamFirstEl).toStrictEqual("6f6e650000000000000000000000000000000000000000000000000000000000");
-        // expect(sixthParamSecondElLen).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000003");
-        // expect(sixthParamSecondEl).toStrictEqual("74776f0000000000000000000000000000000000000000000000000000000000");
-        // expect(finished).toHaveLength(484);
+        const finished = params.toProto();
+        const funcHash              = Buffer.from(finished.slice(0,  4).buffer).toString("hex");
+        const firstParam            = Buffer.from(finished.slice((32 * 0)  + 4, (32 * 1)  + 4).buffer).toString("hex");
+        const secondParam           = Buffer.from(finished.slice((32 * 1)  + 4, (32 * 2)  + 4).buffer).toString("hex");
+        expect(funcHash).toStrictEqual("6a43b6eb");
+        expect(firstParam).toStrictEqual("000000000000000000000000000000000000000000000000ffffffff00000000");
+        expect(secondParam).toStrictEqual("0000000000000000000000000000000000000000000000008000000000000000");
+        expect(finished).toHaveLength(68);
     });
 });

--- a/__tests__/contract/CallParams.test.ts
+++ b/__tests__/contract/CallParams.test.ts
@@ -18,6 +18,8 @@ describe("CallParams", () => {
 
     const str: string = "this is a grin: \uD83D\uDE01";
 
+    const strArray: string[] = ["one", "two"];
+
     it("encodes correctly using function selector", () => {
         const func = new FunctionSelector("f")
             .addParamType("uint32")
@@ -62,18 +64,19 @@ describe("CallParams", () => {
         expect(fourthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000020");
         expect(fourthParamData).toStrictEqual("ff000000000000000000000000000000000000000000000000000000000000ff");
         expect(fifthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000014");
-        expect(fifthParamData).toStrictEqual("746869732069732061206772696e3a20c3b0c29fc298c2810000000000000000");
+        expect(fifthParamData).toStrictEqual("746869732069732061206772696e3a20f09f9881000000000000000000000000");
         expect(finished).toHaveLength(356);
     });
 
-    it("encodes correctly using function selector", () => {
+    it("encodes correctly using generic addParam", () => {
         const params = new CallParams()
             .setFunction("f")
             .addParam(uint32)
             .addParam(bytes)
             .addParam(uint64)
             .addParam(str)
-            .addParam(1515);
+            .addParam(1515)
+            .addParam(strArray);
 
         const finished = params.toProto();
         const funcHash              = Buffer.from(finished.slice(0,  4).buffer).toString("hex");
@@ -82,20 +85,32 @@ describe("CallParams", () => {
         const thirdParam            = Buffer.from(finished.slice((32 * 2)  + 4, (32 * 3)  + 4).buffer).toString("hex");
         const forthParam            = Buffer.from(finished.slice((32 * 3)  + 4, (32 * 4)  + 4).buffer).toString("hex");
         const fifthParam            = Buffer.from(finished.slice((32 * 4)  + 4, (32 * 5)  + 4).buffer).toString("hex");
-        const secondParamDataLength = Buffer.from(finished.slice((32 * 5)  + 4, (32 * 6)  + 4).buffer).toString("hex");
-        const secondParamData       = Buffer.from(finished.slice((32 * 6)  + 4, (32 * 7)  + 4).buffer).toString("hex");
-        const fourthParamDataLength = Buffer.from(finished.slice((32 * 7)  + 4, (32 * 8)  + 4).buffer).toString("hex");
-        const fourthParamData       = Buffer.from(finished.slice((32 * 8)  + 4, (32 * 9)  + 4).buffer).toString("hex");
-        expect(funcHash).toStrictEqual("014647bd");
+        const sixthParam            = Buffer.from(finished.slice((32 * 5)  + 4, (32 * 6)  + 4).buffer).toString("hex");
+        const fourthParamDataLength = Buffer.from(finished.slice((32 * 6)  + 4, (32 * 7)  + 4).buffer).toString("hex");
+        const fourthParamData       = Buffer.from(finished.slice((32 * 7)  + 4, (32 * 8)  + 4).buffer).toString("hex");
+        const sixthParamDataLength  = Buffer.from(finished.slice((32 * 8)  + 4, (32 * 9)  + 4).buffer).toString("hex");
+        const sixthParamFirstElOff  = Buffer.from(finished.slice((32 * 9)  + 4, (32 * 10) + 4).buffer).toString("hex");
+        const sixthParamSecondElOff = Buffer.from(finished.slice((32 * 10) + 4, (32 * 11) + 4).buffer).toString("hex");
+        const sixthParamFirstElLen  = Buffer.from(finished.slice((32 * 11) + 4, (32 * 12) + 4).buffer).toString("hex");
+        const sixthParamFirstEl     = Buffer.from(finished.slice((32 * 12) + 4, (32 * 13) + 4).buffer).toString("hex");
+        const sixthParamSecondElLen = Buffer.from(finished.slice((32 * 13) + 4, (32 * 14) + 4).buffer).toString("hex");
+        const sixthParamSecondEl    = Buffer.from(finished.slice((32 * 14) + 4, (32 * 15) + 4).buffer).toString("hex");
+        expect(funcHash).toStrictEqual("d4dbd767");
         expect(firstParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000001020304");
-        expect(secondParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000a0");
+        expect(secondParam).toStrictEqual("0001000004000000000800000000000000000000000000000000000000000000");
         expect(thirdParam).toStrictEqual("000000000000000000000000000000000000000000000000ffffffff00000000");
-        expect(forthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000e0");
+        expect(forthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000c0");
         expect(fifthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000005eb");
-        expect(secondParamDataLength).toStrictEqual("000000000000000000000000000000000000000000000000000000000000000a");
-        expect(secondParamData).toStrictEqual("0001000004000000000800000000000000000000000000000000000000000000");
+        expect(sixthParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000100");
         expect(fourthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000014");
-        expect(fourthParamData).toStrictEqual("746869732069732061206772696e3a20c3b0c29fc298c2810000000000000000");
-        expect(finished).toHaveLength(292);
+        expect(fourthParamData).toStrictEqual("746869732069732061206772696e3a20f09f9881000000000000000000000000");
+        expect(sixthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000002");
+        expect(sixthParamFirstElOff).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000040");
+        expect(sixthParamSecondElOff).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000080");
+        expect(sixthParamFirstElLen).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000003");
+        expect(sixthParamFirstEl).toStrictEqual("6f6e650000000000000000000000000000000000000000000000000000000000");
+        expect(sixthParamSecondElLen).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000003");
+        expect(sixthParamSecondEl).toStrictEqual("74776f0000000000000000000000000000000000000000000000000000000000");
+        expect(finished).toHaveLength(484);
     });
 });

--- a/__tests__/contract/CallParams.test.ts
+++ b/__tests__/contract/CallParams.test.ts
@@ -1,0 +1,68 @@
+import { CallParams, FunctionSelector } from "../../src/exports";
+
+const utf8 = require("utf8");
+
+describe("CallParams", () => {
+    it("encodes correctly", () => {
+        const func = new FunctionSelector("f")
+            .addParamType("uint32")
+            .addParamType("bytes")
+            .addParamType("uint64")
+            .addParamType("bytes")
+            .addParamType("string");
+
+        const uint32 = new Uint8Array(4);
+        const uint32View = new DataView(uint32.buffer);
+        uint32View.setUint32(0, 16909060);
+
+        const bytes = new Uint8Array(10);
+        bytes[ 1 ] = 1;
+        bytes[ 4 ] = 4;
+        bytes[ 9 ] = 8;
+
+        const uint64 = new Uint8Array(8);
+        const uint64View = new DataView(uint64.buffer);
+        uint64View.setUint32(0, 4294967295);
+
+        const bytes2 = new Uint8Array(32);
+        bytes2[ 0 ] = 255;
+        bytes2[ 31 ] = 255;
+
+        const str: string = "this is a grin: \uD83D\uDE01";
+
+        const params = new CallParams(func);
+        expect(() => params.finish()).toThrow(new Error("Invalid number of parameters provided"));
+        params.addParam(uint32)
+            .addParam(bytes)
+            .addParam(uint64)
+            .addParam(bytes2)
+            .addParam(str);
+
+        const finished = params.finish();
+        const funcHash              = Buffer.from(finished.slice(0,  4).buffer).toString("hex");
+        const firstParam            = Buffer.from(finished.slice((32 * 0)  + 4, (32 * 1)  + 4).buffer).toString("hex");
+        const secondParam           = Buffer.from(finished.slice((32 * 1)  + 4, (32 * 2)  + 4).buffer).toString("hex");
+        const thirdParam            = Buffer.from(finished.slice((32 * 2)  + 4, (32 * 3)  + 4).buffer).toString("hex");
+        const forthParam            = Buffer.from(finished.slice((32 * 3)  + 4, (32 * 4)  + 4).buffer).toString("hex");
+        const fifthParam            = Buffer.from(finished.slice((32 * 4)  + 4, (32 * 5)  + 4).buffer).toString("hex");
+        const secondParamDataLength = Buffer.from(finished.slice((32 * 5)  + 4, (32 * 6)  + 4).buffer).toString("hex");
+        const secondParamData       = Buffer.from(finished.slice((32 * 6)  + 4, (32 * 7)  + 4).buffer).toString("hex");
+        const fourthParamDataLength = Buffer.from(finished.slice((32 * 7)  + 4, (32 * 8)  + 4).buffer).toString("hex");
+        const fourthParamData       = Buffer.from(finished.slice((32 * 8)  + 4, (32 * 9)  + 4).buffer).toString("hex");
+        const fifthParamDataLength  = Buffer.from(finished.slice((32 * 9)  + 4, (32 * 10) + 4).buffer).toString("hex");
+        const fifthParamData        = Buffer.from(finished.slice((32 * 10) + 4, (32 * 11) + 4).buffer).toString("hex");
+        expect(funcHash).toStrictEqual("4fec5a19");
+        expect(firstParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000001020304");
+        expect(secondParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000a0");
+        expect(thirdParam).toStrictEqual("000000000000000000000000000000000000000000000000ffffffff00000000");
+        expect(forthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000e0");
+        expect(fifthParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000120");
+        expect(secondParamDataLength).toStrictEqual("000000000000000000000000000000000000000000000000000000000000000a");
+        expect(secondParamData).toStrictEqual("0001000004000000000800000000000000000000000000000000000000000000");
+        expect(fourthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000020");
+        expect(fourthParamData).toStrictEqual("ff000000000000000000000000000000000000000000000000000000000000ff");
+        expect(fifthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000014");
+        expect(fifthParamData).toStrictEqual("746869732069732061206772696e3a20c3b0c29fc298c2810000000000000000");
+        expect(finished).toHaveLength(356);
+    });
+});

--- a/__tests__/contract/CallParams.test.ts
+++ b/__tests__/contract/CallParams.test.ts
@@ -2,9 +2,6 @@ import { CallParams, FunctionSelector } from "../../src/exports";
 import BigNumber from "bignumber.js";
 
 describe("CallParams", () => {
-    // const uint32 = new Uint8Array(4);
-    // const uint32View = new DataView(uint32.buffer);
-    // uint32View.setUint32(0, 16909060);
     const uint32 = 16909060;
 
     const bytes = new Uint8Array(10);
@@ -12,15 +9,11 @@ describe("CallParams", () => {
     bytes[ 4 ] = 4;
     bytes[ 9 ] = 8;
 
-    // const uint64 = new Uint8Array(8);
-    // const uint64View = new DataView(uint64.buffer);
-    // uint64View.setUint32(0, 4294967295);
-
     const uint64 = new BigNumber("ffffffff", 16).multipliedBy(new BigNumber(256).pow(4));
 
-    const str: string = "this is a grin: \uD83D\uDE01";
+    const str = "this is a grin: \uD83D\uDE01";
 
-    const strArray: string[] = ["one", "two"];
+    const strArray: string[] = [ "one", "two" ];
 
     it("encodes correctly using function selector", () => {
         const bytes2 = new Uint8Array(32);

--- a/__tests__/contract/CallParams.test.ts
+++ b/__tests__/contract/CallParams.test.ts
@@ -3,7 +3,22 @@ import { CallParams, FunctionSelector } from "../../src/exports";
 const utf8 = require("utf8");
 
 describe("CallParams", () => {
-    it("encodes correctly", () => {
+    const uint32 = new Uint8Array(4);
+    const uint32View = new DataView(uint32.buffer);
+    uint32View.setUint32(0, 16909060);
+
+    const bytes = new Uint8Array(10);
+    bytes[ 1 ] = 1;
+    bytes[ 4 ] = 4;
+    bytes[ 9 ] = 8;
+
+    const uint64 = new Uint8Array(8);
+    const uint64View = new DataView(uint64.buffer);
+    uint64View.setUint32(0, 4294967295);
+
+    const str: string = "this is a grin: \uD83D\uDE01";
+
+    it("encodes correctly using function selector", () => {
         const func = new FunctionSelector("f")
             .addParamType("uint32")
             .addParamType("bytes")
@@ -11,34 +26,19 @@ describe("CallParams", () => {
             .addParamType("bytes")
             .addParamType("string");
 
-        const uint32 = new Uint8Array(4);
-        const uint32View = new DataView(uint32.buffer);
-        uint32View.setUint32(0, 16909060);
-
-        const bytes = new Uint8Array(10);
-        bytes[ 1 ] = 1;
-        bytes[ 4 ] = 4;
-        bytes[ 9 ] = 8;
-
-        const uint64 = new Uint8Array(8);
-        const uint64View = new DataView(uint64.buffer);
-        uint64View.setUint32(0, 4294967295);
-
         const bytes2 = new Uint8Array(32);
         bytes2[ 0 ] = 255;
         bytes2[ 31 ] = 255;
 
-        const str: string = "this is a grin: \uD83D\uDE01";
-
         const params = new CallParams(func);
-        expect(() => params.finish()).toThrow(new Error("Invalid number of parameters provided"));
+        expect(() => params.toProto()).toThrow(new Error("Invalid number of parameters provided"));
         params.addParam(uint32)
             .addParam(bytes)
             .addParam(uint64)
             .addParam(bytes2)
             .addParam(str);
 
-        const finished = params.finish();
+        const finished = params.toProto();
         const funcHash              = Buffer.from(finished.slice(0,  4).buffer).toString("hex");
         const firstParam            = Buffer.from(finished.slice((32 * 0)  + 4, (32 * 1)  + 4).buffer).toString("hex");
         const secondParam           = Buffer.from(finished.slice((32 * 1)  + 4, (32 * 2)  + 4).buffer).toString("hex");
@@ -64,5 +64,38 @@ describe("CallParams", () => {
         expect(fifthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000014");
         expect(fifthParamData).toStrictEqual("746869732069732061206772696e3a20c3b0c29fc298c2810000000000000000");
         expect(finished).toHaveLength(356);
+    });
+
+    it("encodes correctly using function selector", () => {
+        const params = new CallParams()
+            .setFunction("f")
+            .addParam(uint32)
+            .addParam(bytes)
+            .addParam(uint64)
+            .addParam(str)
+            .addParam(1515);
+
+        const finished = params.toProto();
+        const funcHash              = Buffer.from(finished.slice(0,  4).buffer).toString("hex");
+        const firstParam            = Buffer.from(finished.slice((32 * 0)  + 4, (32 * 1)  + 4).buffer).toString("hex");
+        const secondParam           = Buffer.from(finished.slice((32 * 1)  + 4, (32 * 2)  + 4).buffer).toString("hex");
+        const thirdParam            = Buffer.from(finished.slice((32 * 2)  + 4, (32 * 3)  + 4).buffer).toString("hex");
+        const forthParam            = Buffer.from(finished.slice((32 * 3)  + 4, (32 * 4)  + 4).buffer).toString("hex");
+        const fifthParam            = Buffer.from(finished.slice((32 * 4)  + 4, (32 * 5)  + 4).buffer).toString("hex");
+        const secondParamDataLength = Buffer.from(finished.slice((32 * 5)  + 4, (32 * 6)  + 4).buffer).toString("hex");
+        const secondParamData       = Buffer.from(finished.slice((32 * 6)  + 4, (32 * 7)  + 4).buffer).toString("hex");
+        const fourthParamDataLength = Buffer.from(finished.slice((32 * 7)  + 4, (32 * 8)  + 4).buffer).toString("hex");
+        const fourthParamData       = Buffer.from(finished.slice((32 * 8)  + 4, (32 * 9)  + 4).buffer).toString("hex");
+        expect(funcHash).toStrictEqual("014647bd");
+        expect(firstParam).toStrictEqual("0000000000000000000000000000000000000000000000000000000001020304");
+        expect(secondParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000a0");
+        expect(thirdParam).toStrictEqual("000000000000000000000000000000000000000000000000ffffffff00000000");
+        expect(forthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000000e0");
+        expect(fifthParam).toStrictEqual("00000000000000000000000000000000000000000000000000000000000005eb");
+        expect(secondParamDataLength).toStrictEqual("000000000000000000000000000000000000000000000000000000000000000a");
+        expect(secondParamData).toStrictEqual("0001000004000000000800000000000000000000000000000000000000000000");
+        expect(fourthParamDataLength).toStrictEqual("0000000000000000000000000000000000000000000000000000000000000014");
+        expect(fourthParamData).toStrictEqual("746869732069732061206772696e3a20c3b0c29fc298c2810000000000000000");
+        expect(finished).toHaveLength(292);
     });
 });

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
     "bip39": "^3.0.2",
     "google-protobuf": "^3.11.0",
     "grpc": "^1.24.2",
-    "tweetnacl": "^1.0.1"
+    "js-sha3": "^0.8.0",
+    "tweetnacl": "^1.0.1",
+    "utf8": "^3.0.0"
   },
   "devDependencies": {
     "@launchbadge/eslint-config": "^0.13.10",

--- a/src/contract/CallParams.ts
+++ b/src/contract/CallParams.ts
@@ -613,8 +613,6 @@ function argumentToBytes(
     let value = new Uint8Array(32);
     let valueView = new DataView(value.buffer, 0);
 
-    console.error(`type: ${ty.ty}`);
-
     if (ty.array) {
         if (!Array.isArray(param)) {
             throw new TypeError("SoldityType indicates type is array, but parameter is not an array");

--- a/src/contract/CallParams.ts
+++ b/src/contract/CallParams.ts
@@ -1,0 +1,198 @@
+import { keccak256 } from "js-sha3";
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const utf8 = require("utf8");
+
+enum ArgumentType {
+    uint32 = "uint32",
+    uint64 = "uint64",
+    uint256 = "uint256",
+    string = "string",
+    bool = "bool",
+    bytes = "bytes",
+}
+
+export class CallParams {
+    private readonly func: Uint8Array;
+    private argumentList: Argument[] = [];
+    private readonly argumentTypes: ArgumentType[];
+    private currentArgument = 0;
+    // Use Uint8Array to hold the offset in bytes, and use
+    // offsetView to get the value as a Uint32; effectively
+    // creating a Uint32 value type.
+    private offset = new Uint8Array(32);
+    private offsetView: DataView;
+
+    public constructor(func: FunctionSelector) {
+        const finish = func.finish();
+
+        this.func = finish.hash;
+        this.argumentTypes = finish.argumentTypes;
+        this.offsetView = new DataView(this.offset.buffer, 28);
+        this.offsetView.setUint32(0, this.argumentTypes.length * 32);
+    }
+
+    // String type unsupported (directly). See `ArgumentType.String` in
+    // the switch statement below
+    public addParam(param: string | boolean | number | Uint8Array): this {
+        let value = new Uint8Array(32);
+        let dynamic = false;
+        const offset = new Uint8Array(32);
+        const offsetView = new DataView(offset.buffer, 28);
+        const length = new Uint8Array(32);
+        const lengthView = new DataView(length.buffer, 28);
+
+        switch (this.argumentTypes[ this.currentArgument ]) {
+            case ArgumentType.uint32:
+                value.set(param as Uint8Array, 28);
+                break;
+            case ArgumentType.uint64:
+                value.set(param as Uint8Array, 24);
+                break;
+            case ArgumentType.uint256:
+                value = (param as Uint8Array);
+                break;
+            case ArgumentType.bool:
+                value[ 31 ] = (param as boolean) ? 1 : 0;
+                break;
+            // Bytes should have not the length already encoded
+            // JS String type is encoded as UTF-16 whilst Solidity `string` type is UTF-8 encoded.
+            // So if will assume is already correctly updated to being a Uint8Array of UTF-8 string
+            case ArgumentType.bytes:
+            case ArgumentType.string:
+                // Bytes and string are dynamic types
+                dynamic = true;
+
+                // eslint-disable-next-line no-case-declarations
+                const par: Uint8Array = param instanceof Uint8Array ?
+                    param as Uint8Array :
+                    utf8.encode(param);
+
+                // eslint-disable-next-line no-case-declarations
+                const length = par.length;
+                // resize value to a 32 byte boundary if needed
+                if (Math.floor(length / 32) >= 0 && Math.floor(length % 32) !== 0) {
+                    value = new Uint8Array((Math.floor(length / 32) + 1) * 32);
+                }
+
+                // Copy data of parameter into value; left to right
+                value.set(Buffer.from(par), 0);
+
+                // Bytes and String types are prefixed with length as an uint256
+                lengthView.setUint32(0, par.length);
+
+                // Update offset for next parameter that needs it
+                offsetView.setUint32(0, this.offsetView.getUint32(0));
+
+                // The next offset is equal to the last offset + the length of this field + 32 bytes for length.
+                // Bytes are encoded as one 32 byte value for the length, and then the value after
+                // right-padded to a 32 byte boundary.
+                this.offsetView.setUint32(0, offsetView.getUint32(0) + value.length + 32);
+                break;
+            default: throw new Error(`Unsupported argument type: ${this.argumentTypes[ this.currentArgument ]}`);
+        }
+
+        this.argumentList.push({ dynamic, offset, offsetView, length, lengthView, value });
+        this.currentArgument += 1;
+
+        return this;
+    }
+
+    public finish(): Uint8Array {
+        if (this.argumentList.length !== this.argumentTypes.length) {
+            throw new Error("Invalid number of parameters provided");
+        }
+
+        // Length = 4 bytes for function header + number of arguments * 32 bytes for each argument +
+        // (for each dynamic argument take the length of value and add 32 for the length)
+        // We have to get this length because Uint8Arrays aren't easily resizable. So create a
+        // Uint8Array of appropriate size initially and populate the contents accordingly
+        const length = (this.argumentList.length * 32) + this.argumentList
+            .map((arg) => arg.dynamic ? arg.value.length + 32 : 0)
+            .reduce((sum, value) => sum + value) + 4;
+
+        const func = new Uint8Array(length);
+        func.set(this.func, 0);
+
+        // Encode the initial arguments
+        // For non dynamic types encode the value in-place,
+        // for dynamic types encode the offset
+        // The 4 bytes is added to offsets because offset don't account
+        // for the function hash
+        for (let i = 0; i < this.argumentList.length; i += 1) {
+            const arg = this.argumentList[ i ];
+            if (arg.dynamic) {
+                func.set(arg.offset as Uint8Array, 4 + (i * 32));
+            } else {
+                func.set(arg.value, 4 + (i * 32));
+            }
+        }
+
+        // Encode dynamic arguments at the offset.
+        for (let i = 0; i < this.argumentList.length; i += 1) {
+            const arg = this.argumentList[ i ];
+            if (arg.dynamic) {
+                const offset = (arg.offsetView as DataView).getUint32(0);
+                func.set(arg.length as Uint8Array, 4 + offset);
+                func.set(arg.value as Uint8Array, 4 + offset + 32);
+            }
+        }
+
+        return func;
+    }
+}
+
+type Argument = {
+    dynamic: boolean;
+    offset: null | Uint8Array;
+    offsetView: null | DataView;
+    length: null | Uint8Array;
+    lengthView: null | DataView;
+    value: Uint8Array;
+};
+
+export class FunctionSelector {
+    private func: string;
+    private needsComma = false;
+    private argumentTypes: ArgumentType[] = [];
+
+    public constructor(func: string) {
+        this.func = `${func}(`;
+    }
+
+    public addParamType(ty: string): this {
+        if (this.needsComma) {
+            this.func += ",";
+        }
+
+        const argument = stringToArgumentType(ty);
+
+        this.func += argument;
+        this.argumentTypes.push(argument);
+        this.needsComma = true;
+
+        return this;
+    }
+
+    public finish(): { hash: Uint8Array; argumentTypes: ArgumentType[] } {
+        this.func += ")";
+
+        return {
+            hash: new Uint8Array(keccak256.arrayBuffer(this.func).slice(0, 4)),
+            argumentTypes: this.argumentTypes
+        };
+    }
+
+    public toString(): string {
+        return this.func;
+    }
+}
+
+function stringToArgumentType(ty: string): ArgumentType {
+    const argument = ArgumentType[ ty as keyof typeof ArgumentType ];
+    if (argument == null) {
+        throw new Error(`Argument Type is unsuppored: ${ty}`);
+    }
+
+    return argument;
+}
+

--- a/src/contract/CallParams.ts
+++ b/src/contract/CallParams.ts
@@ -3,160 +3,55 @@ import { keccak256 } from "js-sha3";
 const utf8 = require("utf8");
 
 enum ArgumentType {
+    uint8 = "uint8",
+    int8 = "int8",
+    uint16 = "uint16",
+    int16 = "int16",
     uint32 = "uint32",
+    int32 = "int32",
     uint64 = "uint64",
+    int64 = "int64",
     uint256 = "uint256",
     string = "string",
     bool = "bool",
     bytes = "bytes",
 }
 
-export class CallParams {
-    private readonly func: Uint8Array;
-    private argumentList: Argument[] = [];
-    private readonly argumentTypes: ArgumentType[];
-    private currentArgument = 0;
-    // Use Uint8Array to hold the offset in bytes, and use
-    // offsetView to get the value as a Uint32; effectively
-    // creating a Uint32 value type.
-    private offset = new Uint8Array(32);
-    private offsetView: DataView;
+export class FunctionSelector {
+    private func?: string;
+    private needsComma = false;
+    public argumentTypes: ArgumentType[] = [];
+    public argumentList: Argument[] = [];
 
-    public constructor(func: FunctionSelector) {
-        const finish = func.finish();
-
-        this.func = finish.hash;
-        this.argumentTypes = finish.argumentTypes;
-        this.offsetView = new DataView(this.offset.buffer, 28);
-        this.offsetView.setUint32(0, this.argumentTypes.length * 32);
+    public constructor(func?: string) {
+        if (func) {
+            this.func = `${func}(`;
+        }
     }
 
-    // String type unsupported (directly). See `ArgumentType.String` in
-    // the switch statement below
-    public addParam(param: string | boolean | number | Uint8Array): this {
-        let value = new Uint8Array(32);
-        let dynamic = false;
-        const offset = new Uint8Array(32);
-        const offsetView = new DataView(offset.buffer, 28);
-        const length = new Uint8Array(32);
-        const lengthView = new DataView(length.buffer, 28);
-
-        switch (this.argumentTypes[ this.currentArgument ]) {
-            case ArgumentType.uint32:
-                value.set(param as Uint8Array, 28);
-                break;
-            case ArgumentType.uint64:
-                value.set(param as Uint8Array, 24);
-                break;
-            case ArgumentType.uint256:
-                value = (param as Uint8Array);
-                break;
-            case ArgumentType.bool:
-                value[ 31 ] = (param as boolean) ? 1 : 0;
-                break;
-            // Bytes should have not the length already encoded
-            // JS String type is encoded as UTF-16 whilst Solidity `string` type is UTF-8 encoded.
-            // So if will assume is already correctly updated to being a Uint8Array of UTF-8 string
-            case ArgumentType.bytes:
-            case ArgumentType.string:
-                // Bytes and string are dynamic types
-                dynamic = true;
-
-                // eslint-disable-next-line no-case-declarations
-                const par: Uint8Array = param instanceof Uint8Array ?
-                    param as Uint8Array :
-                    utf8.encode(param);
-
-                // eslint-disable-next-line no-case-declarations
-                const length = par.length;
-                // resize value to a 32 byte boundary if needed
-                if (Math.floor(length / 32) >= 0 && Math.floor(length % 32) !== 0) {
-                    value = new Uint8Array((Math.floor(length / 32) + 1) * 32);
-                }
-
-                // Copy data of parameter into value; left to right
-                value.set(Buffer.from(par), 0);
-
-                // Bytes and String types are prefixed with length as an uint256
-                lengthView.setUint32(0, par.length);
-
-                // Update offset for next parameter that needs it
-                offsetView.setUint32(0, this.offsetView.getUint32(0));
-
-                // The next offset is equal to the last offset + the length of this field + 32 bytes for length.
-                // Bytes are encoded as one 32 byte value for the length, and then the value after
-                // right-padded to a 32 byte boundary.
-                this.offsetView.setUint32(0, offsetView.getUint32(0) + value.length + 32);
-                break;
-            default: throw new Error(`Unsupported argument type: ${this.argumentTypes[ this.currentArgument ]}`);
+    public setFunction(func: string): this {
+        if (this.func) {
+            throw new Error("Function Name has already been set");
         }
 
-        this.argumentList.push({ dynamic, offset, offsetView, length, lengthView, value });
-        this.currentArgument += 1;
+        this.func = func ? `${func}(` : "";
 
         return this;
     }
 
-    public finish(): Uint8Array {
-        if (this.argumentList.length !== this.argumentTypes.length) {
-            throw new Error("Invalid number of parameters provided");
-        }
+    /**
+     * NOT A STABLE API
+     */
+    public initialOffset(): { offset: Uint8Array; offsetView: DataView } {
+        const offset = new Uint8Array(32);
+        const offsetView = new DataView(offset.buffer, 28);
 
-        // Length = 4 bytes for function header + number of arguments * 32 bytes for each argument +
-        // (for each dynamic argument take the length of value and add 32 for the length)
-        // We have to get this length because Uint8Arrays aren't easily resizable. So create a
-        // Uint8Array of appropriate size initially and populate the contents accordingly
-        const length = (this.argumentList.length * 32) + this.argumentList
-            .map((arg) => arg.dynamic ? arg.value.length + 32 : 0)
-            .reduce((sum, value) => sum + value) + 4;
+        offsetView.setUint32(0, 32 * this.argumentTypes.length);
 
-        const func = new Uint8Array(length);
-        func.set(this.func, 0);
-
-        // Encode the initial arguments
-        // For non dynamic types encode the value in-place,
-        // for dynamic types encode the offset
-        // The 4 bytes is added to offsets because offset don't account
-        // for the function hash
-        for (let i = 0; i < this.argumentList.length; i += 1) {
-            const arg = this.argumentList[ i ];
-            if (arg.dynamic) {
-                func.set(arg.offset as Uint8Array, 4 + (i * 32));
-            } else {
-                func.set(arg.value, 4 + (i * 32));
-            }
-        }
-
-        // Encode dynamic arguments at the offset.
-        for (let i = 0; i < this.argumentList.length; i += 1) {
-            const arg = this.argumentList[ i ];
-            if (arg.dynamic) {
-                const offset = (arg.offsetView as DataView).getUint32(0);
-                func.set(arg.length as Uint8Array, 4 + offset);
-                func.set(arg.value as Uint8Array, 4 + offset + 32);
-            }
-        }
-
-        return func;
-    }
-}
-
-type Argument = {
-    dynamic: boolean;
-    offset: null | Uint8Array;
-    offsetView: null | DataView;
-    length: null | Uint8Array;
-    lengthView: null | DataView;
-    value: Uint8Array;
-};
-
-export class FunctionSelector {
-    private func: string;
-    private needsComma = false;
-    private argumentTypes: ArgumentType[] = [];
-
-    public constructor(func: string) {
-        this.func = `${func}(`;
+        return {
+            offset,
+            offsetView
+        };
     }
 
     public addParamType(ty: string): this {
@@ -173,19 +68,314 @@ export class FunctionSelector {
         return this;
     }
 
-    public finish(): { hash: Uint8Array; argumentTypes: ArgumentType[] } {
+    /**
+     * NOT A STABLE API
+     */
+    public toProto(): Uint8Array {
         this.func += ")";
 
-        return {
-            hash: new Uint8Array(keccak256.arrayBuffer(this.func).slice(0, 4)),
-            argumentTypes: this.argumentTypes
-        };
+        return new Uint8Array(keccak256.arrayBuffer(this.func!).slice(0, 4));
     }
 
     public toString(): string {
-        return this.func;
+        return `${this.func!})`;
     }
 }
+
+export class CallParams {
+    private readonly func: FunctionSelector;
+    private currentArgument = 0;
+    // Use Uint8Array to hold the offset in bytes, and use
+    // offsetView to get the value as a Uint32; effectively
+    // creating a Uint32 value type.
+    private offset = new Uint8Array(32);
+    private offsetView: DataView;
+
+    public constructor(func?: string | FunctionSelector) {
+        if (func && typeof func == "string") {
+            this.func = new FunctionSelector(func);
+        } else if (func instanceof FunctionSelector) {
+            this.func = func;
+        } else {
+            this.func = new FunctionSelector();
+        }
+
+        this.offsetView = new DataView(this.offset.buffer, 28);
+        this.offsetView.setUint32(0, this.func.argumentTypes.length * 32);
+    }
+
+    public setFunction(func: string): this {
+        this.func.setFunction(func);
+
+        return this;
+    }
+
+    private guessType(param: string | boolean | number | Uint8Array): void {
+        // This guesses the parameter type from the passed in parameter
+        // If the user wants to define this themselves they should pass
+        // in a FunctionSelector into the constructor themselves
+        switch (typeof param) {
+            case "string":
+                this.func.addParamType("string");
+                break;
+            case "boolean":
+                this.func.addParamType("bool");
+                break;
+            case "number":
+                if (param as number > 0) {
+                    // If number is less than max uint8
+                    if (Math.floor(param as number) <= 255) {
+                        this.func.addParamType("uint8");
+                    // If number is less than max uint16
+                    } else if (Math.floor(param as number) <= 65536) {
+                        this.func.addParamType("uint16");
+                    // If number is less than max uint32
+                    } else if (Math.floor(param as number) <= 4294967296) {
+                        this.func.addParamType("uint32");
+                    // Else type must be uint64
+                    } else {
+                        this.func.addParamType("uint64");
+                    }
+                } else {
+                    // Disabling no-lonely-if because I think it's valid to have it here
+                    // If number is less than max int8
+                    // eslint-disable-next-line no-lonely-if
+                    if (Math.floor(param as number) >= -128) {
+                        this.func.addParamType("int8");
+                    // If number is less than max int16
+                    } else if (Math.floor(param as number) >= -32768) {
+                        this.func.addParamType("int16");
+                    // If number is less than max int32
+                    } else if (Math.floor(param as number) >= -2147483648) {
+                        this.func.addParamType("int32");
+                    // Else type must be int64
+                    } else {
+                        this.func.addParamType("int64");
+                    }
+                }
+                break;
+            default:
+                if (param instanceof Uint8Array) {
+                    switch ((param as Uint8Array).length) {
+                        case 1:
+                            this.func.addParamType("uint8");
+                            break;
+                        case 2:
+                            this.func.addParamType("uint16");
+                            break;
+                        case 4:
+                            this.func.addParamType("uint32");
+                            break;
+                        case 8:
+                            this.func.addParamType("uint64");
+                            break;
+                        case 32:
+                            this.func.addParamType("uint256");
+                            break;
+                        default:
+                            this.func.addParamType("bytes");
+                    }
+                } else {
+                    throw new TypeError("Should not be possible to get here");
+                }
+        }
+    }
+
+    public addParam(param: string | boolean | number | Uint8Array): this {
+        let value = new Uint8Array(32);
+        let dynamic = false;
+        const length = new Uint8Array(32);
+        const lengthView = new DataView(length.buffer, 28);
+        const valueView = new DataView(value.buffer, 0);
+
+        // Determine if we need to guess the parameter type or if it's already defined
+        // The reason we even have this code is because javascript doesn't support 64-bit numbers.
+        // Note: BigInt isn't allowed to be used because this sdk is supposed to support older
+        // browsers; some of which don't support BigInt. So if the function requires a uint64,
+        // but this sdk is being used, the user is expected to construct the function selector
+        // him/herself, supplying all the required parameters initially, then constructing
+        // this class from that selector. OR, the user is required to constructor a Uint8Array
+        // of appropriate size. For a uint64 the size would be 8 bytes, so `new Uint8Array(8)`.
+        if (this.func.argumentTypes.length === this.currentArgument) {
+            this.guessType(param);
+        }
+
+        // This is required because the user might have already defined the parameter types
+        switch (this.func.argumentTypes[ this.currentArgument ]) {
+            case ArgumentType.uint8:
+                if (typeof param === "number") {
+                    valueView.setUint8(31, param as number);
+                } else {
+                    value.set(param as Uint8Array, 31);
+                }
+                break;
+            case ArgumentType.int8:
+                if (typeof param === "number") {
+                    valueView.setInt8(31, param as number);
+                } else {
+                    value.set(param as Uint8Array, 31);
+                }
+                break;
+            case ArgumentType.uint16:
+                if (typeof param === "number") {
+                    valueView.setUint16(30, param as number);
+                } else {
+                    value.set(param as Uint8Array, 30);
+                }
+                break;
+            case ArgumentType.int16:
+                if (typeof param === "number") {
+                    valueView.setInt16(30, param as number);
+                } else {
+                    value.set(param as Uint8Array, 30);
+                }
+                break;
+            case ArgumentType.uint32:
+                if (typeof param === "number") {
+                    valueView.setUint32(28, param as number);
+                } else {
+                    value.set(param as Uint8Array, 28);
+                }
+                break;
+            case ArgumentType.int32:
+                if (typeof param === "number") {
+                    valueView.setInt32(28, param as number);
+                } else {
+                    value.set(param as Uint8Array, 28);
+                }
+                break;
+            // int64, uint64, and uint256 both expect the parameter to be an Uint8Array instead of number
+            case ArgumentType.uint64:
+                value.set(param as Uint8Array, 24);
+                break;
+            case ArgumentType.int64:
+                value.set(param as Uint8Array, 24);
+                break;
+            case ArgumentType.uint256:
+                value = (param as Uint8Array);
+                break;
+            case ArgumentType.bool:
+                value[ 31 ] = (param as boolean) ? 1 : 0;
+                break;
+            // Bytes should have not the length already encoded
+            // JS String type is encoded as UTF-16 whilst Solidity `string` type is UTF-8 encoded.
+            // So if will assume is already correctly updated to being a Uint8Array of UTF-8 string
+            case ArgumentType.bytes:
+            case ArgumentType.string:
+                // Bytes and string are dynamic types
+                dynamic = true;
+
+                // If param is of type string, encode it in UTF-8 format and conver it to Uint8Array
+                // Required because JS Strings are UTF-16
+                // eslint-disable-next-line no-case-declarations
+                const par: Uint8Array = param instanceof Uint8Array ?
+                    param as Uint8Array :
+                    utf8.encode(param);
+
+                // Resize value to a 32 byte boundary if needed
+                if (Math.floor(par.length / 32) >= 0 && Math.floor(par.length % 32) !== 0) {
+                    value = new Uint8Array((Math.floor(par.length / 32) + 1) * 32);
+                }
+
+                // Copy data of parameter into value; left to right
+                value.set(Buffer.from(par), 0);
+
+                // Bytes and String types are prefixed with length as an uint256
+                lengthView.setUint32(0, par.length);
+
+                // Update offset for next parameter that needs it
+                // offsetView.setUint32(0, this.offsetView.getUint32(0));
+
+                // The next offset is equal to the last offset + the length of this field + 32 bytes for length.
+                // Bytes are encoded as one 32 byte value for the length, and then the value after
+                // right-padded to a 32 byte boundary.
+                // this.offsetView.setUint32(0, offsetView.getUint32(0) + value.length + 32);
+                break;
+            default: throw new Error(`Unsupported argument type: ${this.func.argumentTypes[ this.currentArgument ]}`);
+        }
+
+        this.func.argumentList.push({
+            dynamic,
+            offset: null,
+            offsetView: null,
+            length,
+            lengthView,
+            value
+        });
+
+        this.currentArgument += 1;
+
+        return this;
+    }
+
+    /**
+     * NOT A STABLE API
+     */
+    public toProto(): Uint8Array {
+        if (this.func.argumentList.length !== this.func.argumentTypes.length) {
+            throw new Error("Invalid number of parameters provided");
+        }
+
+        // Length = 4 bytes for function header + number of arguments * 32 bytes for each argument +
+        // (for each dynamic argument take the length of value and add 32 for the length)
+        // We have to get this length because Uint8Arrays aren't easily resizable. So create a
+        // Uint8Array of appropriate size initially and populate the contents accordingly
+        const length = (this.func.argumentList.length * 32) + this.func.argumentList
+            .map((arg) => arg.dynamic ? arg.value.length + 32 : 0)
+            .reduce((sum, value) => sum + value) + 4;
+
+        const func = new Uint8Array(length);
+        func.set(this.func.toProto(), 0);
+
+        const { offset, offsetView } = this.func.initialOffset();
+
+        // Encode the initial arguments
+        // For non dynamic types encode the value in-place,
+        // for dynamic types encode the offset
+        // The 4 bytes is added to offsets because offset don't account
+        // for the function hash
+        for (let i = 0; i < this.func.argumentList.length; i += 1) {
+            const arg = this.func.argumentList[ i ];
+            if (arg.dynamic) {
+                // Set the offset in the argument. This is used later write the argument data into the
+                // appopriate position in the buffer
+                arg.offset = new Uint8Array(Buffer.from(offset.buffer));
+                arg.offsetView = new DataView((arg.offset as Uint8Array).buffer, 28);
+
+                func.set(offset, 4 + (i * 32));
+
+                offsetView.setUint32(
+                    0,
+                    offsetView.getUint32(0) +
+                    arg.value.length + 32
+                );
+            } else {
+                func.set(arg.value, 4 + (i * 32));
+            }
+        }
+
+        // Encode dynamic arguments at the offset.
+        for (let i = 0; i < this.func.argumentList.length; i += 1) {
+            const arg = this.func.argumentList[ i ];
+            if (arg.dynamic) {
+                const argOffset = (arg.offsetView as DataView).getUint32(0);
+                func.set(arg.length as Uint8Array, 4 + argOffset);
+                func.set(arg.value as Uint8Array, 4 + argOffset + 32);
+            }
+        }
+
+        return func;
+    }
+}
+
+type Argument = {
+    dynamic: boolean;
+    offset: null | Uint8Array;
+    offsetView: null | DataView;
+    length: null | Uint8Array;
+    lengthView: null | DataView;
+    value: Uint8Array;
+};
 
 function stringToArgumentType(ty: string): ArgumentType {
     const argument = ArgumentType[ ty as keyof typeof ArgumentType ];

--- a/src/contract/CallParams.ts
+++ b/src/contract/CallParams.ts
@@ -428,46 +428,22 @@ function argumentToBytes(
 
     switch (ty.ty) {
         case ArgumentType.uint8:
-            if (typeof param === "number") {
-                valueView.setUint8(31, param as number);
-            } else {
-                valueView.setUint8(31, (param as BigNumber).toNumber());
-            }
+            numberToBytes(param as number | BigNumber, 31, valueView.setUint8.bind(valueView));
             return value;
         case ArgumentType.int8:
-            if (typeof param === "number") {
-                valueView.setInt8(31, param as number);
-            } else {
-                valueView.setInt8(31, (param as BigNumber).toNumber());
-            }
+            numberToBytes(param as number | BigNumber, 31, valueView.setInt8.bind(valueView));
             return value;
         case ArgumentType.uint16:
-            if (typeof param === "number") {
-                valueView.setUint16(30, param as number);
-            } else {
-                valueView.setUint16(30, (param as BigNumber).toNumber());
-            }
+            numberToBytes(param as number | BigNumber, 30, valueView.setUint16.bind(valueView));
             return value;
         case ArgumentType.int16:
-            if (typeof param === "number") {
-                valueView.setInt16(30, param as number);
-            } else {
-                valueView.setInt16(30, (param as BigNumber).toNumber());
-            }
+            numberToBytes(param as number | BigNumber, 30, valueView.setInt16.bind(valueView));
             return value;
         case ArgumentType.uint32:
-            if (typeof param === "number") {
-                valueView.setUint32(28, param as number);
-            } else {
-                valueView.setUint32(28, (param as BigNumber).toNumber());
-            }
+            numberToBytes(param as number | BigNumber, 28, valueView.setUint32.bind(valueView));
             return value;
         case ArgumentType.int32:
-            if (typeof param === "number") {
-                valueView.setInt32(28, param as number);
-            } else {
-                valueView.setInt32(28, (param as BigNumber).toNumber());
-            }
+            numberToBytes(param as number | BigNumber, 28, valueView.setInt32.bind(valueView));
             return value;
         // int64, uint64, and uint256 both expect the parameter to be an Uint8Array instead of number
         case ArgumentType.uint64:
@@ -527,6 +503,16 @@ function argumentToBytes(
             return value;
         default: throw new Error(`Unsupported argument type: ${ty}`);
     }
+}
+
+function numberToBytes(
+    param: number | BigNumber,
+    byteoffset: number,
+    func: (byteOffset: number, value: number) => void
+): void {
+    const value = param instanceof BigNumber ? (param as BigNumber).toNumber() : param as number;
+
+    func(byteoffset, value);
 }
 
 function solidityTypeFromBitwidth(bitwidth: number, signed: boolean, array: boolean): SolidityType {

--- a/src/contract/ContractCallQuery.ts
+++ b/src/contract/ContractCallQuery.ts
@@ -7,6 +7,7 @@ import { SmartContractService } from "../generated/SmartContractService_pb_servi
 import { ContractIdLike, contractIdToProto } from "./ContractId";
 import { ContractFunctionResult, contractFunctionResultToSdk } from "./ContractFunctionResult";
 import { ContractCallLocalQuery } from "../generated/ContractCallLocal_pb";
+import { CallParams } from "./CallParams";
 
 export class ContractCallQuery extends QueryBuilder<ContractFunctionResult> {
     private readonly _builder: ContractCallLocalQuery;
@@ -20,6 +21,15 @@ export class ContractCallQuery extends QueryBuilder<ContractFunctionResult> {
 
     public setContractId(contractIdLike: ContractIdLike): this {
         this._builder.setContractid(contractIdToProto(contractIdLike));
+        return this;
+    }
+
+    public setFunctionParameters(params: CallParams | Uint8Array): this {
+        if (params instanceof Uint8Array) {
+            this._builder.setFunctionparameters(params as Uint8Array);
+        } else {
+            this._builder.setFunctionparameters((params as CallParams).finish());
+        }
         return this;
     }
 

--- a/src/contract/ContractCallQuery.ts
+++ b/src/contract/ContractCallQuery.ts
@@ -28,7 +28,7 @@ export class ContractCallQuery extends QueryBuilder<ContractFunctionResult> {
         if (params instanceof Uint8Array) {
             this._builder.setFunctionparameters(params as Uint8Array);
         } else {
-            this._builder.setFunctionparameters((params as CallParams).toProto());
+            this._builder.setFunctionparameters((params as CallParams)._toProto());
         }
         return this;
     }

--- a/src/contract/ContractCallQuery.ts
+++ b/src/contract/ContractCallQuery.ts
@@ -28,7 +28,7 @@ export class ContractCallQuery extends QueryBuilder<ContractFunctionResult> {
         if (params instanceof Uint8Array) {
             this._builder.setFunctionparameters(params as Uint8Array);
         } else {
-            this._builder.setFunctionparameters((params as CallParams).finish());
+            this._builder.setFunctionparameters((params as CallParams).toProto());
         }
         return this;
     }

--- a/src/exports.ts
+++ b/src/exports.ts
@@ -59,3 +59,5 @@ export { TransactionId } from "./TransactionId";
 
 export { TransactionReceipt } from "./TransactionReceipt";
 export { TransactionRecord } from "./TransactionRecord";
+
+export { CallParams, FunctionSelector } from "./contract/CallParams";

--- a/yarn.lock
+++ b/yarn.lock
@@ -3733,6 +3733,11 @@ jest@^24.9.0:
     import-local "^2.0.0"
     jest-cli "^24.9.0"
 
+js-sha3@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6403,6 +6408,11 @@ use@^3.1.0:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+
+utf8@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/utf8/-/utf8-3.0.0.tgz#f052eed1364d696e769ef058b183df88c87f69d1"
+  integrity sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==
 
 util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"


### PR DESCRIPTION
Implements encoding function calls in the solidity binary format. This includes encoding parameter types `uint32`, `bytes`, `string`, and `bool` which means encoding now fully supports dynamic types. 
User changes:
- `ContractCallQuery` now supports `setFunctionParameters()` being passed a `CallParams` object which
computes the the solidity binary format from js types.

Note to Reviewers: This PR is branched off another PR; PR #90 so there are a changes that look duplicated.