### PR TITLE
fix: correct invalid import

### DIFF
--- a/src/EntityIdHelper.js
+++ b/src/EntityIdHelper.js
@@ -1,7 +1,7 @@
 import Long from "long";
 import * as hex from "./encoding/hex.js";
 import BadEntityIdError from "./BadEntityIdError.js";
-import * as util from "../src/util.js";
+import * as util from "./util.js";
 
 /**
  * @typedef {import("./client/Client.js").default<*, *>} Client


### PR DESCRIPTION
**Description**:

[This commit] introduced the following runtime error

```
Error: Cannot find module '../src/util.cjs'
```

The offending compiled code looks like

```javascript
var util = _interopRequireWildcard(require("../src/util.cjs"));
```

which does not error when changed to

```javascript
var util = _interopRequireWildcard(require("./util.cjs"));
```

This commit changes the JavaScript source to produce the desired
compiled output.

[this commit]: https://github.com/hashgraph/hedera-sdk-js/pull/709

**Related issue(s)**:

Fixes #729

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
