### PR TITLE
fix bug token transaction fromBytes error

### DIFF
--- a/src/token/TokenAssociateTransaction.js
+++ b/src/token/TokenAssociateTransaction.js
@@ -73,7 +73,7 @@ export default class TokenAssociateTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const associateToken = /** @type {proto.ITokenAssociateTransactionBody} */ (body.tokenCreation);
+        const associateToken = /** @type {proto.ITokenAssociateTransactionBody} */ (body.tokenAssociate);
 
         return Transaction._fromProtobufTransactions(
             new TokenAssociateTransaction({

--- a/src/token/TokenBurnTransaction.js
+++ b/src/token/TokenBurnTransaction.js
@@ -71,7 +71,7 @@ export default class TokenBurnTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const burnToken = /** @type {proto.ITokenBurnTransactionBody} */ (body.tokenCreation);
+        const burnToken = /** @type {proto.ITokenBurnTransactionBody} */ (body.burnToken);
 
         return Transaction._fromProtobufTransactions(
             new TokenBurnTransaction({

--- a/src/token/TokenDeleteTransaction.js
+++ b/src/token/TokenDeleteTransaction.js
@@ -59,7 +59,7 @@ export default class TokenDeleteTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const deleteToken = /** @type {proto.ITokenDeleteTransactionBody} */ (body.tokenCreation);
+        const deleteToken = /** @type {proto.ITokenDeleteTransactionBody} */ (body.tokenDeletion);
 
         return Transaction._fromProtobufTransactions(
             new TokenDeleteTransaction({

--- a/src/token/TokenFreezeTransaction.js
+++ b/src/token/TokenFreezeTransaction.js
@@ -70,7 +70,7 @@ export default class TokenFreezeTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const freezeToken = /** @type {proto.ITokenFreezeAccountTransactionBody} */ (body.tokenCreation);
+        const freezeToken = /** @type {proto.ITokenFreezeAccountTransactionBody} */ (body.tokenFreeze);
 
         return Transaction._fromProtobufTransactions(
             new TokenFreezeTransaction({

--- a/src/token/TokenGrantKycTransaction.js
+++ b/src/token/TokenGrantKycTransaction.js
@@ -70,7 +70,7 @@ export default class TokenGrantKycTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const grantKycToken = /** @type {proto.ITokenGrantKycTransactionBody} */ (body.tokenCreation);
+        const grantKycToken = /** @type {proto.ITokenGrantKycTransactionBody} */ (body.tokenGrantKyc);
 
         return Transaction._fromProtobufTransactions(
             new TokenGrantKycTransaction({

--- a/src/token/TokenRevokeKycTransaction.js
+++ b/src/token/TokenRevokeKycTransaction.js
@@ -70,7 +70,7 @@ export default class TokenRevokeKycTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const revokeKycToken = /** @type {proto.ITokenRevokeKycTransactionBody} */ (body.tokenCreation);
+        const revokeKycToken = /** @type {proto.ITokenRevokeKycTransactionBody} */ (body.tokenRevokeKyc);
 
         return Transaction._fromProtobufTransactions(
             new TokenRevokeKycTransaction({

--- a/src/token/TokenUnfreezeTransaction.js
+++ b/src/token/TokenUnfreezeTransaction.js
@@ -70,7 +70,7 @@ export default class TokenUnfreezeTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const unfreezeToken = /** @type {proto.ITokenUnfreezeAccountTransactionBody} */ (body.tokenCreation);
+        const unfreezeToken = /** @type {proto.ITokenUnfreezeAccountTransactionBody} */ (body.tokenUnfreeze);
 
         return Transaction._fromProtobufTransactions(
             new TokenUnfreezeTransaction({

--- a/src/token/TokenUpdateTransaction.js
+++ b/src/token/TokenUpdateTransaction.js
@@ -185,7 +185,7 @@ export default class TokenUpdateTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const update = /** @type {proto.ITokenUpdateTransactionBody} */ (body.tokenCreation);
+        const update = /** @type {proto.ITokenUpdateTransactionBody} */ (body.tokenUpdate);
 
         return Transaction._fromProtobufTransactions(
             new TokenUpdateTransaction({

--- a/src/token/TokenWipeTransaction.js
+++ b/src/token/TokenWipeTransaction.js
@@ -82,7 +82,7 @@ export default class TokenWipeTransaction extends Transaction {
         bodies
     ) {
         const body = bodies[0];
-        const wipeToken = /** @type {proto.ITokenWipeAccountTransactionBody} */ (body.tokenCreation);
+        const wipeToken = /** @type {proto.ITokenWipeAccountTransactionBody} */ (body.tokenWipe);
 
         return Transaction._fromProtobufTransactions(
             new TokenWipeTransaction({


### PR DESCRIPTION
I raised issue 
https://github.com/hashgraph/hedera-sdk-js/issues/332

I think it is typo error. Maybe copy&paste.

Because All the transaction body implemented tokenCreate, so there are Transaction.fromBytes() error
Except TokenDissociateTransaction.js (It is well).