### PR TITLE
fix: free queries should not require payment transactions to be signed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+
+ * Free queries should not longer attempt to sign payment transactions
+
 ## v2.0.26
 
 ## Changed

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -247,7 +247,7 @@ export default class Query extends Executable {
                         this._paymentTransactionId
                     ),
                     node,
-                    operator,
+                    this._isPaymentRequired() ? operator : null,
                     /** @type {Hbar} */ (cost)
                 )
             );


### PR DESCRIPTION
Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>

**Description**:
Free queries currently require signing even though the payment transaction is a stub with accounts and transfers being `0`. Since the original code was already checking for `operator == null` to determine if a real payment transaction was being generated I updated the parameter to be `null` whenever `this._isPaymentRequired()` is `false`.

**Related issue(s)**:

Closes: #446 

**Notes for reviewer**:

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
