### PR TITLE
AccountInfo and ContractInfo Parity

### DIFF
--- a/examples/delete-account.js
+++ b/examples/delete-account.js
@@ -1,0 +1,50 @@
+const { Client, Ed25519PrivateKey, AccountCreateTransaction, AccountDeleteTransaction, Hbar, TransactionId } = require("@hashgraph/sdk");
+
+async function main() {
+    const operatorPrivateKey = process.env.OPERATOR_KEY;
+    const operatorAccount = process.env.OPERATOR_ID;
+
+    if (operatorPrivateKey == null || operatorAccount == null) {
+        throw new Error("environment variables OPERATOR_KEY and OPERATOR_ID must be present");
+    }
+
+    const client = new Client({
+        network: { "0.testnet.hedera.com:50211": "0.0.3" },
+        operator: {
+            account: operatorAccount,
+            privateKey: operatorPrivateKey
+        }
+    });
+
+    const privateKey = await Ed25519PrivateKey.generate();
+
+    console.log("Creating an account to delete");
+    console.log(`private = ${privateKey.toString()}`);
+    console.log(`public = ${privateKey.publicKey.toString()}`);
+
+    let transactionId = await new AccountCreateTransaction()
+        .setKey(privateKey.publicKey)
+        .setInitialBalance(Hbar.of(2))
+        .execute(client);
+
+    let transactionReceipt = await transactionId.getReceipt(client);
+    const newAccountId = transactionReceipt.getAccountId();
+
+    console.log(`account = ${newAccountId}`);
+    console.log("Deleting created account");
+
+    transactionId = await new AccountDeleteTransaction()
+        .setDeleteAccountId(newAccountId)
+        .setTransferAccountId("0.0.3")
+        .setTransactionId(new TransactionId(newAccountId))
+        .build(client)
+        .sign(privateKey)
+        .execute(client);
+
+    transactionReceipt = await transactionId.getReceipt(client);
+
+    console.log(`status: ${transactionReceipt.status}`);
+}
+
+main();
+

