### PR TITLE
implement rudimentary DER decoding

### DIFF
--- a/__tests__/unit/der.test.ts
+++ b/__tests__/unit/der.test.ts
@@ -1,0 +1,94 @@
+import * as der from '../../src/crypto/der';
+import { decodeHex } from '../../src/crypto/util';
+
+describe('der.decode()', () => {
+    it('decodes an Ed25519 private key as expected', () => {
+        // taken from Keys.test.js
+        const privateKey = "302e020100300506032b657004220420db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10";
+        const rawPrivKey = "db484b828e64b2d8f12ce3c0a0e93a0b8cce7af1bb8f39c97732394482538e10";
+
+        const privKeyBytes = decodeHex(privateKey);
+        const rawPrivKeyBytes = decodeHex(rawPrivKey);
+
+        const decoded = der.decode(privKeyBytes);
+
+        expect(decoded).toStrictEqual({
+            seq: [
+                { int: 0 },
+                {
+                    seq: [
+                        { ident: '1.3.101.112' }
+                    ]
+                },
+                // in PKCS `PrivateKeyInfo` the key data is an opaque byte string
+                // for Ed25519 the contents is another tagged DER `OCTET STRING`, kind of redundant
+                // but for other key types this could be a complex structure
+                { bytes: Uint8Array.of(4, 32, ...rawPrivKeyBytes) }
+            ]
+        })
+    });
+
+    it('decodes an EncryptedPrivateKeyInfo struct', () => {
+        const base64Encoded = "MIGbMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAi8WY7Gy2tThQICCAAw"
+            + "DAYIKoZIhvcNAgkFADAdBglghkgBZQMEAQIEEOq46NPss58chbjUn20NoK0EQG1x"
+            + "R88hIXcWDOECttPTNlMXWJt7Wufm1YwBibrxmCq1QykIyTYhy1TZMyxyPxlYW6aV"
+            + "9hlo4YEh3uEaCmfJzWM=";
+
+        // otherwise the types produced by `.subarray()` won't match
+        const data = Uint8Array.from(Buffer.from(base64Encoded, 'base64'));
+
+        const decoded = der.decode(data);
+
+        expect(decoded).toStrictEqual({
+            seq: [
+                {
+                    seq: [
+                        // algorithm: PBES2
+                        { ident: '1.2.840.113549.1.5.13' },
+                        // parameters
+                        {
+                            seq: [
+                                {
+                                    seq: [
+                                        // PBKDF2
+                                        { ident: '1.2.840.113549.1.5.12' },
+                                        {
+                                            seq: [
+                                                // salt
+                                                { bytes: decodeHex('bc598ec6cb6b5385') },
+                                                // iterations
+                                                { int: 2048 },
+                                                {
+                                                    seq: [
+                                                        // HMAC-SHA-256
+                                                        { ident: '1.2.840.113549.2.9' },
+                                                        // no parameters
+                                                        null
+                                                    ]
+                                                }
+
+                                            ]
+                                        }
+                                    ]
+                                },
+                                {
+                                    seq: [
+                                        // AES-128-CBC
+                                        { ident: '2.16.840.1.101.3.4.1.2' },
+                                        // IV
+                                        { bytes: decodeHex('eab8e8d3ecb39f1c85b8d49f6d0da0ad') }
+                                    ]
+                                }
+                            ]
+                        }
+                    ]
+                },
+                // encrypted key data
+                {
+                    bytes: decodeHex('6d7147cf212177160ce102b6d3d3365317589b7b5ae7e6d58c0189baf1982ab5'
+                        + '432908c93621cb54d9332c723f19585ba695f61968e18121dee11a0a67c9cd63')
+                }
+            ]
+        })
+    });
+});

