### PR TITLE
Build in commonjs_strict mode

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,7 @@ gulp.task("build:proto", (cb) => {
     const cmd = "protoc " +
         `--plugin="protoc-gen-ts=${plugin}" ` +
         `--ts_out="service=grpc-web:${out}" ` +
-        `--js_out="import_style=commonjs,binary:${out}" ` +
+        `--js_out="import_style=commonjs_strict,binary:${out}" ` +
         `-I "${include}" ` +
         ` ${files}`;
 

--- a/src/mirror/node/MirrorConsensusTopicQuery.ts
+++ b/src/mirror/node/MirrorConsensusTopicQuery.ts
@@ -1,6 +1,6 @@
 import * as grpc from "@grpc/grpc-js";
 import { ConsensusTopicResponse } from "../../generated/MirrorConsensusService_pb";
-import { ConsensusService } from "../../generated/MirrorConsensusService_pb_service";
+import { MirrorConsensusService } from "../../generated/MirrorConsensusService_pb_service";
 import { TransactionId } from "../../TransactionId";
 import { BaseMirrorConsensusTopicQuery, ErrorHandler, Listener } from "../BaseMirrorConsensusTopicQuery";
 import { MirrorConsensusTopicResponse } from "../MirrorConsensusTopicResponse";
@@ -33,7 +33,7 @@ export class MirrorConsensusTopicQuery extends BaseMirrorConsensusTopicQuery {
         let shouldRetry = true;
 
         const response = client._client.makeServerStreamRequest(
-            `/${ConsensusService.serviceName}/${ConsensusService.subscribeTopic.methodName}`,
+            `/${MirrorConsensusService.serviceName}/${MirrorConsensusService.subscribeTopic.methodName}`,
             (req) => Buffer.from(req.serializeBinary()),
             ConsensusTopicResponse.deserializeBinary,
             this._builder,

--- a/src/mirror/web/MirrorConsensusTopicQuery.ts
+++ b/src/mirror/web/MirrorConsensusTopicQuery.ts
@@ -1,6 +1,6 @@
 import { grpc } from "@improbable-eng/grpc-web";
 import { ConsensusTopicResponse } from "../../generated/MirrorConsensusService_pb";
-import { ConsensusService } from "../../generated/MirrorConsensusService_pb_service";
+import { MirrorConsensusService } from "../../generated/MirrorConsensusService_pb_service";
 import { TransactionId } from "../../TransactionId";
 import { BaseMirrorConsensusTopicQuery, ErrorHandler, Listener } from "../BaseMirrorConsensusTopicQuery";
 import { MirrorConsensusTopicResponse } from "../MirrorConsensusTopicResponse";
@@ -33,7 +33,7 @@ export class MirrorConsensusTopicQuery extends BaseMirrorConsensusTopicQuery {
         const _makeServerStreamRequest = this._makeServerStreamRequest;
         let shouldRetry = true;
 
-        const response = grpc.invoke(ConsensusService.subscribeTopic, {
+        const response = grpc.invoke(MirrorConsensusService.subscribeTopic, {
             host: client.endpoint,
             request: this._builder,
             onMessage(message: ConsensusTopicResponse): void {

--- a/src/proto/BasicTypes.proto
+++ b/src/proto/BasicTypes.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 import "Timestamp.proto";
 
 option java_package = "com.hederahashgraph.api.proto.java";

--- a/src/proto/ConsensusCreateTopic.proto
+++ b/src/proto/ConsensusCreateTopic.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ConsensusDeleteTopic.proto
+++ b/src/proto/ConsensusDeleteTopic.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ConsensusGetTopicInfo.proto
+++ b/src/proto/ConsensusGetTopicInfo.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ConsensusService.proto
+++ b/src/proto/ConsensusService.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.service.proto.java";
 
 import "Query.proto";

--- a/src/proto/ConsensusSubmitMessage.proto
+++ b/src/proto/ConsensusSubmitMessage.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ConsensusTopicInfo.proto
+++ b/src/proto/ConsensusTopicInfo.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ConsensusUpdateTopic.proto
+++ b/src/proto/ConsensusUpdateTopic.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ContractCall.proto
+++ b/src/proto/ContractCall.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ContractCallLocal.proto
+++ b/src/proto/ContractCallLocal.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ContractCreate.proto
+++ b/src/proto/ContractCreate.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 import "BasicTypes.proto";

--- a/src/proto/ContractDelete.proto
+++ b/src/proto/ContractDelete.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ContractGetBytecode.proto
+++ b/src/proto/ContractGetBytecode.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ContractGetInfo.proto
+++ b/src/proto/ContractGetInfo.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ContractGetRecords.proto
+++ b/src/proto/ContractGetRecords.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ContractUpdate.proto
+++ b/src/proto/ContractUpdate.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoAddClaim.proto
+++ b/src/proto/CryptoAddClaim.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoAddLiveHash.proto
+++ b/src/proto/CryptoAddLiveHash.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoCreate.proto
+++ b/src/proto/CryptoCreate.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoDelete.proto
+++ b/src/proto/CryptoDelete.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoDeleteClaim.proto
+++ b/src/proto/CryptoDeleteClaim.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoDeleteLiveHash.proto
+++ b/src/proto/CryptoDeleteLiveHash.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoGetAccountBalance.proto
+++ b/src/proto/CryptoGetAccountBalance.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoGetAccountRecords.proto
+++ b/src/proto/CryptoGetAccountRecords.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoGetClaim.proto
+++ b/src/proto/CryptoGetClaim.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoGetInfo.proto
+++ b/src/proto/CryptoGetInfo.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoGetLiveHash.proto
+++ b/src/proto/CryptoGetLiveHash.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoGetStakers.proto
+++ b/src/proto/CryptoGetStakers.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoService.proto
+++ b/src/proto/CryptoService.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.service.proto.java";
 
 import "Query.proto";

--- a/src/proto/CryptoTransfer.proto
+++ b/src/proto/CryptoTransfer.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/CryptoUpdate.proto
+++ b/src/proto/CryptoUpdate.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/Duration.proto
+++ b/src/proto/Duration.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ExchangeRate.proto
+++ b/src/proto/ExchangeRate.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/FileAppend.proto
+++ b/src/proto/FileAppend.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/FileCreate.proto
+++ b/src/proto/FileCreate.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/FileDelete.proto
+++ b/src/proto/FileDelete.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/FileGetContents.proto
+++ b/src/proto/FileGetContents.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/FileGetInfo.proto
+++ b/src/proto/FileGetInfo.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/FileService.proto
+++ b/src/proto/FileService.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.service.proto.java";
 
 import "Query.proto";

--- a/src/proto/FileUpdate.proto
+++ b/src/proto/FileUpdate.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/Freeze.proto
+++ b/src/proto/Freeze.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/FreezeService.proto
+++ b/src/proto/FreezeService.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.service.proto.java";
 
 import "TransactionResponse.proto";

--- a/src/proto/GetByKey.proto
+++ b/src/proto/GetByKey.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/GetBySolidityID.proto
+++ b/src/proto/GetBySolidityID.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/MirrorConsensusService.proto
+++ b/src/proto/MirrorConsensusService.proto
@@ -20,8 +20,6 @@
 
 syntax = "proto3";
 
-package com.hedera.mirror.api.proto;
-
 option java_multiple_files = true; // Required for the reactor-grpc generator to work correctly
 option java_package = "com.hedera.mirror.api.proto";
 
@@ -30,13 +28,13 @@ import "Timestamp.proto";
 import "ConsensusSubmitMessage.proto";
 
 message ConsensusTopicQuery {
-    .proto.TopicID topicID = 1; // A required topic ID to retrieve messages for.
+    TopicID topicID = 1; // A required topic ID to retrieve messages for.
 
     // Include messages which reached consensus on or after this time. Defaults to current time if not set.
-    .proto.Timestamp consensusStartTime = 2;
+    Timestamp consensusStartTime = 2;
 
     // Include messages which reached consensus before this time. If not set it will receive indefinitely.
-    .proto.Timestamp consensusEndTime = 3;
+    Timestamp consensusEndTime = 3;
 
     // The maximum number of messages to receive before stopping. If not set or set to zero it will return messages
     // indefinitely.
@@ -44,7 +42,7 @@ message ConsensusTopicQuery {
 }
 
 message ConsensusTopicResponse {
-    .proto.Timestamp consensusTimestamp = 1; // The time at which the transaction reached consensus
+    Timestamp consensusTimestamp = 1; // The time at which the transaction reached consensus
 
     // The message body originally in the ConsensusSubmitMessageTransactionBody. Message size will be less than 6KiB.
     bytes message = 2;
@@ -55,13 +53,13 @@ message ConsensusTopicResponse {
 
     uint64 runningHashVersion = 5; // Version of the SHA-384 digest used to update the running hash.
 
-    .proto.ConsensusMessageChunkInfo chunkInfo = 6; // Optional information of the current chunk in a fragmented message.
+    ConsensusMessageChunkInfo chunkInfo = 6; // Optional information of the current chunk in a fragmented message.
 }
 
 //
 // The Mirror Service provides the ability to query a stream of Hedera Consensus Service (HCS) messages for an
 // HCS Topic via a specific (possibly open-ended) time range.
 //
-service ConsensusService {
+service MirrorConsensusService {
     rpc subscribeTopic (ConsensusTopicQuery) returns (stream ConsensusTopicResponse);
 }

--- a/src/proto/NetworkGetVersionInfo.proto
+++ b/src/proto/NetworkGetVersionInfo.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/NetworkService.proto
+++ b/src/proto/NetworkService.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.service.proto.java";
 
 import "Query.proto";

--- a/src/proto/Query.proto
+++ b/src/proto/Query.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/QueryHeader.proto
+++ b/src/proto/QueryHeader.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/Response.proto
+++ b/src/proto/Response.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ResponseCode.proto
+++ b/src/proto/ResponseCode.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/ResponseHeader.proto
+++ b/src/proto/ResponseHeader.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/SmartContractService.proto
+++ b/src/proto/SmartContractService.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.service.proto.java";
 
 import "TransactionResponse.proto";

--- a/src/proto/SystemDelete.proto
+++ b/src/proto/SystemDelete.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/SystemUndelete.proto
+++ b/src/proto/SystemUndelete.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/Timestamp.proto
+++ b/src/proto/Timestamp.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/Transaction.proto
+++ b/src/proto/Transaction.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/TransactionBody.proto
+++ b/src/proto/TransactionBody.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/TransactionGetFastRecord.proto
+++ b/src/proto/TransactionGetFastRecord.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/TransactionGetReceipt.proto
+++ b/src/proto/TransactionGetReceipt.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/TransactionGetRecord.proto
+++ b/src/proto/TransactionGetRecord.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/TransactionReceipt.proto
+++ b/src/proto/TransactionReceipt.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/TransactionRecord.proto
+++ b/src/proto/TransactionRecord.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 

--- a/src/proto/TransactionResponse.proto
+++ b/src/proto/TransactionResponse.proto
@@ -1,7 +1,5 @@
 syntax = "proto3";
 
-package proto;
-
 option java_package = "com.hederahashgraph.api.proto.java";
 option java_multiple_files = true;
 


### PR DESCRIPTION
`package` statements removed from protocols, since in strict mode the whole namespace is exported instead of the package, and keeping the packages would have required changes in all js files that import protocols.

Had to rename one `ConsensusService` -> `MirrorConsensusService`, as there were two different entities named `ConsensusService`.

This mostly solves #267, apart from #268. I.e. with this patch, the only thing that remains polluting the global scope is:
```js
> proto
{
  google: {
    protobuf: {
      BoolValue: [Function],
      BytesValue: [Function],
      DoubleValue: [Function],
      FloatValue: [Function],
      Int32Value: [Function],
      Int64Value: [Function],
      StringValue: [Function],
      UInt32Value: [Function],
      UInt64Value: [Function]
    }
  }
}
```
which comes from`google/protobuf/wrappers.proto` (see #268).