### PR TITLE
Fix `FreezeTransaction.set*Time()`

### DIFF
--- a/src/FreezeTransaction.ts
+++ b/src/FreezeTransaction.ts
@@ -14,20 +14,16 @@ export class FreezeTransaction extends TransactionBuilder {
         this._inner.setFreeze(this._body);
     }
 
-    public setStartTime(startTime: number | Date): this {
-        const startDateTime = new Date(startTime);
-
-        this._body.setStarthour(startDateTime.getUTCHours());
-        this._body.setStartmin(startDateTime.getUTCMinutes());
+    public setStartTime(hour: number, minute: number): this {
+        this._body.setStarthour(hour);
+        this._body.setStartmin(minute);
 
         return this;
     }
 
-    public setEndTime(endTime: number | Date): this {
-        const endDateTime = new Date(endTime);
-
-        this._body.setEndhour(endDateTime.getUTCHours());
-        this._body.setEndmin(endDateTime.getUTCMinutes());
+    public setEndTime(hour: number, minute: number): this {
+        this._body.setEndhour(hour);
+        this._body.setEndmin(minute);
 
         return this;
     }

--- a/src/FreezeTransaction.ts
+++ b/src/FreezeTransaction.ts
@@ -14,14 +14,42 @@ export class FreezeTransaction extends TransactionBuilder {
         this._inner.setFreeze(this._body);
     }
 
-    public setStartTime(hour: number, minute: number): this {
+    public setStartTime(date: number | Date): this;
+    public setStartTime(hour: number, minute: number): this;
+    public setStartTime(dateOrHour: number | Date, maybeMinute?: number): this {
+        let hour;
+        let minute;
+        if (typeof dateOrHour === "number" && maybeMinute != null) {
+            hour = dateOrHour as number;
+            minute = maybeMinute!;
+        } else {
+            console.warn(`Using \`number | Date\` for parameter is invalid and incorrect.
+Instead pass in \`hour: number, minute: number\``);
+            hour = (dateOrHour as Date).getHours();
+            minute = (dateOrHour as Date).getMinutes();
+        }
+
         this._body.setStarthour(hour);
         this._body.setStartmin(minute);
 
         return this;
     }
 
-    public setEndTime(hour: number, minute: number): this {
+    public setEndTime(date: number | Date): this;
+    public setEndTime(hour: number, minute: number): this;
+    public setEndTime(dateOrHour: number | Date, maybeMinute?: number): this {
+        let hour;
+        let minute;
+        if (typeof dateOrHour === "number" && maybeMinute != null) {
+            hour = dateOrHour as number;
+            minute = maybeMinute!;
+        } else {
+            console.warn(`Using \`number | Date\` for parameter is invalid and incorrect.
+Instead pass in \`hour: number, minute: number\``);
+            hour = (dateOrHour as Date).getHours();
+            minute = (dateOrHour as Date).getMinutes();
+        }
+
         this._body.setEndhour(hour);
         this._body.setEndmin(minute);
 


### PR DESCRIPTION
    - Update `.setStartTime()`  and `.setEndTime()` to take
      `hour: number` and `minute: number` parameters
      instead of `date: Date`.

Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>