### PR TITLE
fix: `TopicMessageQuery`

### DIFF
--- a/src/Timestamp.js
+++ b/src/Timestamp.js
@@ -5,6 +5,8 @@ import Long from "long";
  * @typedef {import("@hashgraph/proto").ITimestamp} proto.ITimestamp
  */
 
+const MAX_NS = Long.fromNumber(999999999);
+
 export default class Timestamp {
     /**
      * @param {Long | number} seconds
@@ -74,6 +76,16 @@ export default class Timestamp {
             this.seconds.toInt() * 1000 +
                 Math.floor(this.nanos.toInt() / 1000000)
         );
+    }
+
+    /**
+     * @param {Long | number} nanos
+     * @returns {Timestamp}
+     */
+    plusNanos(nanos) {
+        const ns = this.nanos.add(nanos);
+
+        return new Timestamp(this.seconds.add(ns.div(MAX_NS)), ns.mod(MAX_NS));
     }
 
     /**

--- a/src/Timestamp.js
+++ b/src/Timestamp.js
@@ -5,7 +5,7 @@ import Long from "long";
  * @typedef {import("@hashgraph/proto").ITimestamp} proto.ITimestamp
  */
 
-const MAX_NS = Long.fromNumber(999999999);
+const MAX_NS = Long.fromNumber(1000000000);
 
 export default class Timestamp {
     /**

--- a/src/topic/TopicMessageQuery.js
+++ b/src/topic/TopicMessageQuery.js
@@ -347,18 +347,11 @@ export default class TopicMessageQuery {
                         this._limit = this._limit.sub(1);
                     }
 
-                    const consensusTimestamp = /** @type {proto.ITimestamp} */ (
-                        message.consensusTimestamp
-                    );
-
-                    const nanos = /** @type {number} */ (
-                        consensusTimestamp.nanos
-                    );
-
-                    this._startTime = Timestamp._fromProtobuf({
-                        seconds: consensusTimestamp.seconds,
-                        nanos: nanos + 1,
-                    });
+                    this._startTime = Timestamp._fromProtobuf(
+                        /** @type {proto.ITimestamp} */ (
+                            message.consensusTimestamp
+                        )
+                    ).plusNanos(1);
 
                     if (
                         message.chunkInfo == null ||

--- a/src/topic/TopicMessageQuery.js
+++ b/src/topic/TopicMessageQuery.js
@@ -404,6 +404,9 @@ export default class TopicMessageQuery {
                     }
                 },
                 (error) => {
+                    const message =
+                        error instanceof Error ? error.message : error.details;
+
                     if (
                         this._attempt < this._maxAttempts &&
                         this._retryHandler(error)
@@ -412,14 +415,14 @@ export default class TopicMessageQuery {
                             250 * 2 ** this._attempt,
                             this._maxBackoff
                         );
-                        console.log(
+                        console.warn(
                             `Error subscribing to topic ${
                                 this._topicId != null
                                     ? this._topicId.toString()
                                     : "UNKNOWN"
                             } during attempt ${
                                 this._attempt
-                            }. Waiting ${delay} ms before next attempt`
+                            }. Waiting ${delay} ms before next attempt: ${message}`
                         );
 
                         this._attempt += 1;

--- a/test/unit/Timestamp.js
+++ b/test/unit/Timestamp.js
@@ -1,0 +1,25 @@
+import { Timestamp } from "../src/exports.js";
+
+describe("Timestamp", function () {
+    it("plusNanos works correctly", async function () {
+        let timestamp = new Timestamp(0, 999999998);
+
+        expect(timestamp.seconds.toInt()).to.be.eql(0);
+        expect(timestamp.nanos.toInt()).to.be.eql(999999998);
+
+        timestamp = timestamp.plusNanos(1);
+
+        expect(timestamp.seconds.toInt()).to.be.eql(0);
+        expect(timestamp.nanos.toInt()).to.be.eql(999999999);
+
+        timestamp = timestamp.plusNanos(1);
+
+        expect(timestamp.seconds.toInt()).to.be.eql(1);
+        expect(timestamp.nanos.toInt()).to.be.eql(0);
+
+        timestamp = timestamp.plusNanos(1);
+
+        expect(timestamp.seconds.toInt()).to.be.eql(1);
+        expect(timestamp.nanos.toInt()).to.be.eql(1);
+    });
+});


### PR DESCRIPTION
Make sure `startTime` is one nanosecond in the future when saving the `consensusTimestamp` of a message.
Add a log statement when retrying `TopicMessageQuery`