### PR TITLE
fix: remove `ledgerId` from `*.fromProtobuf()` implementations

### DIFF
--- a/src/BadEntityIdError.js
+++ b/src/BadEntityIdError.js
@@ -1,0 +1,22 @@
+export default class BadEntityIdException extends Error {
+    /**
+     * @param {Long} shard
+     * @param {Long} realm
+     * @param {Long} num
+     * @param {string} presentChecksum
+     * @param {string} expectedChecksum
+     */
+    constructor(shard, realm, num, presentChecksum, expectedChecksum) {
+        super(
+            `Entity ID ${shard.toString()}.${realm.toString()}.${num.toString()}-${presentChecksum} was incorrect.`
+        );
+
+        this.name = "BadEntityIdException";
+
+        this.shard = shard;
+        this.realm = realm;
+        this.num = num;
+        this.presentChecksum = presentChecksum;
+        this.expectedChecksum = expectedChecksum;
+    }
+}

--- a/src/Transfer.js
+++ b/src/Transfer.js
@@ -49,14 +49,12 @@ export default class Transfer {
     /**
      * @internal
      * @param {proto.IAccountAmount} transfer
-     * @param {(string | null)=} ledgerId
      * @returns {Transfer}
      */
-    static _fromProtobuf(transfer, ledgerId) {
+    static _fromProtobuf(transfer) {
         return new Transfer({
             accountId: AccountId._fromProtobuf(
-                /** @type {proto.IAccountID} */ (transfer.accountID),
-                ledgerId
+                /** @type {proto.IAccountID} */ (transfer.accountID)
             ),
             amount: Hbar.fromTinybars(
                 transfer.amount != null ? transfer.amount : 0

--- a/src/account/AccountBalance.js
+++ b/src/account/AccountBalance.js
@@ -59,18 +59,16 @@ export default class AccountBalance {
     /**
      * @internal
      * @param {proto.ICryptoGetAccountBalanceResponse} accountBalance
-     * @param {(string | null)=} ledgerId
      * @returns {AccountBalance}
      */
-    static _fromProtobuf(accountBalance, ledgerId) {
+    static _fromProtobuf(accountBalance) {
         const tokenBalances = new TokenBalanceMap();
         const tokenDecimals = new TokenDecimalMap();
 
         if (accountBalance.tokenBalances != null) {
             for (const balance of accountBalance.tokenBalances) {
                 const tokenId = TokenId._fromProtobuf(
-                    /** @type {proto.ITokenID} */ (balance.tokenId),
-                    ledgerId
+                    /** @type {proto.ITokenID} */ (balance.tokenId)
                 );
 
                 tokenDecimals._set(

--- a/src/account/AccountBalanceQuery.js
+++ b/src/account/AccountBalanceQuery.js
@@ -140,13 +140,13 @@ export default class AccountBalanceQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
 
         if (this._contractId != null) {
-            this._contractId.validate(client);
+            this._contractId.validateChecksum(client);
         }
     }
 
@@ -185,17 +185,16 @@ export default class AccountBalanceQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<AccountBalance>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const cryptogetAccountBalance =
             /** @type {proto.ICryptoGetAccountBalanceResponse} */ (
                 response.cryptogetAccountBalance
             );
         return Promise.resolve(
-            AccountBalance._fromProtobuf(cryptogetAccountBalance, ledgerId)
+            AccountBalance._fromProtobuf(cryptogetAccountBalance)
         );
     }
 

--- a/src/account/AccountCreateTransaction.js
+++ b/src/account/AccountCreateTransaction.js
@@ -309,9 +309,9 @@ export default class AccountCreateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._proxyAccountId != null) {
-            this._proxyAccountId.validate(client);
+            this._proxyAccountId.validateChecksum(client);
         }
     }
 

--- a/src/account/AccountDeleteTransaction.js
+++ b/src/account/AccountDeleteTransaction.js
@@ -155,13 +155,13 @@ export default class AccountDeleteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
 
         if (this._transferAccountId != null) {
-            this._transferAccountId.validate(client);
+            this._transferAccountId.validateChecksum(client);
         }
     }
 

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -42,59 +42,45 @@ export default class AccountId {
     /**
      * @internal
      * @param {proto.IAccountID} id
-     * @param {(string | null)=} ledgerId
      * @returns {AccountId}
      */
-    static _fromProtobuf(id, ledgerId) {
+    static _fromProtobuf(id) {
         const accountId = new AccountId(
             id.shardNum != null ? id.shardNum : 0,
             id.realmNum != null ? id.realmNum : 0,
             id.accountNum != null ? id.accountNum : 0
         );
 
-        if (ledgerId != null) {
-            accountId._setNetwork(ledgerId);
-        }
-
         return accountId;
     }
 
     /**
-     * @internal
-     * @param {Client} client
+     * @returns {string | null}
      */
-    _setNetworkWith(client) {
-        if (client._network._ledgerId != null) {
-            this._setNetwork(client._network._ledgerId);
-        }
+    get checksum() {
+        return this._checksum;
     }
 
     /**
-     * @internal
-     * @param {string} ledgerId
-     */
-    _setNetwork(ledgerId) {
-        this._checksum = entity_id._checksum(
-            ledgerId,
-            `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-        );
-    }
-
-    /**
+     * @deprecated - Use `validateChecksum` instead
      * @param {Client} client
      */
     validate(client) {
-        if (
-            client._network._ledgerId != null &&
-            this._checksum != null &&
-            this._checksum !=
-                entity_id._checksum(
-                    client._network._ledgerId,
-                    `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-                )
-        ) {
-            throw new Error("Entity ID is for a different network than client");
-        }
+        console.warn("Deprecated: Use `validateChecksum` instead");
+        this.validateChecksum(client);
+    }
+
+    /**
+     * @param {Client} client
+     */
+    validateChecksum(client) {
+        entity_id.validateChecksum(
+            this.shard,
+            this.realm,
+            this.num,
+            this._checksum,
+            client
+        );
     }
 
     /**
@@ -136,13 +122,15 @@ export default class AccountId {
      * @returns {string}
      */
     toString() {
-        if (this._checksum == null) {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
-        } else {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}-${
-                this._checksum
-            }`;
-        }
+        return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
+    }
+
+    /**
+     * @param {Client} client
+     * @returns {string}
+     */
+    toStringWithChecksum(client) {
+        return entity_id.toStringWithChecksum(this.toString(), client);
     }
 
     /**

--- a/src/account/AccountInfo.js
+++ b/src/account/AccountInfo.js
@@ -148,22 +148,17 @@ export default class AccountInfo {
     /**
      * @internal
      * @param {proto.IAccountInfo} info
-     * @param {(string | null)=} ledgerId
      * @returns {AccountInfo}
      */
-    static _fromProtobuf(info, ledgerId) {
+    static _fromProtobuf(info) {
         return new AccountInfo({
             accountId: AccountId._fromProtobuf(
-                /** @type {proto.IAccountID} */ (info.accountID),
-                ledgerId
+                /** @type {proto.IAccountID} */ (info.accountID)
             ),
             contractAccountId:
                 info.contractAccountID != null ? info.contractAccountID : null,
             isDeleted: info.deleted != null ? info.deleted : false,
-            key: keyFromProtobuf(
-                /** @type {proto.IKey} */ (info.key),
-                ledgerId
-            ),
+            key: keyFromProtobuf(/** @type {proto.IKey} */ (info.key)),
             balance: Hbar.fromTinybars(info.balance != null ? info.balance : 0),
             sendRecordThreshold: Hbar.fromTinybars(
                 info.generateSendRecordThreshold != null
@@ -201,17 +196,16 @@ export default class AccountInfo {
                         info.proxyAccountID.accountNum
                     )
                 ).toInt() !== 0
-                    ? AccountId._fromProtobuf(info.proxyAccountID, ledgerId)
+                    ? AccountId._fromProtobuf(info.proxyAccountID)
                     : null,
             proxyReceived: Hbar.fromTinybars(
                 info.proxyReceived != null ? info.proxyReceived : 0
             ),
             liveHashes: (info.liveHashes != null ? info.liveHashes : []).map(
-                (hash) => LiveHash._fromProtobuf(hash, ledgerId)
+                (hash) => LiveHash._fromProtobuf(hash)
             ),
             tokenRelationships: TokenRelationshipMap._fromProtobuf(
-                info.tokenRelationships != null ? info.tokenRelationships : [],
-                ledgerId
+                info.tokenRelationships != null ? info.tokenRelationships : []
             ),
             accountMemo: info.memo != null ? info.memo : "",
             ownedNfts: info.ownedNfts ? info.ownedNfts : Long.ZERO,

--- a/src/account/AccountInfoQuery.js
+++ b/src/account/AccountInfoQuery.js
@@ -83,9 +83,9 @@ export default class AccountInfoQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 
@@ -134,19 +134,17 @@ export default class AccountInfoQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<AccountInfo>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const info = /** @type {proto.ICryptoGetInfoResponse} */ (
             response.cryptoGetInfo
         );
 
         return Promise.resolve(
             AccountInfo._fromProtobuf(
-                /** @type {proto.IAccountInfo} */ (info.accountInfo),
-                ledgerId
+                /** @type {proto.IAccountInfo} */ (info.accountInfo)
             )
         );
     }

--- a/src/account/AccountRecordsQuery.js
+++ b/src/account/AccountRecordsQuery.js
@@ -86,9 +86,9 @@ export default class AccountRecordsQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 
@@ -125,11 +125,10 @@ export default class AccountRecordsQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<TransactionRecord[]>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const cryptoGetAccountRecords =
             /** @type {proto.ICryptoGetAccountRecordsResponse} */ (
                 response.cryptoGetAccountRecords
@@ -139,9 +138,7 @@ export default class AccountRecordsQuery extends Query {
         );
 
         return Promise.resolve(
-            records.map((record) =>
-                TransactionRecord._fromProtobuf(record, ledgerId)
-            )
+            records.map((record) => TransactionRecord._fromProtobuf(record))
         );
     }
 

--- a/src/account/AccountStakersQuery.js
+++ b/src/account/AccountStakersQuery.js
@@ -88,9 +88,9 @@ export default class AccountStakersQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/account/AccountUpdateTransaction.js
+++ b/src/account/AccountUpdateTransaction.js
@@ -334,13 +334,13 @@ export default class AccountUpdateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
 
         if (this._proxyAccountId != null) {
-            this._proxyAccountId.validate(client);
+            this._proxyAccountId.validateChecksum(client);
         }
     }
 

--- a/src/account/LiveHash.js
+++ b/src/account/LiveHash.js
@@ -44,16 +44,14 @@ export default class LiveHash {
     /**
      * @internal
      * @param {proto.ILiveHash} liveHash
-     * @param {(string | null)=} ledgerId
      * @returns {LiveHash}
      */
-    static _fromProtobuf(liveHash, ledgerId) {
+    static _fromProtobuf(liveHash) {
         const liveHash_ = /** @type {proto.ILiveHash} */ (liveHash);
 
         return new LiveHash({
             accountId: AccountId._fromProtobuf(
-                /** @type {proto.IAccountID} */ (liveHash_.accountId),
-                ledgerId
+                /** @type {proto.IAccountID} */ (liveHash_.accountId)
             ),
             hash: liveHash_.hash != null ? liveHash_.hash : new Uint8Array(),
             keys:

--- a/src/account/LiveHashAddTransaction.js
+++ b/src/account/LiveHashAddTransaction.js
@@ -207,9 +207,9 @@ export default class LiveHashAddTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/account/LiveHashDeleteTransaction.js
+++ b/src/account/LiveHashDeleteTransaction.js
@@ -133,9 +133,9 @@ export default class LiveHashDeleteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/account/LiveHashQuery.js
+++ b/src/account/LiveHashQuery.js
@@ -114,9 +114,9 @@ export default class LiveHashQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/account/ProxyStaker.js
+++ b/src/account/ProxyStaker.js
@@ -46,14 +46,12 @@ export default class ProxyStaker {
     /**
      * @internal
      * @param {proto.IProxyStaker} transfer
-     * @param {(string | null)=} ledgerId
      * @returns {ProxyStaker}
      */
-    static _fromProtobuf(transfer, ledgerId) {
+    static _fromProtobuf(transfer) {
         return new ProxyStaker({
             accountId: AccountId._fromProtobuf(
-                /** @type {proto.IAccountID} */ (transfer.accountID),
-                ledgerId
+                /** @type {proto.IAccountID} */ (transfer.accountID)
             ),
             amount: Hbar.fromTinybars(
                 transfer.amount != null ? transfer.amount : 0

--- a/src/account/TokenNftTransferMap.js
+++ b/src/account/TokenNftTransferMap.js
@@ -46,28 +46,24 @@ export default class TokenNftTransferMap extends ObjectMap {
 
     /**
      * @param {proto.ITokenTransferList[]} transfers
-     * @param {(string | null)=} ledgerId
      * @returns {TokenNftTransferMap}
      */
-    static _fromProtobuf(transfers, ledgerId) {
+    static _fromProtobuf(transfers) {
         const tokenTransfersMap = new TokenNftTransferMap();
 
         for (const transfer of transfers) {
             const token = TokenId._fromProtobuf(
-                /** @type {proto.ITokenID} */ (transfer.token),
-                ledgerId
+                /** @type {proto.ITokenID} */ (transfer.token)
             );
 
             for (const aa of transfer.nftTransfers != null
                 ? transfer.nftTransfers
                 : []) {
                 const sender = AccountId._fromProtobuf(
-                    /** @type {proto.IAccountID} */ (aa.senderAccountID),
-                    ledgerId
+                    /** @type {proto.IAccountID} */ (aa.senderAccountID)
                 );
                 const recipient = AccountId._fromProtobuf(
-                    /** @type {proto.IAccountID} */ (aa.receiverAccountID),
-                    ledgerId
+                    /** @type {proto.IAccountID} */ (aa.receiverAccountID)
                 );
 
                 tokenTransfersMap.__set(token, {

--- a/src/account/TokenRelationship.js
+++ b/src/account/TokenRelationship.js
@@ -62,13 +62,11 @@ export default class TokenRelationship {
 
     /**
      * @param {proto.ITokenRelationship} relationship
-     * @param {(string | null)=} ledgerId
      * @returns {TokenRelationship}
      */
-    static _fromProtobuf(relationship, ledgerId) {
+    static _fromProtobuf(relationship) {
         const tokenId = TokenId._fromProtobuf(
-            /** @type {proto.ITokenID} */ (relationship.tokenId),
-            ledgerId
+            /** @type {proto.ITokenID} */ (relationship.tokenId)
         );
         const isKycGranted =
             relationship.kycStatus == null || relationship.kycStatus === 0

--- a/src/account/TokenRelationshipMap.js
+++ b/src/account/TokenRelationshipMap.js
@@ -22,21 +22,19 @@ export default class TokenRelationshipMap extends ObjectMap {
 
     /**
      * @param {proto.ITokenRelationship[]} relationships
-     * @param {(string | null)=} ledgerId
      * @returns {TokenRelationshipMap}
      */
-    static _fromProtobuf(relationships, ledgerId) {
+    static _fromProtobuf(relationships) {
         const tokenRelationships = new TokenRelationshipMap();
 
         for (const relationship of relationships) {
             const tokenId = TokenId._fromProtobuf(
-                /** @type {proto.ITokenID} */ (relationship.tokenId),
-                ledgerId
+                /** @type {proto.ITokenID} */ (relationship.tokenId)
             );
 
             tokenRelationships._set(
                 tokenId,
-                TokenRelationship._fromProtobuf(relationship, ledgerId)
+                TokenRelationship._fromProtobuf(relationship)
             );
         }
 

--- a/src/account/TokenTransferMap.js
+++ b/src/account/TokenTransferMap.js
@@ -40,24 +40,21 @@ export default class TokenTransferMap extends ObjectMap {
 
     /**
      * @param {proto.ITokenTransferList[]} transfers
-     * @param {(string | null)=} ledgerId
      * @returns {TokenTransferMap}
      */
-    static _fromProtobuf(transfers, ledgerId) {
+    static _fromProtobuf(transfers) {
         const tokenTransfersMap = new TokenTransferMap();
 
         for (const transfer of transfers) {
             const token = TokenId._fromProtobuf(
-                /** @type {proto.ITokenID} */ (transfer.token),
-                ledgerId
+                /** @type {proto.ITokenID} */ (transfer.token)
             );
 
             for (const aa of transfer.transfers != null
                 ? transfer.transfers
                 : []) {
                 const account = AccountId._fromProtobuf(
-                    /** @type {proto.IAccountID} */ (aa.accountID),
-                    ledgerId
+                    /** @type {proto.IAccountID} */ (aa.accountID)
                 );
 
                 tokenTransfersMap.__set(

--- a/src/account/TransferTransaction.js
+++ b/src/account/TransferTransaction.js
@@ -247,23 +247,23 @@ export default class TransferTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const [a, _] of this._hbarTransfers) {
             if (a != null) {
-                a.validate(client);
+                a.validateChecksum(client);
             }
         }
 
         for (const [tokenId, transfers] of this._tokenTransfers) {
             if (tokenId != null) {
-                tokenId.validate(client);
+                tokenId.validateChecksum(client);
             }
 
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             for (const [a, _] of transfers) {
                 if (a != null) {
-                    a.validate(client);
+                    a.validateChecksum(client);
                 }
             }
         }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -93,6 +93,8 @@ export default class Client {
         }
 
         this._signOnDemand = false;
+
+        this._autoValidateChecksums = false;
     }
 
     /**
@@ -167,7 +169,7 @@ export default class Client {
                 ? accountId
                 : AccountId.fromString(accountId);
 
-        accountId_.validate(this);
+        accountId_.validateChecksum(this);
 
         this._operator = {
             transactionSigner,
@@ -181,6 +183,22 @@ export default class Client {
         };
 
         return this;
+    }
+
+    /**
+     * @param {boolean} value
+     * @returns {this}
+     */
+    setAutoValidateChecksums(value) {
+        this._autoValidateChecksums = value;
+        return this;
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    isAutoValidateChecksumsEnabled() {
+        return this._autoValidateChecksums;
     }
 
     /**

--- a/src/contract/ContractByteCodeQuery.js
+++ b/src/contract/ContractByteCodeQuery.js
@@ -81,9 +81,9 @@ export default class ContractByteCodeQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._contractId != null) {
-            this._contractId.validate(client);
+            this._contractId.validateChecksum(client);
         }
     }
 

--- a/src/contract/ContractCallQuery.js
+++ b/src/contract/ContractCallQuery.js
@@ -190,9 +190,9 @@ export default class ContractCallQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._contractId != null) {
-            this._contractId.validate(client);
+            this._contractId.validateChecksum(client);
         }
     }
 

--- a/src/contract/ContractCreateTransaction.js
+++ b/src/contract/ContractCreateTransaction.js
@@ -358,13 +358,13 @@ export default class ContractCreateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._bytecodeFileId != null) {
-            this._bytecodeFileId.validate(client);
+            this._bytecodeFileId.validateChecksum(client);
         }
 
         if (this._proxyAccountId != null) {
-            this._proxyAccountId.validate(client);
+            this._proxyAccountId.validateChecksum(client);
         }
     }
 

--- a/src/contract/ContractDeleteTransaction.js
+++ b/src/contract/ContractDeleteTransaction.js
@@ -192,17 +192,17 @@ export default class ContractDeleteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._contractId != null) {
-            this._contractId.validate(client);
+            this._contractId.validateChecksum(client);
         }
 
         if (this._transferAccountId != null) {
-            this._transferAccountId.validate(client);
+            this._transferAccountId.validateChecksum(client);
         }
 
         if (this._transferContractId != null) {
-            this._transferContractId.validate(client);
+            this._transferContractId.validateChecksum(client);
         }
     }
 

--- a/src/contract/ContractExecuteTransaction.js
+++ b/src/contract/ContractExecuteTransaction.js
@@ -229,9 +229,9 @@ export default class ContractExecuteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._contractId != null) {
-            this._contractId.validate(client);
+            this._contractId.validateChecksum(client);
         }
     }
 

--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -45,58 +45,45 @@ export default class ContractId extends Key {
     /**
      * @internal
      * @param {proto.IContractID} id
-     * @param {(string | null)=} ledgerId
      * @returns {ContractId}
      */
-    static _fromProtobuf(id, ledgerId) {
+    static _fromProtobuf(id) {
         const contractId = new ContractId(
             id.shardNum != null ? id.shardNum : 0,
             id.realmNum != null ? id.realmNum : 0,
             id.contractNum != null ? id.contractNum : 0
         );
 
-        if (ledgerId != null) {
-            contractId._setNetwork(ledgerId);
-        }
-
         return contractId;
     }
 
     /**
-     * @internal
-     * @param {Client} client
+     * @returns {string | null}
      */
-    _setNetworkWith(client) {
-        if (client._network._ledgerId != null) {
-            this._setNetwork(client._network._ledgerId);
-        }
+    get checksum() {
+        return this._checksum;
     }
 
     /**
-     * @internal
-     * @param {string} ledgerId
-     */
-    _setNetwork(ledgerId) {
-        this._checksum = entity_id._checksum(
-            ledgerId,
-            `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-        );
-    }
-
-    /**
+     * @deprecated - Use `validateChecksum` instead
      * @param {Client} client
      */
     validate(client) {
-        if (
-            client._network._ledgerId != null &&
-            this._checksum !=
-                entity_id._checksum(
-                    client._network._ledgerId,
-                    `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-                )
-        ) {
-            throw new Error("Entity ID is for a different network than client");
-        }
+        console.warn("Deprecated: Use `validateChecksum` instead");
+        this.validateChecksum(client);
+    }
+
+    /**
+     * @param {Client} client
+     */
+    validateChecksum(client) {
+        entity_id.validateChecksum(
+            this.shard,
+            this.realm,
+            this.num,
+            this._checksum,
+            client
+        );
     }
 
     /**
@@ -129,17 +116,18 @@ export default class ContractId extends Key {
     }
 
     /**
-     * @override
      * @returns {string}
      */
     toString() {
-        if (this._checksum == null) {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
-        } else {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}-${
-                this._checksum
-            }`;
-        }
+        return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
+    }
+
+    /**
+     * @param {Client} client
+     * @returns {string}
+     */
+    toStringWithChecksum(client) {
+        return entity_id.toStringWithChecksum(this.toString(), client);
     }
 
     /**

--- a/src/contract/ContractInfo.js
+++ b/src/contract/ContractInfo.js
@@ -125,29 +125,24 @@ export default class ContractInfo {
     /**
      * @internal
      * @param {proto.IContractInfo} info
-     * @param {(string | null)=} ledgerId
      * @returns {ContractInfo}
      */
-    static _fromProtobuf(info, ledgerId) {
+    static _fromProtobuf(info) {
         const autoRenewPeriod = /** @type {Long | number} */ (
             /** @type {proto.IDuration} */ (info.autoRenewPeriod).seconds
         );
 
         return new ContractInfo({
             contractId: ContractId._fromProtobuf(
-                /** @type {proto.IContractID} */ (info.contractID),
-                ledgerId
+                /** @type {proto.IContractID} */ (info.contractID)
             ),
             accountId: AccountId._fromProtobuf(
-                /** @type {proto.IAccountID} */ (info.accountID),
-                ledgerId
+                /** @type {proto.IAccountID} */ (info.accountID)
             ),
             contractAccountId:
                 info.contractAccountID != null ? info.contractAccountID : "",
             adminKey:
-                info.adminKey != null
-                    ? keyFromProtobuf(info.adminKey, ledgerId)
-                    : null,
+                info.adminKey != null ? keyFromProtobuf(info.adminKey) : null,
             expirationTime: Timestamp._fromProtobuf(
                 /** @type {proto.ITimestamp} */ (info.expirationTime)
             ),
@@ -162,8 +157,7 @@ export default class ContractInfo {
             balance: Hbar.fromTinybars(info.balance != null ? info.balance : 0),
             isDeleted: /** @type {boolean} */ (info.deleted),
             tokenRelationships: TokenRelationshipMap._fromProtobuf(
-                info.tokenRelationships != null ? info.tokenRelationships : [],
-                ledgerId
+                info.tokenRelationships != null ? info.tokenRelationships : []
             ),
         });
     }

--- a/src/contract/ContractInfoQuery.js
+++ b/src/contract/ContractInfoQuery.js
@@ -84,9 +84,9 @@ export default class ContractInfoQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._contractId != null) {
-            this._contractId.validate(client);
+            this._contractId.validateChecksum(client);
         }
     }
 
@@ -135,19 +135,17 @@ export default class ContractInfoQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<ContractInfo>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const info = /** @type {proto.IContractGetInfoResponse} */ (
             response.contractGetInfo
         );
 
         return Promise.resolve(
             ContractInfo._fromProtobuf(
-                /** @type {proto.IContractInfo} */ (info.contractInfo),
-                ledgerId
+                /** @type {proto.IContractInfo} */ (info.contractInfo)
             )
         );
     }

--- a/src/contract/ContractUpdateTranscation.js
+++ b/src/contract/ContractUpdateTranscation.js
@@ -345,17 +345,17 @@ export default class ContractUpdateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._contractId != null) {
-            this._contractId.validate(client);
+            this._contractId.validateChecksum(client);
         }
 
         if (this._bytecodeFileId != null) {
-            this._bytecodeFileId.validate(client);
+            this._bytecodeFileId.validateChecksum(client);
         }
 
         if (this._proxyAccountId != null) {
-            this._proxyAccountId.validate(client);
+            this._proxyAccountId.validateChecksum(client);
         }
     }
 

--- a/src/cryptography/protobuf.js
+++ b/src/cryptography/protobuf.js
@@ -71,12 +71,11 @@ export function keyListToProtobuf(list) {
 
 /**
  * @param {proto.IKey} key
- * @param {(string | null)=} ledgerId
  * @returns {KeyList | PublicKey | ContractId}
  */
-export function keyFromProtobuf(key, ledgerId) {
+export function keyFromProtobuf(key) {
     if (key.contractID != null) {
-        return ContractId._fromProtobuf(key.contractID, ledgerId);
+        return ContractId._fromProtobuf(key.contractID);
     }
 
     if (key.ed25519 != null && key.ed25519.byteLength > 0) {

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -377,9 +377,9 @@ export default class FileAppendTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._fileId != null) {
-            this._fileId.validate(client);
+            this._fileId.validateChecksum(client);
         }
     }
 

--- a/src/file/FileContentsQuery.js
+++ b/src/file/FileContentsQuery.js
@@ -60,9 +60,9 @@ export default class FileContentsQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._fileId != null) {
-            this._fileId.validate(client);
+            this._fileId.validateChecksum(client);
         }
     }
 

--- a/src/file/FileDeleteTransaction.js
+++ b/src/file/FileDeleteTransaction.js
@@ -112,9 +112,9 @@ export default class FileDeleteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._fileId != null) {
-            this._fileId.validate(client);
+            this._fileId.validateChecksum(client);
         }
     }
 

--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -42,59 +42,45 @@ export default class FileId {
     /**
      * @internal
      * @param {proto.IFileID} id
-     * @param {(string | null)=} ledgerId
      * @returns {FileId}
      */
-    static _fromProtobuf(id, ledgerId) {
+    static _fromProtobuf(id) {
         const fileId = new FileId(
             id.shardNum != null ? id.shardNum : 0,
             id.realmNum != null ? id.realmNum : 0,
             id.fileNum != null ? id.fileNum : 0
         );
 
-        if (ledgerId != null) {
-            fileId._setNetwork(ledgerId);
-        }
-
         return fileId;
     }
 
     /**
-     * @internal
-     * @param {Client} client
+     * @returns {string | null}
      */
-    _setNetworkWith(client) {
-        if (client._network._ledgerId != null) {
-            this._setNetwork(client._network._ledgerId);
-        }
+    get checksum() {
+        return this._checksum;
     }
 
     /**
-     * @internal
-     * @param {string} ledgerId
-     */
-    _setNetwork(ledgerId) {
-        this._checksum = entity_id._checksum(
-            ledgerId,
-            `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-        );
-    }
-
-    /**
+     * @deprecated - Use `validateChecksum` instead
      * @param {Client} client
      */
     validate(client) {
-        if (
-            client._network._ledgerId != null &&
-            this._checksum != null &&
-            this._checksum !=
-                entity_id._checksum(
-                    client._network._ledgerId,
-                    `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-                )
-        ) {
-            throw new Error("Entity ID is for a different network than client");
-        }
+        console.warn("Deprecated: Use `validateChecksum` instead");
+        this.validateChecksum(client);
+    }
+
+    /**
+     * @param {Client} client
+     */
+    validateChecksum(client) {
+        entity_id.validateChecksum(
+            this.shard,
+            this.realm,
+            this.num,
+            this._checksum,
+            client
+        );
     }
 
     /**
@@ -121,13 +107,15 @@ export default class FileId {
      * @returns {string}
      */
     toString() {
-        if (this._checksum == null) {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
-        } else {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}-${
-                this._checksum
-            }`;
-        }
+        return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
+    }
+
+    /**
+     * @param {Client} client
+     * @returns {string}
+     */
+    toStringWithChecksum(client) {
+        return entity_id.toStringWithChecksum(this.toString(), client);
     }
 
     /**

--- a/src/file/FileInfo.js
+++ b/src/file/FileInfo.js
@@ -67,16 +67,14 @@ export default class FileInfo {
     /**
      * @internal
      * @param {proto.IFileInfo} info
-     * @param {(string | null)=} ledgerId
      * @returns {FileInfo}
      */
-    static _fromProtobuf(info, ledgerId) {
+    static _fromProtobuf(info) {
         const size = /** @type {Long | number} */ (info.size);
 
         return new FileInfo({
             fileId: FileId._fromProtobuf(
-                /** @type {proto.IFileID} */ (info.fileID),
-                ledgerId
+                /** @type {proto.IFileID} */ (info.fileID)
             ),
             size: size instanceof Long ? size : Long.fromValue(size),
             expirationTime: Timestamp._fromProtobuf(

--- a/src/file/FileInfoQuery.js
+++ b/src/file/FileInfoQuery.js
@@ -97,9 +97,9 @@ export default class FileInfoQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._fileId != null) {
-            this._fileId.validate(client);
+            this._fileId.validateChecksum(client);
         }
     }
 
@@ -133,19 +133,17 @@ export default class FileInfoQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<FileInfo>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const info = /** @type {proto.IFileGetInfoResponse} */ (
             response.fileGetInfo
         );
 
         return Promise.resolve(
             FileInfo._fromProtobuf(
-                /** @type {proto.IFileInfo} */ (info.fileInfo),
-                ledgerId
+                /** @type {proto.IFileInfo} */ (info.fileInfo)
             )
         );
     }

--- a/src/file/FileUpdateTransaction.js
+++ b/src/file/FileUpdateTransaction.js
@@ -304,9 +304,9 @@ export default class FileUpdateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._fileId != null) {
-            this._fileId.validate(client);
+            this._fileId.validateChecksum(client);
         }
     }
 

--- a/src/query/CostQuery.js
+++ b/src/query/CostQuery.js
@@ -110,12 +110,11 @@ export default class CostQuery extends Executable {
      * @internal
      * @param {proto.IQuery} request
      * @param {proto.IResponse} response
-     * @param {string | null} ledgerId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response, ledgerId) {
-        return this._query._mapStatusError(request, response, ledgerId);
+    _mapStatusError(request, response) {
+        return this._query._mapStatusError(request, response);
     }
 
     /**

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -176,7 +176,7 @@ export default class Query extends Executable {
      * @param {Client} client
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         // Do nothing
     }
 
@@ -190,7 +190,9 @@ export default class Query extends Executable {
             return;
         }
 
-        this._validateIdNetworks(client);
+        if (client.isAutoValidateChecksumsEnabled()) {
+            this._validateChecksums(client);
+        }
 
         if (this._nodeIds.length == 0) {
             this._nodeIds = client._network.getNodeAccountIdsForExecute();
@@ -356,11 +358,10 @@ export default class Query extends Executable {
      * @internal
      * @param {proto.IQuery} request
      * @param {proto.IResponse} response
-     * @param {string | null} ledgerId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response, ledgerId) {
+    _mapStatusError(request, response) {
         const { nodeTransactionPrecheckCode } =
             this._mapResponseHeader(response);
 

--- a/src/schedule/ScheduleCreateTransaction.js
+++ b/src/schedule/ScheduleCreateTransaction.js
@@ -219,9 +219,9 @@ export default class ScheduleCreateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._payerAccountId != null) {
-            this._payerAccountId.validate(client);
+            this._payerAccountId.validateChecksum(client);
         }
     }
 

--- a/src/schedule/ScheduleDeleteTransaction.js
+++ b/src/schedule/ScheduleDeleteTransaction.js
@@ -111,9 +111,9 @@ export default class ScheduleDeleteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._scheduleId != null) {
-            this._scheduleId.validate(client);
+            this._scheduleId.validateChecksum(client);
         }
     }
 

--- a/src/schedule/ScheduleId.js
+++ b/src/schedule/ScheduleId.js
@@ -44,59 +44,45 @@ export default class ScheduleId {
     /**
      * @internal
      * @param {proto.IScheduleID} id
-     * @param {(string | null)=} ledgerId
      * @returns {ScheduleId}
      */
-    static _fromProtobuf(id, ledgerId) {
+    static _fromProtobuf(id) {
         const scheduleId = new ScheduleId(
             id.shardNum != null ? id.shardNum : 0,
             id.realmNum != null ? id.realmNum : 0,
             id.scheduleNum != null ? id.scheduleNum : 0
         );
 
-        if (ledgerId != null) {
-            scheduleId._setNetwork(ledgerId);
-        }
-
         return scheduleId;
     }
 
     /**
-     * @internal
-     * @param {Client} client
+     * @returns {string | null}
      */
-    _setNetworkWith(client) {
-        if (client._network._ledgerId != null) {
-            this._setNetwork(client._network._ledgerId);
-        }
+    get checksum() {
+        return this._checksum;
     }
 
     /**
-     * @internal
-     * @param {string} ledgerId
-     */
-    _setNetwork(ledgerId) {
-        this._checksum = entity_id._checksum(
-            ledgerId,
-            `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-        );
-    }
-
-    /**
+     * @deprecated - Use `validateChecksum` instead
      * @param {Client} client
      */
     validate(client) {
-        if (
-            client._network._ledgerId != null &&
-            this._checksum != null &&
-            this._checksum !=
-                entity_id._checksum(
-                    client._network._ledgerId,
-                    `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-                )
-        ) {
-            throw new Error("Entity ID is for a different network than client");
-        }
+        console.warn("Deprecated: Use `validateChecksum` instead");
+        this.validateChecksum(client);
+    }
+
+    /**
+     * @param {Client} client
+     */
+    validateChecksum(client) {
+        entity_id.validateChecksum(
+            this.shard,
+            this.realm,
+            this.num,
+            this._checksum,
+            client
+        );
     }
 
     /**
@@ -131,13 +117,15 @@ export default class ScheduleId {
      * @returns {string}
      */
     toString() {
-        if (this._checksum == null) {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
-        } else {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}-${
-                this._checksum
-            }`;
-        }
+        return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
+    }
+
+    /**
+     * @param {Client} client
+     * @returns {string}
+     */
+    toStringWithChecksum(client) {
+        return entity_id.toStringWithChecksum(this.toString(), client);
     }
 
     /**

--- a/src/schedule/ScheduleInfo.js
+++ b/src/schedule/ScheduleInfo.js
@@ -125,29 +125,25 @@ export default class ScheduleInfo {
     /**
      * @internal
      * @param {proto.IScheduleInfo} info
-     * @param {(string | null)=} ledgerId
      * @returns {ScheduleInfo}
      */
-    static _fromProtobuf(info, ledgerId) {
+    static _fromProtobuf(info) {
         return new ScheduleInfo({
             scheduleId: ScheduleId._fromProtobuf(
-                /** @type {proto.IScheduleID} */ (info.scheduleID),
-                ledgerId
+                /** @type {proto.IScheduleID} */ (info.scheduleID)
             ),
             creatorAccountID:
                 info.creatorAccountID != null
                     ? AccountId._fromProtobuf(
                           /** @type {proto.IAccountID} */ (
                               info.creatorAccountID
-                          ),
-                          ledgerId
+                          )
                       )
                     : null,
             payerAccountID:
                 info.payerAccountID != null
                     ? AccountId._fromProtobuf(
-                          /** @type {proto.IAccountID} */ (info.payerAccountID),
-                          ledgerId
+                          /** @type {proto.IAccountID} */ (info.payerAccountID)
                       )
                     : null,
             schedulableTransactionBody:
@@ -155,9 +151,7 @@ export default class ScheduleInfo {
                     ? info.scheduledTransactionBody
                     : null,
             adminKey:
-                info.adminKey != null
-                    ? keyFromProtobuf(info.adminKey, ledgerId)
-                    : null,
+                info.adminKey != null ? keyFromProtobuf(info.adminKey) : null,
             signers:
                 info.signers != null ? keyListFromProtobuf(info.signers) : null,
             scheduleMemo: info.memo != null ? info.memo : null,
@@ -181,10 +175,7 @@ export default class ScheduleInfo {
                     : null,
             scheduledTransactionId:
                 info.scheduledTransactionID != null
-                    ? TransactionId._fromProtobuf(
-                          info.scheduledTransactionID,
-                          ledgerId
-                      )
+                    ? TransactionId._fromProtobuf(info.scheduledTransactionID)
                     : null,
         });
     }

--- a/src/schedule/ScheduleInfoQuery.js
+++ b/src/schedule/ScheduleInfoQuery.js
@@ -99,9 +99,9 @@ export default class ScheduleInfoQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._scheduleId != null) {
-            this._scheduleId.validate(client);
+            this._scheduleId.validateChecksum(client);
         }
     }
 
@@ -135,19 +135,17 @@ export default class ScheduleInfoQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<ScheduleInfo>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const info = /** @type {proto.IScheduleGetInfoResponse} */ (
             response.scheduleGetInfo
         );
 
         return Promise.resolve(
             ScheduleInfo._fromProtobuf(
-                /** @type {proto.IScheduleInfo} */ (info.scheduleInfo),
-                ledgerId
+                /** @type {proto.IScheduleInfo} */ (info.scheduleInfo)
             )
         );
     }

--- a/src/schedule/ScheduleSignTransaction.js
+++ b/src/schedule/ScheduleSignTransaction.js
@@ -125,9 +125,9 @@ export default class ScheduleSignTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._scheduleId != null) {
-            this._scheduleId.validate(client);
+            this._scheduleId.validateChecksum(client);
         }
     }
 

--- a/src/token/NftId.js
+++ b/src/token/NftId.js
@@ -42,15 +42,11 @@ export default class NftId {
     /**
      * @internal
      * @param {proto.INftID} id
-     * @param {(string | null)=} ledgerId
      * @returns {NftId}
      */
-    static _fromProtobuf(id, ledgerId) {
+    static _fromProtobuf(id) {
         return new NftId(
-            TokenId._fromProtobuf(
-                /** @type {proto.ITokenID} */ (id.tokenID),
-                ledgerId
-            ),
+            TokenId._fromProtobuf(/** @type {proto.ITokenID} */ (id.tokenID)),
             id.serialNumber != null ? id.serialNumber : Long.ZERO
         );
     }

--- a/src/token/TokenAssociateTransaction.js
+++ b/src/token/TokenAssociateTransaction.js
@@ -146,14 +146,14 @@ export default class TokenAssociateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
 
         for (const tokenId of this._tokenIds != null ? this._tokenIds : []) {
             if (tokenId != null) {
-                tokenId.validate(client);
+                tokenId.validateChecksum(client);
             }
         }
     }

--- a/src/token/TokenBurnTransaction.js
+++ b/src/token/TokenBurnTransaction.js
@@ -149,9 +149,9 @@ export default class TokenBurnTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenCreateTransaction.js
+++ b/src/token/TokenCreateTransaction.js
@@ -754,13 +754,13 @@ export default class TokenCreateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._treasuryAccountId != null) {
-            this._treasuryAccountId.validate(client);
+            this._treasuryAccountId.validateChecksum(client);
         }
 
         if (this._autoRenewAccountId != null) {
-            this._autoRenewAccountId.validate(client);
+            this._autoRenewAccountId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenDeleteTransaction.js
+++ b/src/token/TokenDeleteTransaction.js
@@ -103,9 +103,9 @@ export default class TokenDeleteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenDissociateTransaction.js
+++ b/src/token/TokenDissociateTransaction.js
@@ -146,14 +146,14 @@ export default class TokenDissociateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
 
         for (const tokenId of this._tokenIds != null ? this._tokenIds : []) {
             if (tokenId != null) {
-                tokenId.validate(client);
+                tokenId.validateChecksum(client);
             }
         }
     }

--- a/src/token/TokenFreezeTransaction.js
+++ b/src/token/TokenFreezeTransaction.js
@@ -140,13 +140,13 @@ export default class TokenFreezeTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
 
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenGrantKycTransaction.js
+++ b/src/token/TokenGrantKycTransaction.js
@@ -140,13 +140,13 @@ export default class TokenGrantKycTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
 
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenInfo.js
+++ b/src/token/TokenInfo.js
@@ -198,10 +198,9 @@ export default class TokenInfo {
     /**
      * @internal
      * @param {proto.ITokenInfo} info
-     * @param {(string | null)=} ledgerId
      * @returns {TokenInfo}
      */
-    static _fromProtobuf(info, ledgerId) {
+    static _fromProtobuf(info) {
         const defaultFreezeStatus = /** @type {proto.TokenFreezeStatus} */ (
             info.defaultFreezeStatus
         );
@@ -211,13 +210,12 @@ export default class TokenInfo {
 
         const autoRenewAccountId =
             info.autoRenewAccount != null
-                ? AccountId._fromProtobuf(info.autoRenewAccount, ledgerId)
+                ? AccountId._fromProtobuf(info.autoRenewAccount)
                 : new AccountId(0);
 
         return new TokenInfo({
             tokenId: TokenId._fromProtobuf(
-                /** @type {proto.ITokenID} */ (info.tokenId),
-                ledgerId
+                /** @type {proto.ITokenID} */ (info.tokenId)
             ),
             name: /** @type {string} */ (info.name),
             symbol: /** @type {string} */ (info.symbol),
@@ -226,33 +224,21 @@ export default class TokenInfo {
             treasuryAccountId:
                 info.treasury != null
                     ? AccountId._fromProtobuf(
-                          /** @type {proto.IAccountID} */ (info.treasury),
-                          ledgerId
+                          /** @type {proto.IAccountID} */ (info.treasury)
                       )
                     : null,
             adminKey:
-                info.adminKey != null
-                    ? keyFromProtobuf(info.adminKey, ledgerId)
-                    : null,
-            kycKey:
-                info.kycKey != null
-                    ? keyFromProtobuf(info.kycKey, ledgerId)
-                    : null,
+                info.adminKey != null ? keyFromProtobuf(info.adminKey) : null,
+            kycKey: info.kycKey != null ? keyFromProtobuf(info.kycKey) : null,
             freezeKey:
-                info.freezeKey != null
-                    ? keyFromProtobuf(info.freezeKey, ledgerId)
-                    : null,
+                info.freezeKey != null ? keyFromProtobuf(info.freezeKey) : null,
             wipeKey:
-                info.wipeKey != null
-                    ? keyFromProtobuf(info.wipeKey, ledgerId)
-                    : null,
+                info.wipeKey != null ? keyFromProtobuf(info.wipeKey) : null,
             supplyKey:
-                info.supplyKey != null
-                    ? keyFromProtobuf(info.supplyKey, ledgerId)
-                    : null,
+                info.supplyKey != null ? keyFromProtobuf(info.supplyKey) : null,
             feeScheduleKey:
                 info.feeScheduleKey != null
-                    ? keyFromProtobuf(info.feeScheduleKey, ledgerId)
+                    ? keyFromProtobuf(info.feeScheduleKey)
                     : null,
             defaultFreezeStatus:
                 defaultFreezeStatus === 0 ? null : defaultFreezeStatus == 1,

--- a/src/token/TokenInfoQuery.js
+++ b/src/token/TokenInfoQuery.js
@@ -99,9 +99,9 @@ export default class TokenInfoQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
     }
 
@@ -135,19 +135,17 @@ export default class TokenInfoQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<TokenInfo>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const info = /** @type {proto.ITokenGetInfoResponse} */ (
             response.tokenGetInfo
         );
 
         return Promise.resolve(
             TokenInfo._fromProtobuf(
-                /** @type {proto.ITokenInfo} */ (info.tokenInfo),
-                ledgerId
+                /** @type {proto.ITokenInfo} */ (info.tokenInfo)
             )
         );
     }

--- a/src/token/TokenMintTransaction.js
+++ b/src/token/TokenMintTransaction.js
@@ -148,9 +148,9 @@ export default class TokenMintTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenNftInfo.js
+++ b/src/token/TokenNftInfo.js
@@ -56,18 +56,15 @@ export default class TokenNftInfo {
     /**
      * @internal
      * @param {proto.ITokenNftInfo} info
-     * @param {(string | null)=} ledgerId
      * @returns {TokenNftInfo}
      */
-    static _fromProtobuf(info, ledgerId) {
+    static _fromProtobuf(info) {
         return new TokenNftInfo({
             nftId: NftId._fromProtobuf(
-                /** @type {proto.INftID} */ (info.nftID),
-                ledgerId
+                /** @type {proto.INftID} */ (info.nftID)
             ),
             accountId: AccountId._fromProtobuf(
-                /** @type {proto.IAccountID} */ (info.accountID),
-                ledgerId
+                /** @type {proto.IAccountID} */ (info.accountID)
             ),
             creationTime: Timestamp._fromProtobuf(
                 /** @type {proto.ITimestamp} */ (info.creationTime)

--- a/src/token/TokenNftInfoQuery.js
+++ b/src/token/TokenNftInfoQuery.js
@@ -89,10 +89,9 @@ export default class TokenNftInfoQuery extends Query {
     /**
      * @internal
      * @param {proto.IQuery} query
-     * @param {(string | null)=} ledgerId
      * @returns {TokenNftInfoQuery}
      */
-    static _fromProtobuf(query, ledgerId) {
+    static _fromProtobuf(query) {
         if (query.tokenGetNftInfo != null) {
             const info = /** @type {proto.ITokenGetNftInfoQuery} */ (
                 query.tokenGetNftInfo
@@ -101,7 +100,7 @@ export default class TokenNftInfoQuery extends Query {
             return new TokenNftInfoQuery({
                 nftId:
                     info.nftID != null
-                        ? NftId._fromProtobuf(info.nftID, ledgerId)
+                        ? NftId._fromProtobuf(info.nftID)
                         : undefined,
             });
         } else if (query.tokenGetAccountNftInfos != null) {
@@ -112,7 +111,7 @@ export default class TokenNftInfoQuery extends Query {
             return new TokenNftInfoQuery({
                 accountId:
                     info.accountID != null
-                        ? AccountId._fromProtobuf(info.accountID, ledgerId)
+                        ? AccountId._fromProtobuf(info.accountID)
                         : undefined,
                 start: info.start != null ? info.start : undefined,
                 end: info.end != null ? info.end : undefined,
@@ -125,7 +124,7 @@ export default class TokenNftInfoQuery extends Query {
             return new TokenNftInfoQuery({
                 tokenId:
                     info.tokenID != null
-                        ? TokenId._fromProtobuf(info.tokenID, ledgerId)
+                        ? TokenId._fromProtobuf(info.tokenID)
                         : undefined,
                 start: info.start != null ? info.start : undefined,
                 end: info.end != null ? info.end : undefined,
@@ -301,11 +300,10 @@ export default class TokenNftInfoQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<TokenNftInfo[]>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         let nfts = [];
         /** @type {proto.ITokenGetNftInfoResponse} */ (
             response.tokenGetNftInfo
@@ -341,8 +339,7 @@ export default class TokenNftInfoQuery extends Query {
         return Promise.resolve(
             nfts.map((nft) =>
                 TokenNftInfo._fromProtobuf(
-                    /** @type {proto.ITokenNftInfo} */ (nft),
-                    ledgerId
+                    /** @type {proto.ITokenNftInfo} */ (nft)
                 )
             )
         );

--- a/src/token/TokenRevokeKycTransaction.js
+++ b/src/token/TokenRevokeKycTransaction.js
@@ -140,13 +140,13 @@ export default class TokenRevokeKycTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
 
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenUnfreezeTransaction.js
+++ b/src/token/TokenUnfreezeTransaction.js
@@ -140,13 +140,13 @@ export default class TokenUnfreezeTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
 
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenUpdateTransaction.js
+++ b/src/token/TokenUpdateTransaction.js
@@ -551,17 +551,17 @@ export default class TokenUpdateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
 
         if (this._treasuryAccountId != null) {
-            this._treasuryAccountId.validate(client);
+            this._treasuryAccountId.validateChecksum(client);
         }
 
         if (this._autoRenewAccountId != null) {
-            this._autoRenewAccountId.validate(client);
+            this._autoRenewAccountId.validateChecksum(client);
         }
     }
 

--- a/src/token/TokenWipeTransaction.js
+++ b/src/token/TokenWipeTransaction.js
@@ -182,13 +182,13 @@ export default class TokenWipeTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._tokenId != null) {
-            this._tokenId.validate(client);
+            this._tokenId.validateChecksum(client);
         }
 
         if (this._accountId != null) {
-            this._accountId.validate(client);
+            this._accountId.validateChecksum(client);
         }
     }
 

--- a/src/topic/TopicCreateTransaction.js
+++ b/src/topic/TopicCreateTransaction.js
@@ -242,9 +242,9 @@ export default class TopicCreateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._autoRenewAccountId != null) {
-            this._autoRenewAccountId.validate(client);
+            this._autoRenewAccountId.validateChecksum(client);
         }
     }
 

--- a/src/topic/TopicDeleteTransaction.js
+++ b/src/topic/TopicDeleteTransaction.js
@@ -110,9 +110,9 @@ export default class TopicDeleteTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._topicId != null) {
-            this._topicId.validate(client);
+            this._topicId.validateChecksum(client);
         }
     }
 

--- a/src/topic/TopicId.js
+++ b/src/topic/TopicId.js
@@ -47,59 +47,45 @@ export default class TopicId {
     /**
      * @internal
      * @param {proto.ITopicID} id
-     * @param {(string | null)=} ledgerId
      * @returns {TopicId}
      */
-    static _fromProtobuf(id, ledgerId) {
+    static _fromProtobuf(id) {
         const topicId = new TopicId(
             id.shardNum != null ? id.shardNum : 0,
             id.realmNum != null ? id.realmNum : 0,
             id.topicNum != null ? id.topicNum : 0
         );
 
-        if (ledgerId != null) {
-            topicId._setNetwork(ledgerId);
-        }
-
         return topicId;
     }
 
     /**
-     * @internal
-     * @param {Client} client
+     * @returns {string | null}
      */
-    _setNetworkWith(client) {
-        if (client._network._ledgerId != null) {
-            this._setNetwork(client._network._ledgerId);
-        }
+    get checksum() {
+        return this._checksum;
     }
 
     /**
-     * @internal
-     * @param {string} ledgerId
-     */
-    _setNetwork(ledgerId) {
-        this._checksum = entity_id._checksum(
-            ledgerId,
-            `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-        );
-    }
-
-    /**
+     * @deprecated - Use `validateChecksum` instead
      * @param {Client} client
      */
     validate(client) {
-        if (
-            client._network._ledgerId != null &&
-            this._checksum != null &&
-            this._checksum !=
-                entity_id._checksum(
-                    client._network._ledgerId,
-                    `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`
-                )
-        ) {
-            throw new Error("Entity ID is for a different network than client");
-        }
+        console.warn("Deprecated: Use `validateChecksum` instead");
+        this.validateChecksum(client);
+    }
+
+    /**
+     * @param {Client} client
+     */
+    validateChecksum(client) {
+        entity_id.validateChecksum(
+            this.shard,
+            this.realm,
+            this.num,
+            this._checksum,
+            client
+        );
     }
 
     /**
@@ -125,13 +111,15 @@ export default class TopicId {
      * @returns {string}
      */
     toString() {
-        if (this._checksum == null) {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
-        } else {
-            return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}-${
-                this._checksum
-            }`;
-        }
+        return `${this.shard.toString()}.${this.realm.toString()}.${this.num.toString()}`;
+    }
+
+    /**
+     * @param {Client} client
+     * @returns {string}
+     */
+    toStringWithChecksum(client) {
+        return entity_id.toStringWithChecksum(this.toString(), client);
     }
 
     /**

--- a/src/topic/TopicInfo.js
+++ b/src/topic/TopicInfo.js
@@ -93,18 +93,16 @@ export default class TopicInfo {
     /**
      * @internal
      * @param {proto.IConsensusGetTopicInfoResponse} infoResponse
-     * @param {(string | null)=} ledgerId
      * @returns {TopicInfo}
      */
-    static _fromProtobuf(infoResponse, ledgerId) {
+    static _fromProtobuf(infoResponse) {
         const info = /** @type {proto.IConsensusTopicInfo} */ (
             infoResponse.topicInfo
         );
 
         return new TopicInfo({
             topicId: TopicId._fromProtobuf(
-                /** @type {proto.ITopicID} */ (infoResponse.topicID),
-                ledgerId
+                /** @type {proto.ITopicID} */ (infoResponse.topicID)
             ),
             topicMemo: info.memo != null ? info.memo : "",
             runningHash:
@@ -120,13 +118,9 @@ export default class TopicInfo {
                     ? Timestamp._fromProtobuf(info.expirationTime)
                     : null,
             adminKey:
-                info.adminKey != null
-                    ? keyFromProtobuf(info.adminKey, ledgerId)
-                    : null,
+                info.adminKey != null ? keyFromProtobuf(info.adminKey) : null,
             submitKey:
-                info.submitKey != null
-                    ? keyFromProtobuf(info.submitKey, ledgerId)
-                    : null,
+                info.submitKey != null ? keyFromProtobuf(info.submitKey) : null,
             autoRenewPeriod:
                 info.autoRenewPeriod != null
                     ? new Duration(
@@ -135,7 +129,7 @@ export default class TopicInfo {
                     : null,
             autoRenewAccountId:
                 info.autoRenewAccount != null
-                    ? AccountId._fromProtobuf(info.autoRenewAccount, ledgerId)
+                    ? AccountId._fromProtobuf(info.autoRenewAccount)
                     : null,
         });
     }

--- a/src/topic/TopicInfoQuery.js
+++ b/src/topic/TopicInfoQuery.js
@@ -101,9 +101,9 @@ export default class TopicInfoQuery extends Query {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._topicId != null) {
-            this._topicId.validate(client);
+            this._topicId.validateChecksum(client);
         }
     }
 
@@ -140,17 +140,15 @@ export default class TopicInfoQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<TopicInfo>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         return Promise.resolve(
             TopicInfo._fromProtobuf(
                 /** @type {proto.IConsensusGetTopicInfoResponse} */ (
                     response.consensusGetTopicInfo
-                ),
-                ledgerId
+                )
             )
         );
     }

--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -340,13 +340,13 @@ export default class TopicUpdateTransaction extends Transaction {
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (this._topicId != null) {
-            this._topicId.validate(client);
+            this._topicId.validateChecksum(client);
         }
 
         if (this._autoRenewAccountId != null) {
-            this._autoRenewAccountId.validate(client);
+            this._autoRenewAccountId.validateChecksum(client);
         }
     }
 

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -657,7 +657,7 @@ export default class Transaction extends Executable {
         }
 
         if (client != null && this._transactionIds[0].accountId != null) {
-            this._transactionIds[0].accountId.validate(client);
+            this._transactionIds[0].accountId.validateChecksum(client);
         }
 
         if (this._nodeIds.length > 0) {
@@ -755,7 +755,7 @@ export default class Transaction extends Executable {
      * @param {Client} client
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars,@typescript-eslint/no-empty-function
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         // Do nothing
     }
 
@@ -770,8 +770,8 @@ export default class Transaction extends Executable {
             this.freezeWith(client);
         }
 
-        if (client._operator != null) {
-            this._validateIdNetworks(client);
+        if (client.isAutoValidateChecksumsEnabled()) {
+            this._validateChecksums(client);
         }
 
         // on execute, sign each transaction with the operator, if present
@@ -960,11 +960,10 @@ export default class Transaction extends Executable {
      * @internal
      * @param {proto.ITransaction} request
      * @param {proto.ITransactionResponse} response
-     * @param {string | null} ledgerId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response, ledgerId) {
+    _mapStatusError(request, response) {
         const { nodeTransactionPrecheckCode } = response;
 
         const status = Status._fromCode(

--- a/src/transaction/TransactionId.js
+++ b/src/transaction/TransactionId.js
@@ -115,13 +115,12 @@ export default class TransactionId {
     /**
      * @internal
      * @param {proto.ITransactionID} id
-     * @param {(string | null)=} networkName
      * @returns {TransactionId}
      */
-    static _fromProtobuf(id, networkName) {
+    static _fromProtobuf(id) {
         if (id.accountID != null && id.transactionValidStart != null) {
             return new TransactionId(
-                AccountId._fromProtobuf(id.accountID, networkName),
+                AccountId._fromProtobuf(id.accountID),
                 Timestamp._fromProtobuf(id.transactionValidStart),
                 id.scheduled
             );

--- a/src/transaction/TransactionReceipt.js
+++ b/src/transaction/TransactionReceipt.js
@@ -160,10 +160,9 @@ export default class TransactionReceipt {
     /**
      * @internal
      * @param {proto.ITransactionReceipt} receipt
-     * @param {(string | null)=} ledgerId
      * @returns {TransactionReceipt}
      */
-    static _fromProtobuf(receipt, ledgerId) {
+    static _fromProtobuf(receipt) {
         const exchangeRateSet = /** @type {proto.IExchangeRateSet} */ (
             receipt.exchangeRate
         );
@@ -175,32 +174,32 @@ export default class TransactionReceipt {
 
             accountId:
                 receipt.accountID != null
-                    ? AccountId._fromProtobuf(receipt.accountID, ledgerId)
+                    ? AccountId._fromProtobuf(receipt.accountID)
                     : null,
 
             fileId:
                 receipt.fileID != null
-                    ? FileId._fromProtobuf(receipt.fileID, ledgerId)
+                    ? FileId._fromProtobuf(receipt.fileID)
                     : null,
 
             contractId:
                 receipt.contractID != null
-                    ? ContractId._fromProtobuf(receipt.contractID, ledgerId)
+                    ? ContractId._fromProtobuf(receipt.contractID)
                     : null,
 
             topicId:
                 receipt.topicID != null
-                    ? TopicId._fromProtobuf(receipt.topicID, ledgerId)
+                    ? TopicId._fromProtobuf(receipt.topicID)
                     : null,
 
             tokenId:
                 receipt.tokenID != null
-                    ? TokenId._fromProtobuf(receipt.tokenID, ledgerId)
+                    ? TokenId._fromProtobuf(receipt.tokenID)
                     : null,
 
             scheduleId:
                 receipt.scheduleID != null
-                    ? ScheduleId._fromProtobuf(receipt.scheduleID, ledgerId)
+                    ? ScheduleId._fromProtobuf(receipt.scheduleID)
                     : null,
 
             exchangeRate:
@@ -227,8 +226,7 @@ export default class TransactionReceipt {
             scheduledTransactionId:
                 receipt.scheduledTransactionID != null
                     ? TransactionId._fromProtobuf(
-                          receipt.scheduledTransactionID,
-                          ledgerId
+                          receipt.scheduledTransactionID
                       )
                     : null,
             serials: receipt.serialNumbers != null ? receipt.serialNumbers : [],
@@ -241,8 +239,7 @@ export default class TransactionReceipt {
      */
     static fromBytes(bytes) {
         return TransactionReceipt._fromProtobuf(
-            proto.TransactionReceipt.decode(bytes),
-            null
+            proto.TransactionReceipt.decode(bytes)
         );
     }
 

--- a/src/transaction/TransactionReceiptQuery.js
+++ b/src/transaction/TransactionReceiptQuery.js
@@ -154,11 +154,10 @@ export default class TransactionReceiptQuery extends Query {
      * @internal
      * @param {proto.IQuery} request
      * @param {proto.IResponse} response
-     * @param {string | null} ledgerId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response, ledgerId) {
+    _mapStatusError(request, response) {
         const { nodeTransactionPrecheckCode } =
             this._mapResponseHeader(response);
 
@@ -196,22 +195,19 @@ export default class TransactionReceiptQuery extends Query {
         return new ReceiptStatusError({
             status,
             transactionId: this._getTransactionId(),
-            transactionReceipt: TransactionReceipt._fromProtobuf(
-                receipt,
-                ledgerId
-            ),
+            transactionReceipt: TransactionReceipt._fromProtobuf(receipt),
         });
     }
 
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (
             this._transactionId != null &&
             this._transactionId.accountId != null
         ) {
-            this._transactionId.accountId.validate(client);
+            this._transactionId.accountId.validateChecksum(client);
         }
     }
 
@@ -248,11 +244,10 @@ export default class TransactionReceiptQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<TransactionReceipt>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const transactionGetReceipt =
             /** @type {proto.ITransactionGetReceiptResponse} */ (
                 response.transactionGetReceipt
@@ -261,9 +256,7 @@ export default class TransactionReceiptQuery extends Query {
             transactionGetReceipt.receipt
         );
 
-        return Promise.resolve(
-            TransactionReceipt._fromProtobuf(receipt, ledgerId)
-        );
+        return Promise.resolve(TransactionReceipt._fromProtobuf(receipt));
     }
 
     /**

--- a/src/transaction/TransactionRecord.js
+++ b/src/transaction/TransactionRecord.js
@@ -200,10 +200,9 @@ export default class TransactionRecord {
     /**
      * @internal
      * @param {proto.ITransactionRecord} record
-     * @param {(string | null)=} ledgerId
      * @returns {TransactionRecord}
      */
-    static _fromProtobuf(record, ledgerId) {
+    static _fromProtobuf(record) {
         const contractFunctionResult =
             record.contractCallResult != null
                 ? ContractFunctionResult._fromProtobuf(
@@ -217,8 +216,7 @@ export default class TransactionRecord {
 
         return new TransactionRecord({
             receipt: TransactionReceipt._fromProtobuf(
-                /** @type {proto.ITransactionReceipt} */ (record.receipt),
-                ledgerId
+                /** @type {proto.ITransactionReceipt} */ (record.receipt)
             ),
             transactionHash:
                 record.transactionHash != null
@@ -229,8 +227,7 @@ export default class TransactionRecord {
                 (record.consensusTimestamp)
             ),
             transactionId: TransactionId._fromProtobuf(
-                /** @type {proto.ITransactionID} */ (record.transactionID),
-                ledgerId
+                /** @type {proto.ITransactionID} */ (record.transactionID)
             ),
             transactionMemo: record.memo != null ? record.memo : "",
             transactionFee: Hbar.fromTinybars(
@@ -241,17 +238,16 @@ export default class TransactionRecord {
                     ? record.transferList.accountAmounts
                     : []
                 : []
-            ).map((aa) => Transfer._fromProtobuf(aa, ledgerId)),
+            ).map((aa) => Transfer._fromProtobuf(aa)),
             contractFunctionResult,
             tokenTransfers: TokenTransferMap._fromProtobuf(
                 record.tokenTransferLists != null
                     ? record.tokenTransferLists
-                    : [],
-                ledgerId
+                    : []
             ),
             scheduleRef:
                 record.scheduleRef != null
-                    ? ScheduleId._fromProtobuf(record.scheduleRef, ledgerId)
+                    ? ScheduleId._fromProtobuf(record.scheduleRef)
                     : null,
             assessedCustomFees:
                 record.assessedCustomFees != null
@@ -262,8 +258,7 @@ export default class TransactionRecord {
             nftTransfers: TokenNftTransferMap._fromProtobuf(
                 record.tokenTransferLists != null
                     ? record.tokenTransferLists
-                    : [],
-                ledgerId
+                    : []
             ),
         });
     }

--- a/src/transaction/TransactionRecordQuery.js
+++ b/src/transaction/TransactionRecordQuery.js
@@ -163,11 +163,10 @@ export default class TransactionRecordQuery extends Query {
      * @internal
      * @param {proto.IQuery} request
      * @param {proto.IResponse} response
-     * @param {string | null} ledgerId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response, ledgerId) {
+    _mapStatusError(request, response) {
         const { nodeTransactionPrecheckCode } =
             this._mapResponseHeader(response);
 
@@ -208,22 +207,19 @@ export default class TransactionRecordQuery extends Query {
         return new ReceiptStatusError({
             status,
             transactionId: this._getTransactionId(),
-            transactionReceipt: TransactionReceipt._fromProtobuf(
-                receipt,
-                ledgerId
-            ),
+            transactionReceipt: TransactionReceipt._fromProtobuf(receipt),
         });
     }
 
     /**
      * @param {Client} client
      */
-    _validateIdNetworks(client) {
+    _validateChecksums(client) {
         if (
             this._transactionId != null &&
             this._transactionId.accountId != null
         ) {
-            this._transactionId.accountId.validate(client);
+            this._transactionId.accountId.validateChecksum(client);
         }
     }
 
@@ -261,11 +257,10 @@ export default class TransactionRecordQuery extends Query {
      * @param {proto.IResponse} response
      * @param {AccountId} nodeAccountId
      * @param {proto.IQuery} request
-     * @param {string | null} ledgerId
      * @returns {Promise<TransactionRecord>}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request, ledgerId) {
+    _mapResponse(response, nodeAccountId, request) {
         const record = /** @type {proto.ITransactionGetRecordResponse} */ (
             response.transactionGetRecord
         );
@@ -274,8 +269,7 @@ export default class TransactionRecordQuery extends Query {
             TransactionRecord._fromProtobuf(
                 /** @type {proto.ITransactionRecord} */ (
                     record.transactionRecord
-                ),
-                ledgerId
+                )
             )
         );
     }

--- a/test/integration/AccountIdTest.js
+++ b/test/integration/AccountIdTest.js
@@ -3,34 +3,32 @@ import IntegrationTestEnv from "./client/index.js";
 
 describe("AccountId", function () {
     it("should generate checksum for account ID", function () {
+        const client = IntegrationTestEnv.forMainnet();
         const accountId = new AccountId(123);
-
-        accountId._setNetworkWith(IntegrationTestEnv.forMainnet());
 
         expect(accountId.num.toNumber()).to.eql(123);
         expect(accountId.realm.toNumber()).to.eql(0);
         expect(accountId.shard.toNumber()).to.eql(0);
 
-        expect(accountId.toString()).to.be.eql("0.0.123-vfmkw");
+        expect(accountId.toStringWithChecksum(client)).to.be.eql("0.0.123-vfmkw");
     });
 
     it("should generate checksum for token ID", function () {
+        const client = IntegrationTestEnv.forMainnet();
         const tokenId = new TokenId(123);
-
-        tokenId._setNetworkWith(IntegrationTestEnv.forMainnet());
 
         expect(tokenId.num.toNumber()).to.eql(123);
         expect(tokenId.realm.toNumber()).to.eql(0);
         expect(tokenId.shard.toNumber()).to.eql(0);
 
-        expect(tokenId.toString()).to.be.eql("0.0.123-vfmkw");
+        expect(tokenId.toStringWithChecksum(client)).to.be.eql("0.0.123-vfmkw");
     });
 
     it("should parse previewnet ID with checksum {0.0.123-ghaha}", function () {
         let err = false;
 
         try {
-            AccountId.fromString("0.0.123-ghaha").validate(
+            AccountId.fromString("0.0.123-ghaha").validateChecksum(
                 IntegrationTestEnv.forMainnet()
             );
         } catch {


### PR DESCRIPTION
Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>

**Description**:
Update checksums to only validate if an option is enabled on the client. Update all `_fromProtobuf()` implementations to not use `ledgerId` meaning checksums will not be part of the response types of requests.

**Related issue(s)**:

Closes: #466 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
