### PR TITLE
Resolve several issues

### DIFF
--- a/__tests__/contract/ContractFunctionParams.test.ts
+++ b/__tests__/contract/ContractFunctionParams.test.ts
@@ -153,6 +153,16 @@ describe("ContractFunctionParams", () => {
         expect(finished).toHaveLength(32);
     });
 
+    it("encodes address with 0x prefix", () => {
+        const params = new ContractFunctionParams()
+            .addAddress("0x888937961a6E3D313e481a2c5BAd9791fD11ea5b");
+
+        const finished = params._build(null);
+        const firstParam = Buffer.from(finished.slice((32 * 0), (32 * 1)).buffer).toString("hex");
+        expect(firstParam).toStrictEqual("000000000000000000000000888937961a6e3d313e481a2c5bad9791fd11ea5b");
+        expect(finished).toHaveLength(32);
+    });
+
     it("encodes arrays correctly", () => {
         const params = new ContractFunctionParams()
             .addInt256(int64)

--- a/examples/get-file-contents.js
+++ b/examples/get-file-contents.js
@@ -20,7 +20,7 @@ async function main() {
         .setFileId(FileId.ADDRESS_BOOK)
         .execute(client);
 
-    console.log(resp.contents);
+    console.log(resp);
 }
 
 main();

--- a/src/BaseClient.ts
+++ b/src/BaseClient.ts
@@ -71,8 +71,10 @@ export abstract class BaseClient {
         }
     }
 
-    /** Add a node to the list of nodes */
+    // Add a node to the list of nodes
+    // @deprecate `BaseClient.putNode()` is deprecrated. Use `BaseClient.replaceNodes()` instead.
     public putNode(id: AccountIdLike, url: string): this {
+        console.warn("`BaseClient.putNode()` is deprecrated. Use `BaseClient.replaceNodes()` instead.");
         this._nodes.push({ id: new AccountId(id), url });
         return this;
     }

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -160,11 +160,15 @@ export class Transaction {
         /* eslint-enable no-await-in-loop */
     }
 
+    // @deprecate `Transaction.getReceipt()` is deprecrated. Use `(await Transaction.execute()).getReceipt()` instead.
     public getReceipt(client: BaseClient): Promise<TransactionReceipt> {
+        console.warn("`Transaction.getReceipt()` is deprecrated. Use `(await Transaction.execute()).getReceipt()` instead.");
         return this.id.getReceipt(client);
     }
 
+    // @deprecate `Transaction.getRecord()` is deprecrated. Use `(await Transaction.execute()).getRecord()` instead.
     public getRecord(client: BaseClient): Promise<TransactionRecord> {
+        console.warn("`Transaction.getRecord()` is deprecrated. Use `(await Transaction.execute()).getRecord()` instead.");
         return this.id.getRecord(client);
     }
 

--- a/src/TransactionReceipt.ts
+++ b/src/TransactionReceipt.ts
@@ -13,6 +13,8 @@ export class TransactionReceipt {
     private _contractId: ContractId | null;
     private _topicId: ConsensusTopicId | null;
     private readonly _exchangeRateSet: ExchangeRateSet | null;
+    public readonly topicSequenceNubmer: number;
+    public readonly topicRunningHash: Uint8Array;
 
     private constructor(
         status: Status,
@@ -20,7 +22,9 @@ export class TransactionReceipt {
         fileId: FileId | null,
         contractId: ContractId | null,
         topicId: ConsensusTopicId | null,
-        exchangeRateSet: ExchangeRateSet | null
+        exchangeRateSet: ExchangeRateSet | null,
+        topicSequenceNubmer: number,
+        topicRunningHash: Uint8Array
     ) {
         this.status = status;
         this._accountId = accountId;
@@ -28,6 +32,8 @@ export class TransactionReceipt {
         this._contractId = contractId;
         this._topicId = topicId;
         this._exchangeRateSet = exchangeRateSet;
+        this.topicSequenceNubmer = topicSequenceNubmer;
+        this.topicRunningHash = topicRunningHash;
     }
 
     public getAccountId(): AccountId {
@@ -60,7 +66,9 @@ export class TransactionReceipt {
                 null,
             receipt.hasExchangerate() ?
                 exchangeRateSetToSdk(receipt.getExchangerate()!) :
-                null
+                null,
+            receipt.getTopicsequencenumber(),
+            receipt.getTopicrunninghash_asU8()
         );
     }
 }

--- a/src/consensus/ConsensusMessageSubmitTransaction.ts
+++ b/src/consensus/ConsensusMessageSubmitTransaction.ts
@@ -11,11 +11,8 @@ import { utf8encode } from "../util";
 export class ConsensusSubmitMessageTransaction extends TransactionBuilder {
     private _body: ConsensusSubmitMessageTransactionBody;
 
-    // @deprecate `ConsensusSubmitMessageTransaction` is deprecated.
-    // Use `ConsensusMessageSubmitTransaction` instead.
     public constructor() {
         super();
-        console.warn("@deprecate `ConsensusSubmitMessageTransaction` is deprecated. Use `ConsensusMessageSubmitTransaction` instead.");
         const body = new ConsensusSubmitMessageTransactionBody();
         this._body = body;
         this._inner.setConsensussubmitmessage(body);

--- a/src/contract/ContractFunctionParams.ts
+++ b/src/contract/ContractFunctionParams.ts
@@ -165,11 +165,14 @@ export class ContractFunctionParams {
     }
 
     public addAddress(value: string): this {
-        const par = Buffer.from(value, "hex");
-
-        if (par.length !== 20) {
-            throw new Error("`address` type requires parameter to be exactly 20 bytes");
+        // Allow `0x` prefix
+        if (value.length !== 40 && value.length !== 42) {
+            throw new Error("`address` type requires parameter to be 40 or 42 characters");
         }
+
+        const par = value.length === 40 ?
+            Buffer.from(value, "hex") :
+            Buffer.from(value.substring(2), "hex");
 
         this._selector.addAddress();
 
@@ -180,12 +183,14 @@ export class ContractFunctionParams {
         const par: Uint8Array[] = [];
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        for (const [ _, a ] of value.entries()) {
-            const buf = Buffer.from(a, "hex");
-
-            if (buf.length !== 20) {
-                throw new Error("`address` type requires parameter to be exactly 20 bytes");
+        for (const [ _, entry ] of value.entries()) {
+            if (entry.length !== 40 && entry.length !== 42) {
+                throw new Error("`address` type requires parameter to be 40 or 42 characters");
             }
+
+            const buf = entry.length === 40 ?
+                Buffer.from(entry, "hex") :
+                Buffer.from(entry.substring(2), "hex");
 
             par.push(buf);
         }

--- a/src/file/FileId.ts
+++ b/src/file/FileId.ts
@@ -77,7 +77,7 @@ export class FileId {
 
     public toSolidityAddress(): string {
         const buffer = new Uint8Array(20);
-        const view = new DataView(buffer, 0, 20);
+        const view = new DataView(buffer.buffer, 0, 20);
 
         view.setUint32(0, this.shard);
         view.setUint32(8, this.realm);


### PR DESCRIPTION
    - Fixes #183 
        - Add `TransactionReceipt.consensusTopicSequenceNumber`
        - Add `TransactionReceipt.consensusTopicRunningHash`
    - Fixes #164 
        - Deprecates `BaseClient.putNode()`
    - Fixes #165 
        - Deprecates `Transaction.getReceipt` and
          `Transaction.getRecord()`
    - Fixes #169 
        - Adds support for addresses with a leading `0x` prefix.
    - Fixes #171 
        - Deprecates `ConsensusSubmitMessageTransaction` in favor
          of a new class `ConsensusMessageSubmitTransaction`
    - Fixes #182 
        - Removes `.contents` in `console.log(resp.contents)`
          since `FileContentsQuery` returns `Uint8Array`

#183, #164, #165, #169, #171, #182 