### PR TITLE
Examples should construct the client more cleanly

### DIFF
--- a/examples/consensus-pub-sub.js
+++ b/examples/consensus-pub-sub.js
@@ -18,7 +18,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const response = await new TopicCreateTransaction()

--- a/examples/consensus-pub-sub.js
+++ b/examples/consensus-pub-sub.js
@@ -1,5 +1,6 @@
 require("dotenv").config();
 
+
 const {
     Client,
     PrivateKey,

--- a/examples/consensus-pub-sub.js
+++ b/examples/consensus-pub-sub.js
@@ -1,6 +1,5 @@
 require("dotenv").config();
 
-
 const {
     Client,
     PrivateKey,
@@ -14,26 +13,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.")
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.")
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".")
     }
 
     const response = await new TopicCreateTransaction()

--- a/examples/consensus-pub-sub.js
+++ b/examples/consensus-pub-sub.js
@@ -12,26 +12,13 @@ const {
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.")
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.")
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".")
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const response = await new TopicCreateTransaction()

--- a/examples/create-account.js
+++ b/examples/create-account.js
@@ -11,26 +11,13 @@ const {
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/create-account.js
+++ b/examples/create-account.js
@@ -17,7 +17,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/create-account.js
+++ b/examples/create-account.js
@@ -12,26 +12,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/create-topic.js
+++ b/examples/create-topic.js
@@ -11,26 +11,13 @@ const {
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     // create topic

--- a/examples/create-topic.js
+++ b/examples/create-topic.js
@@ -12,26 +12,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     // create topic

--- a/examples/create-topic.js
+++ b/examples/create-topic.js
@@ -17,7 +17,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     // create topic

--- a/examples/delete-account.js
+++ b/examples/delete-account.js
@@ -12,26 +12,13 @@ const {
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/delete-account.js
+++ b/examples/delete-account.js
@@ -18,7 +18,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/delete-account.js
+++ b/examples/delete-account.js
@@ -13,26 +13,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/file-append-chunked.js
+++ b/examples/file-append-chunked.js
@@ -62,26 +62,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     const resp = await new FileCreateTransaction()

--- a/examples/file-append-chunked.js
+++ b/examples/file-append-chunked.js
@@ -67,7 +67,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const resp = await new FileCreateTransaction()

--- a/examples/file-append-chunked.js
+++ b/examples/file-append-chunked.js
@@ -61,26 +61,13 @@ Etiam ut sodales ex. Nulla luctus, magna eu scelerisque sagittis, nibh quam cons
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const resp = await new FileCreateTransaction()

--- a/examples/get-account-balance.js
+++ b/examples/get-account-balance.js
@@ -11,26 +11,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     const balance = await new AccountBalanceQuery()

--- a/examples/get-account-balance.js
+++ b/examples/get-account-balance.js
@@ -16,7 +16,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const balance = await new AccountBalanceQuery()

--- a/examples/get-account-balance.js
+++ b/examples/get-account-balance.js
@@ -10,26 +10,13 @@ const {
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const balance = await new AccountBalanceQuery()

--- a/examples/get-account-balance.mjs
+++ b/examples/get-account-balance.mjs
@@ -18,7 +18,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const balance = await new AccountBalanceQuery()

--- a/examples/get-account-balance.mjs
+++ b/examples/get-account-balance.mjs
@@ -13,26 +13,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     const balance = await new AccountBalanceQuery()

--- a/examples/get-account-balance.mjs
+++ b/examples/get-account-balance.mjs
@@ -12,26 +12,13 @@ import {
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const balance = await new AccountBalanceQuery()

--- a/examples/get-account-info.js
+++ b/examples/get-account-info.js
@@ -11,7 +11,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const info = await new AccountInfoQuery()

--- a/examples/get-account-info.js
+++ b/examples/get-account-info.js
@@ -5,26 +5,13 @@ const { Client, AccountInfoQuery, Hbar, AccountId, PrivateKey } = require("@hash
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const info = await new AccountInfoQuery()

--- a/examples/get-account-info.js
+++ b/examples/get-account-info.js
@@ -6,26 +6,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     const info = await new AccountInfoQuery()

--- a/examples/multi-sig-offline.js
+++ b/examples/multi-sig-offline.js
@@ -17,26 +17,13 @@ let user2Key;
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     user1Key = PrivateKey.generate();

--- a/examples/multi-sig-offline.js
+++ b/examples/multi-sig-offline.js
@@ -23,7 +23,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     user1Key = PrivateKey.generate();

--- a/examples/multi-sig-offline.js
+++ b/examples/multi-sig-offline.js
@@ -18,26 +18,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     user1Key = PrivateKey.generate();

--- a/examples/scheduled-transaction-multi-sig-threshold.js
+++ b/examples/scheduled-transaction-multi-sig-threshold.js
@@ -23,7 +23,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     // generate keys

--- a/examples/scheduled-transaction-multi-sig-threshold.js
+++ b/examples/scheduled-transaction-multi-sig-threshold.js
@@ -17,26 +17,13 @@ async function main() {
     // set up client
     let client;
     
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     // generate keys

--- a/examples/scheduled-transaction-multi-sig-threshold.js
+++ b/examples/scheduled-transaction-multi-sig-threshold.js
@@ -16,25 +16,27 @@ const {
 async function main() {
     // set up client
     let client;
+    
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     // generate keys

--- a/examples/sign-transaction.js
+++ b/examples/sign-transaction.js
@@ -16,26 +16,13 @@ let user2Key;
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     user1Key = PrivateKey.generate();

--- a/examples/sign-transaction.js
+++ b/examples/sign-transaction.js
@@ -17,26 +17,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     user1Key = PrivateKey.generate();

--- a/examples/sign-transaction.js
+++ b/examples/sign-transaction.js
@@ -22,7 +22,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment; variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     user1Key = PrivateKey.generate();

--- a/examples/transfer-tokens.js
+++ b/examples/transfer-tokens.js
@@ -26,7 +26,7 @@ async function main() {
             PrivateKey.fromString(process.env.OPERATOR_KEY)
             );            
     } catch {
-        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.");
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/transfer-tokens.js
+++ b/examples/transfer-tokens.js
@@ -21,26 +21,25 @@ async function main() {
     let client;
 
     if (process.env.HEDERA_NETWORK != null) {
-        switch (process.env.HEDERA_NETWORK) {
-            case "previewnet":
-                client = Client.forPreviewnet();
-                break;
-            default:
-                client = Client.forTestnet();
+        if (process.env.OPERATOR_KEY != null) {
+            if (process.env.OPERATOR_ID != null) {
+                client = Client.forName(process.env.HEDERA_NETWORK);   
+                
+                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
+                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+        
+                client.setOperator(operatorId, operatorKey);
+            }
+            else {
+                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
+            }
         }
-    } else {
-        try {
-            client = await Client.fromConfigFile(process.env.CONFIG_FILE);
-        } catch (err) {
-            client = Client.forTestnet();
+        else {
+            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
         }
     }
-
-    if (process.env.OPERATOR_KEY != null && process.env.OPERATOR_ID != null) {
-        const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-        const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-
-        client.setOperator(operatorId, operatorKey);
+    else {
+        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
     }
 
     const newKey = PrivateKey.generate();

--- a/examples/transfer-tokens.js
+++ b/examples/transfer-tokens.js
@@ -20,26 +20,13 @@ const {
 async function main() {
     let client;
 
-    if (process.env.HEDERA_NETWORK != null) {
-        if (process.env.OPERATOR_KEY != null) {
-            if (process.env.OPERATOR_ID != null) {
-                client = Client.forName(process.env.HEDERA_NETWORK);   
-                
-                const operatorKey = PrivateKey.fromString(process.env.OPERATOR_KEY);
-                const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
-        
-                client.setOperator(operatorId, operatorKey);
-            }
-            else {
-                throw new Error("Environment Variable:\tOPERATOR_ID is required to initialize the client.");
-            }
-        }
-        else {
-            throw new Error("Environment Variable:\tOPERATOR_KEY is required to initialize the client.");
-        }
-    }
-    else {
-        throw new Error("Environment Variable:\tHEDERA_NETWORK is required to initialize the client.\nThis value can be \"mainnet\", \"testnet\", or \"previewnet\".");
+    try {
+        client = Client.forName(process.env.HEDERA_NETWORK).setOperator(
+            AccountId.fromString(process.env.OPERATOR_ID), 
+            PrivateKey.fromString(process.env.OPERATOR_KEY)
+            );            
+    } catch {
+        throw new Error("Environment variables HEDERA_NETWORK, OPERATOR_ID, and OPERATOR_KEY are required.")
     }
 
     const newKey = PrivateKey.generate();


### PR DESCRIPTION
Signed-off-by: andvara-naut <dalton.kaua@launchbadge.com>

**Problem**
Right now the examples construct the client like they do in the integration tests which is way more complex than it should be. Currently it tries to use HEDERA_NETWORK environment variable, and then falls back to CONFIG_FILE, then defaults to testnet if that still fails. For examples we should simply require HEDERA_NETWORK and construct the client using Client.forName()

**Solution**
Use Client.forName() instead of the complicated mess we have right now.
This means we also should require OPERATOR_ID and OPERATOR_KEY environment variables.