--- a/examples/delete-account.js
+++ b/examples/delete-account.js
@@ -33,12 +33,18 @@ async function main() {
     console.log(`account = ${newAccountId}`);
     console.log("Deleting created account");
 
+    // To delete an account you **MUST** do the following:
     transactionId = await new AccountDeleteTransaction()
+        // Set which account to delete.
         .setDeleteAccountId(newAccountId)
+        // Set which account to transfer the remaining balance to.
         .setTransferAccountId("0.0.3")
+        // Manually set a `TransactionId` constructed from the `AccountId` you are  deleting.
         .setTransactionId(new TransactionId(newAccountId))
         .build(client)
+        // Sign the transaction with the same key as on the acount being deleted.
         .sign(privateKey)
+        // Finally, execute the transaction with `Transaction.execute()`
         .execute(client);
 
     transactionReceipt = await transactionId.getReceipt(client);

--- a/src/account/AccountDeleteTransaction.ts
+++ b/src/account/AccountDeleteTransaction.ts
@@ -6,6 +6,7 @@ import { CryptoService } from "../generated/CryptoService_pb_service";
 import UnaryMethodDefinition = grpc.UnaryMethodDefinition;
 import { CryptoDeleteTransactionBody } from "../generated/CryptoDelete_pb";
 import { AccountId, AccountIdLike } from "./AccountId";
+import { TransactionId } from "../TransactionId";
 
 export class AccountDeleteTransaction extends TransactionBuilder {
     private _body: CryptoDeleteTransactionBody;
@@ -18,7 +19,9 @@ export class AccountDeleteTransaction extends TransactionBuilder {
     }
 
     public setDeleteAccountId(accountId: AccountIdLike): this {
-        this._body.setDeleteaccountid(new AccountId(accountId)._toProto());
+        const account = new AccountId(accountId);
+        this.setTransactionId(new TransactionId(account));
+        this._body.setDeleteaccountid(account._toProto());
         return this;
     }
 

--- a/src/account/AccountDeleteTransaction.ts
+++ b/src/account/AccountDeleteTransaction.ts
@@ -19,9 +19,7 @@ export class AccountDeleteTransaction extends TransactionBuilder {
     }
 
     public setDeleteAccountId(accountId: AccountIdLike): this {
-        const account = new AccountId(accountId);
-        this.setTransactionId(new TransactionId(account));
-        this._body.setDeleteaccountid(account._toProto());
+        this._body.setDeleteaccountid(new AccountId(accountId)._toProto());
         return this;
     }
 

--- a/src/account/AccountDeleteTransaction.ts
+++ b/src/account/AccountDeleteTransaction.ts
@@ -6,7 +6,6 @@ import { CryptoService } from "../generated/CryptoService_pb_service";
 import UnaryMethodDefinition = grpc.UnaryMethodDefinition;
 import { CryptoDeleteTransactionBody } from "../generated/CryptoDelete_pb";
 import { AccountId, AccountIdLike } from "./AccountId";
-import { TransactionId } from "../TransactionId";
 
 export class AccountDeleteTransaction extends TransactionBuilder {
     private _body: CryptoDeleteTransactionBody;
@@ -18,6 +17,9 @@ export class AccountDeleteTransaction extends TransactionBuilder {
         this._inner.setCryptodelete(body);
     }
 
+    // Sets the account to delete. Note: To successfully delete an account
+    // one must also manually set the `TransactionId` to a `TransactionId`
+    // constructed from the same `AccountId`
     public setDeleteAccountId(accountId: AccountIdLike): this {
         this._body.setDeleteaccountid(new AccountId(accountId)._toProto());
         return this;

--- a/src/account/AccountInfoQuery.ts
+++ b/src/account/AccountInfoQuery.ts
@@ -46,7 +46,7 @@ export class AccountInfoQuery extends QueryBuilder<AccountInfo> {
 
     public async getCost(client: BaseClient): Promise<Hbar> {
         // deleted accounts return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
-        // if you set that as the query payment; 25 tinybar seems to be the minimum to get
+        // if you set that as the query payment; 25 tinybar seems to be enough to get
         // `ACCOUNT_DELETED` back instead.
         const min = Hbar.fromTinybar(25);
         const cost = await super.getCost(client);

--- a/src/account/AccountInfoQuery.ts
+++ b/src/account/AccountInfoQuery.ts
@@ -45,6 +45,9 @@ export class AccountInfoQuery extends QueryBuilder<AccountInfo> {
     }
 
     public async getCost(client: BaseClient): Promise<Hbar> {
+        // deleted accounts return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
+        // if you set that as the query payment; 25 tinybar seems to be the minimum to get
+        // `ACCOUNT_DELETED` back instead.
         const min = Hbar.fromTinybar(25);
         const cost = await super.getCost(client);
         return cost.isGreaterThan(min) ? cost : min;

--- a/src/account/AccountInfoQuery.ts
+++ b/src/account/AccountInfoQuery.ts
@@ -10,6 +10,7 @@ import { AccountId, AccountIdLike } from "./AccountId";
 import { timestampToMs } from "../Timestamp";
 import { ResponseHeader } from "../generated/ResponseHeader_pb";
 import { PublicKey, _fromProtoKey } from "../crypto/PublicKey";
+import { BaseClient } from "../BaseClient";
 
 export interface AccountInfo {
     accountId: AccountId;
@@ -41,6 +42,12 @@ export class AccountInfoQuery extends QueryBuilder<AccountInfo> {
     public setAccountId(accountId: AccountIdLike): this {
         this._builder.setAccountid(new AccountId(accountId)._toProto());
         return this;
+    }
+
+    public async getCost(client: BaseClient): Promise<Hbar> {
+        const min = Hbar.fromTinybar(25);
+        const cost = await super.getCost(client);
+        return cost.isGreaterThan(min) ? cost : min;
     }
 
     protected _doLocalValidate(errors: string[]): void {

--- a/src/contract/ContractInfoQuery.ts
+++ b/src/contract/ContractInfoQuery.ts
@@ -10,6 +10,8 @@ import { AccountId } from "../account/AccountId";
 import { timestampToDate } from "../Timestamp";
 import { ResponseHeader } from "../generated/ResponseHeader_pb";
 import { PublicKey, _fromProtoKey } from "../crypto/PublicKey";
+import { BaseClient } from "../BaseClient";
+import { Hbar } from "../Hbar";
 
 export interface ContractInfo {
     contractId: ContractId;
@@ -36,6 +38,12 @@ export class ContractInfoQuery extends QueryBuilder<ContractInfo> {
     public setContractId(contractIdLike: ContractIdLike): this {
         this._builder.setContractid(new ContractId(contractIdLike)._toProto());
         return this;
+    }
+
+    public async getCost(client: BaseClient): Promise<Hbar> {
+        const min = Hbar.fromTinybar(25);
+        const cost = await super.getCost(client);
+        return cost.isGreaterThan(min) ? cost : min;
     }
 
     protected _doLocalValidate(errors: string[]): void {

--- a/src/contract/ContractInfoQuery.ts
+++ b/src/contract/ContractInfoQuery.ts
@@ -41,6 +41,9 @@ export class ContractInfoQuery extends QueryBuilder<ContractInfo> {
     }
 
     public async getCost(client: BaseClient): Promise<Hbar> {
+        // deleted contracts return a COST_ANSWER of zero which triggers `INSUFFICIENT_TX_FEE`
+        // if you set that as the query payment; 25 tinybar seems to be the minimum to get
+        // `CONTRACT_DELETED` back instead.
         const min = Hbar.fromTinybar(25);
         const cost = await super.getCost(client);
         return cost.isGreaterThan(min) ? cost : min;


### PR DESCRIPTION
    - Implement `AccountInfo.getCost()`
    - Implement `ContractInfo.getCost()`
    - Update `AccountDeleteTransaction.setDeleteAccountId()`
      to automatically create a `TransactionId` with the correct
      `AccountId`

Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>