### PR TITLE
Drop stablelib/base64 as there is already a decoder impl present here

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.1.3",
     "@improbable-eng/grpc-web": "^0.13.0",
-    "@stablelib/base64": "^1.0.0",
     "@stablelib/hex": "^1.0.0",
     "@stablelib/hmac": "^1.0.0",
     "@stablelib/pbkdf2": "^1.0.0",
@@ -67,6 +66,7 @@
   },
   "devDependencies": {
     "@launchbadge/eslint-config": "^0.13.10",
+    "@stablelib/base64": "^1.0.0",
     "@types/jest": "^26.0.7",
     "@types/node": "^14.0.27",
     "eslint": "^7.5.0",

--- a/src/Transaction.ts
+++ b/src/Transaction.ts
@@ -18,7 +18,7 @@ import { Ed25519PublicKey } from "./crypto/Ed25519PublicKey";
 import { Ed25519PrivateKey } from "./crypto/Ed25519PrivateKey";
 import { TransactionRecord } from "./TransactionRecord";
 import { Status } from "./Status";
-import * as base64 from "@stablelib/base64";
+import * as base64 from "./encoding/base64";
 import UnaryMethodDefinition = grpc.UnaryMethodDefinition;
 import { hash as sha384Hash } from "@stablelib/sha384";
 import { HederaPrecheckStatusError } from "./errors/HederaPrecheckStatusError";

--- a/src/crypto/Ed25519PrivateKey.ts
+++ b/src/crypto/Ed25519PrivateKey.ts
@@ -13,7 +13,6 @@ import { BadKeyError } from "../errors/BadKeyError";
 import { BadPemFileError } from "../errors/BadPemFileError";
 import { EncryptedPrivateKeyInfo } from "./pkcs";
 import { decodeDer } from "./der";
-// import * as base64 from "@stablelib/base64";
 import * as base64 from "../encoding/base64";
 import * as hex from "@stablelib/hex";
 import { Hmac, HashAlgorithm } from "./Hmac";
@@ -287,8 +286,6 @@ export class Ed25519PrivateKey {
 
         const keyEncoded = pem.slice(beginIndex + beginTag.length, endIndex);
 
-        // Base64 library throws a "Base64Coder: incorrect characters for decoding"
-        // const key = base64.decode(keyEncoded);
         const key = base64.decode(keyEncoded);
 
         if (passphrase) {


### PR DESCRIPTION
There is already a slim decoder implementation here and there seems to be no reason for pulling in a custom base64 decoder when a two-liner with `atob`/`Buffer.from` works just as fine.

The point of `@stablelib/base64`, it seems, was to provide a decoder which delays decoding errors until the end so that it can be close to constant time on valid and invalid input of the same length. If that is needed here, this PR should be rejected (and perhaps instead the removed here code which is currently commented out should be fixed).

Refs: 87ed8eb9e72c4507a38280550753aa43bc2acd16

---

One thing that confuses me though: _what_ were those strings that `@stablelib/base64` failed to decode?
Buffer base64 decoder differs in these aspects:
 1. It supports both default ([RFC3548, section 3](https://tools.ietf.org/html/rfc3548#section-3) and url-safe ([RFC3548, section 4](https://tools.ietf.org/html/rfc3548#section-4)) base64 decoding.
 _Note: stablelib also supports both, but under separate functions, `decode` and `decodeURLSafe`._
 2. It skips garbage (in 7-bit plane), e.g. whitespace.

The potential problem is that if the reason why decoding with stablelib decoder failed in 87ed8eb9e72c4507a38280550753aa43bc2acd16, then it will also fail with atob which is used in browser version here.

Both of those could be solved with a trivial regex on `text` here: https://github.com/hashgraph/hedera-sdk-js/blob/cfb607bd49ee937ecea572ec7debf0bae610f6a9/src/encoding/base64.ts#L2-L4
replacing `-` with `+`, `_` with `/`, and whitespace (and/or other chars in 7-bit plane) with an empty string.