### PR TITLE
Hbar Parity

### DIFF
--- a/__tests__/Hbar.test.ts
+++ b/__tests__/Hbar.test.ts
@@ -26,27 +26,27 @@ describe("hbar", () => {
     it.each([[ 50_000_000, HbarUnit.Microbar ], [ "50000000", HbarUnit.Microbar ], [ 50_000, HbarUnit.Millibar ], [ "50000", HbarUnit.Millibar ], [ 50, HbarUnit.Hbar ], [ "50", HbarUnit.Hbar ], [ 0.05, HbarUnit.Kilobar ], [ "0.05", HbarUnit.Kilobar ], [ 0.00005, HbarUnit.Megabar ], [ "0.00005", HbarUnit.Megabar ], [ 0.00000005, HbarUnit.Gigabar ], [ "0.00000005", HbarUnit.Gigabar ]] as [number, HbarUnit][])(
         "value conversions are correct/50 hbar",
         (amount, unit) => {
-            expect(Hbar.from(amount, unit)).toStrictEqual(fiftyHbar);
+            expect(Hbar.from(amount, unit).asTinybar()).toStrictEqual(fiftyHbar.asTinybar());
 
             expect(fiftyHbar.as(unit)).toStrictEqual(new BigNumber(amount));
         }
     );
 
     it("arithmetic works correctly", () => {
-        expect(fiftyHbar.plus(fiftyHbar)).toStrictEqual(hundredHbar);
-        expect(fiftyHbar.plus(fiftyGTinybar, HbarUnit.Tinybar)).toStrictEqual(hundredHbar);
-        expect(fiftyHbar.plus(negativeFiftyHbar)).toStrictEqual(zeroHbar);
-        expect(fiftyHbar.plus(zeroHbar)).toStrictEqual(fiftyHbar);
-        expect(fiftyHbar.plus(negativeZeroHbar)).toStrictEqual(fiftyHbar);
+        expect(fiftyHbar.plus(fiftyHbar).asTinybar()).toStrictEqual(hundredHbar.asTinybar());
+        expect(fiftyHbar.plus(fiftyGTinybar, HbarUnit.Tinybar).asTinybar()).toStrictEqual(hundredHbar.asTinybar());
+        expect(fiftyHbar.plus(negativeFiftyHbar).asTinybar()).toStrictEqual(zeroHbar.asTinybar());
+        expect(fiftyHbar.plus(zeroHbar).asTinybar()).toStrictEqual(fiftyHbar.asTinybar());
+        expect(fiftyHbar.plus(negativeZeroHbar).asTinybar()).toStrictEqual(fiftyHbar.asTinybar());
 
-        expect(fiftyHbar.minus(fiftyHbar)).toStrictEqual(zeroHbar);
-        expect(fiftyHbar.minus(fiftyGTinybar, HbarUnit.Tinybar)).toStrictEqual(zeroHbar);
-        expect(fiftyHbar.minus(negativeFiftyHbar)).toStrictEqual(hundredHbar);
-        expect(fiftyHbar.minus(zeroHbar)).toStrictEqual(fiftyHbar);
-        expect(fiftyHbar.minus(negativeZeroHbar)).toStrictEqual(fiftyHbar);
+        expect(fiftyHbar.minus(fiftyHbar).asTinybar()).toStrictEqual(zeroHbar.asTinybar());
+        expect(fiftyHbar.minus(fiftyGTinybar, HbarUnit.Tinybar).asTinybar()).toStrictEqual(zeroHbar.asTinybar());
+        expect(fiftyHbar.minus(negativeFiftyHbar).asTinybar()).toStrictEqual(hundredHbar.asTinybar());
+        expect(fiftyHbar.minus(zeroHbar).asTinybar()).toStrictEqual(fiftyHbar.asTinybar());
+        expect(fiftyHbar.minus(negativeZeroHbar).asTinybar()).toStrictEqual(fiftyHbar.asTinybar());
 
-        expect(zeroHbar.minus(fiftyHbar)).toStrictEqual(negativeFiftyHbar);
-        expect(negativeZeroHbar.minus(fiftyHbar)).toStrictEqual(negativeFiftyHbar);
+        expect(zeroHbar.minus(fiftyHbar).asTinybar()).toStrictEqual(negativeFiftyHbar.asTinybar());
+        expect(negativeZeroHbar.minus(fiftyHbar).asTinybar()).toStrictEqual(negativeFiftyHbar.asTinybar());
 
         expect(fiftyHbar.negated().asTinybar()).toStrictEqual(fiftyGTinybar.negated());
         expect(fiftyHbar.negated().isNegative()).toBe(true);

--- a/__tests__/contract/ContractExecuteTransaction.test.ts
+++ b/__tests__/contract/ContractExecuteTransaction.test.ts
@@ -6,7 +6,7 @@ describe("ContractExecuteTransaction", () => {
         const transaction = new ContractExecuteTransaction()
             .setContractId({ shard: 0, realm: 0, contract: 5 })
             .setGas(141)
-            .setAmount(10000)
+            .setPayableAmount(10000)
             .setFunction("set_message", new ContractFunctionParams().addString("this is random message"))
             .setMaxTransactionFee(1e6)
             .setTransactionId({

--- a/src/Hbar.ts
+++ b/src/Hbar.ts
@@ -96,7 +96,9 @@ export class Hbar {
     }
 
     public toString(): string {
-        return `${this.value()} ${this._unit.toString()} (${this._tinybar.toString(10)} tinybar)`;
+        return this._unit === HbarUnit.Tinybar ?
+            `${this.value()} ${this._unit.toString()}` :
+            `${this.value()} ${this._unit.toString()} (${this._tinybar.toString(10)} tinybar)`;
     }
 
     public value(): BigNumber {

--- a/src/Hbar.ts
+++ b/src/Hbar.ts
@@ -57,9 +57,11 @@ function convertToTinybar(amount: BigNumber.Value, unit: HbarUnit): BigNumber {
 export class Hbar {
     /** The HBAR value in tinybar, used natively by the SDK and Hedera itself */
     private readonly _tinybar: BigNumber;
+    private readonly _unit: HbarUnit;
 
-    private constructor(tinybar: BigNumber) {
+    private constructor(tinybar: BigNumber, unit: HbarUnit = HbarUnit.Hbar) {
         this._tinybar = tinybar;
+        this._unit = unit;
     }
 
     public static readonly MAX: Hbar = new Hbar(new BigNumber(2).pow(63).minus(1));
@@ -72,25 +74,29 @@ export class Hbar {
      * Calculate the HBAR amount given a raw value and a unit.
      */
     public static from(amount: number | BigNumber | string, unit: HbarUnit): Hbar {
-        return new Hbar(convertToTinybar(amount, unit));
+        return new Hbar(convertToTinybar(amount, unit), unit);
     }
 
     /** Get HBAR from a tinybar amount, may be a string */
     public static fromTinybar(amount: number | BigNumber | string): Hbar {
         const bnAmount = amount instanceof BigNumber ? amount : new BigNumber(amount);
-        return new Hbar(bnAmount);
+        return new Hbar(bnAmount, HbarUnit.Tinybar);
     }
 
     /**
      * Wrap a raw value of HBAR, may be a string.
      */
     public static of(amount: number | BigNumber | string): Hbar {
-        return new Hbar(convertToTinybar(amount, HbarUnit.Hbar));
+        return new Hbar(convertToTinybar(amount, HbarUnit.Hbar), HbarUnit.Hbar);
     }
 
     /** Create an Hbar with a value of 0 tinybar; Note that this is a positive signed zero */
     public static zero(): Hbar {
         return new Hbar(new BigNumber(0));
+    }
+
+    public toString(): string {
+        return `${this.value()} ${this._unit.toString()} (${this._tinybar.toString(10)} tinybar)`;
     }
 
     public value(): BigNumber {

--- a/src/contract/ContractExecuteTransaction.ts
+++ b/src/contract/ContractExecuteTransaction.ts
@@ -7,6 +7,8 @@ import { ContractCallTransactionBody } from "../generated/ContractCall_pb";
 import BigNumber from "bignumber.js";
 import { ContractId, ContractIdLike } from "./ContractId";
 import { ContractFunctionParams } from "./ContractFunctionParams";
+import { Tinybar, tinybarToString } from "../Tinybar";
+import { Hbar } from "../Hbar";
 
 export class ContractExecuteTransaction extends TransactionBuilder {
     private readonly _body: ContractCallTransactionBody;
@@ -22,8 +24,8 @@ export class ContractExecuteTransaction extends TransactionBuilder {
         return this;
     }
 
-    public setPayableAmount(amount: number): this {
-        this._body.setAmount(amount);
+    public setPayableAmount(amount: Tinybar | Hbar): this {
+        this._body.setAmount(tinybarToString(amount));
         return this;
     }
 

--- a/src/contract/ContractExecuteTransaction.ts
+++ b/src/contract/ContractExecuteTransaction.ts
@@ -22,7 +22,7 @@ export class ContractExecuteTransaction extends TransactionBuilder {
         return this;
     }
 
-    public setAmount(amount: number): this {
+    public setPayableAmount(amount: number): this {
         this._body.setAmount(amount);
         return this;
     }

--- a/src/proto/ContractCall.proto
+++ b/src/proto/ContractCall.proto
@@ -13,6 +13,6 @@ import "BasicTypes.proto";
 message ContractCallTransactionBody {
     ContractID contractID = 1; // the contract instance to call, in the format used in transactions
     int64 gas = 2 [jstype = JS_STRING]; // the maximum amount of gas to use for the call
-    int64 amount = 3; // number of tinybars sent (the function must be payable if this is nonzero)
+    int64 amount = 3 [ jstype = JS_STRING] ; // number of tinybars sent (the function must be payable if this is nonzero)
     bytes functionParameters = 4; // which function to call, and the parameters to pass to the function
 }


### PR DESCRIPTION
    - Implement `Hbar.toString()` to print out debug information
    - Add `Hbar._unit` field to store original unit the hbar converted
      from.
    - Update Hbar tests to use `.asTinybar()` in `toStringEquals()`
    - Rename `ContractExecuteTransaction.setAmount()` to
      `ContractExecuteTransaction.setPayableAmount()`

Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>