--- a/src/crypto/der.ts
+++ b/src/crypto/der.ts
@@ -1,0 +1,118 @@
+export type AsnSeq = { seq: AsnType[] }
+export type AsnInt = { int: number }
+export type AsnBytes = { bytes: Uint8Array }
+export type AsnIdent = { ident: string }
+export type AsnNull = null;
+
+export type AsnType = AsnSeq | AsnInt | AsnBytes | AsnIdent | AsnNull;
+
+/**
+ * Note: may throw weird errors on malformed input. Catch and rethrow with, e.g. `BadKeyError`.
+ */
+export function decode(derBytes: Uint8Array): AsnType {
+    const [ asn ] = decodeIncremental(derBytes);
+    return asn;
+}
+
+export function decodeIncremental(bytes: Uint8Array): [AsnType, Uint8Array] {
+    // slice off the initial tag byte, `decodeLength` returns a slice of the remaining data
+    const [ len, rem ] = decodeLength(bytes.subarray(1));
+    const data = rem.subarray(0, len);
+    const tail = rem.subarray(len);
+
+    switch (bytes[ 0 ]) {
+        case 2:
+            return [{ int: decodeInt(data) }, tail ];
+        case 4: // must always be primitive form in DER; for OCTET STRING this is literal bytes
+            return [{ bytes: data }, tail ];
+        case 5: // empty
+            return [ null, tail ];
+        case 6:
+            return [{ ident: decodeObjectIdent(data) }, tail ];
+        case 48:
+            return [{ seq: decodeSeq(data) }, tail ];
+        default:
+            throw new Error(`unsupported DER type tag: ${bytes[ 0 ]}`);
+    }
+}
+
+function decodeSeq(seqBytes: Uint8Array): AsnType[] {
+    let data = seqBytes;
+
+    const seq = [];
+
+    while (data.length !== 0) {
+        const [ decoded, remaining ] = decodeIncremental(data);
+        seq.push(decoded);
+        data = remaining;
+    }
+
+    return seq;
+}
+
+function decodeObjectIdent(idBytes: Uint8Array): string {
+    const id = [
+        // first octet is 40 * value1 + value2
+        Math.floor(idBytes[ 0 ] / 40),
+        idBytes[ 0 ] % 40
+    ];
+
+    // each following ID component is big-endian base128 where the MSB is set if another byte
+    // follows for the same value
+    let val = 0;
+
+    for (const byte of idBytes.subarray(1)) {
+        // shift the entire value left by 7 bits
+        val *= 128;
+
+        if (byte < 128) {
+            // no more octets follow for this value, finish it off
+            val += byte;
+            id.push(val);
+            val = 0;
+        } else {
+            // zero the MSB
+            val += byte & 127;
+        }
+    }
+
+    return id.join(".");
+}
+
+function decodeLength(lenBytes: Uint8Array): [number, Uint8Array] {
+    if (lenBytes[ 0 ] < 128) {
+        // definite, short form
+        return [ lenBytes[ 0 ], lenBytes.subarray(1) ];
+    }
+
+    const numBytes = lenBytes[ 0 ] - 128;
+
+    const intBytes = lenBytes.subarray(1, numBytes + 1);
+    const rem = lenBytes.subarray(numBytes + 1);
+
+    return [ decodeInt(intBytes), rem ];
+}
+
+function decodeInt(intBytes: Uint8Array): number {
+    const len = intBytes.length;
+    if (len === 1) {
+        return intBytes[ 0 ];
+    }
+
+    let view = new DataView(intBytes.buffer, intBytes.byteOffset, intBytes.byteLength);
+
+    if (len === 2) return view.getUint16(0, false);
+
+    if (len === 3) {
+        // prefix a zero byte and we'll treat it as a 32-bit int
+        const data = Uint8Array.of(0, ...intBytes);
+        view = new DataView(data.buffer);
+    }
+
+    if (len > 4) {
+        // this probably means a bug in the decoding as this would mean a >4GB structure
+        throw new Error(`unsupported DER integer length of ${len} bytes`);
+    }
+
+    return view.getUint32(0, false);
+}


### PR DESCRIPTION
initial support for encrypted private keys in PEMs since we have to introspect the PKCS#8 `EncryptedPrivateKeyInfo` struct (an example of which I have added to the test)

Signed-off-by: Austin Bonander <austin@launchbadge.com>