### PR TITLE
Deprecate methods that shouldn't exist from `ConsensusTopic[Create|Update]Transaction`

### DIFF
--- a/src/consensus/ConsensusTopicCreateTransaction.ts
+++ b/src/consensus/ConsensusTopicCreateTransaction.ts
@@ -26,23 +26,18 @@ export class ConsensusTopicCreateTransaction extends TransactionBuilder {
         return this;
     }
 
-    public setSubmitKey(key: PublicKey): this {
-        this._body.setSubmitkey(key._toProtoKey());
-        return this;
+    /**
+     * @deprecated `ConsensusTopicUpdateTransaction.setAutoRenewAccount()`
+     * use `ConsensusTopicUpdateTransaction.setAutoRenewAccountId()` instead.
+     */
+    public setAutoRenewAccount(id: AccountIdLike): this {
+        console.warn("`ConsensusTopicCreateTransaction.setAutoRenewAccount()` is deprecated\
+use `ConsensusTopicCreateTransaction.setAutoRenewAccountId()` instead.");
+        return this.setAutoRenewAccountId(id);
     }
 
-    public setValidStart(time: Time): this {
-        this._body.setValidstarttime(time._toProto());
-        return this;
-    }
-
-    public setExpirationTime(time: Time): this {
-        this._body.setExpirationtime(time._toProto());
-        return this;
-    }
-
-    public setTopicMemo(memo: string): this {
-        this._body.setMemo(memo);
+    public setAutoRenewAccountId(id: AccountIdLike): this {
+        this._body.setAutorenewaccount(new AccountId(id)._toProto());
         return this;
     }
 
@@ -51,8 +46,33 @@ export class ConsensusTopicCreateTransaction extends TransactionBuilder {
         return this;
     }
 
-    public setAutoRenewAccount(id: AccountIdLike): this {
-        this._body.setAutorenewaccount(new AccountId(id)._toProto());
+    /**
+     * @deprecated `ConsensusTopicCreateTransaction.setExpirationTime()` is deprecated, and
+     * should not be used.
+     */
+    public setExpirationTime(time: Time): this {
+        console.warn("`ConsensusTopicCreateTransaction.setExpirationTime()` is deprecated, and should not be used");
+        this._body.setExpirationtime(time._toProto());
+        return this;
+    }
+
+    public setSubmitKey(key: PublicKey): this {
+        this._body.setSubmitkey(key._toProtoKey());
+        return this;
+    }
+
+    public setTopicMemo(memo: string): this {
+        this._body.setMemo(memo);
+        return this;
+    }
+
+    /**
+     * @deprecated `ConsensusTopicCreateTransaction.setValidStart()` is deprecated, and
+     * should not be used.
+     */
+    public setValidStart(time: Time): this {
+        console.warn("`ConsensusTopicCreateTransaction.setValidStart()` is deprecated.");
+        this._body.setValidstarttime(time._toProto());
         return this;
     }
 

--- a/src/consensus/ConsensusTopicUpdateTransaction.ts
+++ b/src/consensus/ConsensusTopicUpdateTransaction.ts
@@ -22,43 +22,6 @@ export class ConsensusTopicUpdateTransaction extends TransactionBuilder {
         this._inner.setConsensusupdatetopic(body);
     }
 
-    public setTopicId(id: ConsensusTopicIdLike): this {
-        this._body.setTopicid(new ConsensusTopicId(id)._toProto());
-        return this;
-    }
-
-    public setAdminKey(key: PublicKey): this {
-        this._body.setAdminkey(key._toProtoKey());
-        return this;
-    }
-
-    public setSubmitKey(key: PublicKey): this {
-        this._body.setSubmitkey(key._toProtoKey());
-        return this;
-    }
-
-    public setExpirationTime(time: Time): this {
-        this._body.setExpirationtime(time._toProto());
-        return this;
-    }
-
-    public setTopicMemo(memo: string): this {
-        const value = new StringValue();
-        value.setValue(memo);
-        this._body.setMemo(value);
-        return this;
-    }
-
-    public setAutoRenewPeriod(seconds: number): this {
-        this._body.setAutorenewperiod(newDuration(seconds));
-        return this;
-    }
-
-    public setAutoRenewAccount(id: AccountIdLike): this {
-        this._body.setAutorenewaccount(new AccountId(id)._toProto());
-        return this;
-    }
-
     public clearTopicMemo(): this {
         this._body.clearMemo();
         return this;
@@ -76,6 +39,53 @@ export class ConsensusTopicUpdateTransaction extends TransactionBuilder {
 
     public clearAutoRenewAccount(): this {
         this._body.clearAutorenewaccount();
+        return this;
+    }
+
+    public setAdminKey(key: PublicKey): this {
+        this._body.setAdminkey(key._toProtoKey());
+        return this;
+    }
+
+    /**
+     * @deprecated `ConsensusTopicCreateTransaction.setAutoRenewAccount()`
+     * use `ConsensusTopicCreateTransaction.setAutoRenewAccountId()` instead.
+     */
+    public setAutoRenewAccount(id: AccountIdLike): this {
+        console.warn("`ConsensusTopicUpdateTransaction.setAutoRenewAccount()` is deprecated\
+use `ConsensusTopicUpdateTransaction.setAutoRenewAccountId()` instead.");
+        return this.setAutoRenewAccountId(id);
+    }
+
+    public setAutoRenewAccountId(id: AccountIdLike): this {
+        this._body.setAutorenewaccount(new AccountId(id)._toProto());
+        return this;
+    }
+
+    public setAutoRenewPeriod(seconds: number): this {
+        this._body.setAutorenewperiod(newDuration(seconds));
+        return this;
+    }
+
+    public setExpirationTime(time: Time): this {
+        this._body.setExpirationtime(time._toProto());
+        return this;
+    }
+
+    public setSubmitKey(key: PublicKey): this {
+        this._body.setSubmitkey(key._toProtoKey());
+        return this;
+    }
+
+    public setTopicId(id: ConsensusTopicIdLike): this {
+        this._body.setTopicid(new ConsensusTopicId(id)._toProto());
+        return this;
+    }
+
+    public setTopicMemo(memo: string): this {
+        const value = new StringValue();
+        value.setValue(memo);
+        this._body.setMemo(value);
         return this;
     }
 


### PR DESCRIPTION
    - Deprecate `setValidStart()` and `.setExpirationTime()` on
      `ConsensusTopicCreateTransaction`.
    - Rename `setAutoRenewAccount()` and `.setAutoRenewAccountId()` in
      `ConsensusTopicCreateTransaction` and
      `ConsensusTopicUpdateTransaction`.

Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>