### PR TITLE
fix: nft Transaction.fromBytes support

### DIFF
--- a/src/account/TransferTransaction.js
+++ b/src/account/TransferTransaction.js
@@ -394,8 +394,6 @@ export default class TransferTransaction extends Transaction {
         }
 
         for (const [tokenId, value] of this._nftTransfers) {
-            let found = false;
-
             // eslint-disable-next-line ie11/no-loop-func
             const nftTransfers = value.map((transfer) => {
                 return {
@@ -416,12 +414,7 @@ export default class TransferTransaction extends Transaction {
                 }
             }
 
-            if (!found) {
-                tokenTransfers.push({
-                    token: tokenId._toProtobuf(),
-                    nftTransfers,
-                });
-            }
+            tokenTransfers.push({ token: tokenId._toProtobuf(), nftTransfers });
         }
 
         for (const [accountId, value] of this._hbarTransfers) {

--- a/src/account/TransferTransaction.js
+++ b/src/account/TransferTransaction.js
@@ -164,6 +164,25 @@ export default class TransferTransaction extends Transaction {
                     /** @type {Long} */ (transfer.amount)
                 );
             }
+
+            for (const transfer of list.nftTransfers != null
+                ? list.nftTransfers
+                : []) {
+                transfers.addNftTransfer(
+                    tokenId,
+                    /** @type {Long} */ (transfer.serialNumber),
+                    AccountId._fromProtobuf(
+                        /** @type {proto.IAccountID} */ (
+                            transfer.senderAccountID
+                        )
+                    ),
+                    AccountId._fromProtobuf(
+                        /** @type {proto.IAccountID} */ (
+                            transfer.receiverAccountID
+                        )
+                    )
+                );
+            }
         }
 
         const accountAmounts =

--- a/test/unit/TransferTransaction.js
+++ b/test/unit/TransferTransaction.js
@@ -1,6 +1,11 @@
 import TransferTransaction from "../src/account/TransferTransaction.js";
 import HbarUnit from "../src/HbarUnit.js";
 import Hbar from "../src/Hbar.js";
+import TokenId from "../src/token/TokenId.js";
+import AccountId from "../src/account/AccountId.js";
+import Transaction from "../src/transaction/Transaction.js";
+import TransactionId from "../src/transaction/TransactionId.js";
+import Timestamp from "../src/Timestamp.js";
 
 describe("TransferTransaction", function () {
     it("should combine multiple same accountId tansfers into one transfer", function () {
@@ -17,5 +22,41 @@ describe("TransferTransaction", function () {
         expect(
             transfer.hbarTransfers.get(accountId).to(HbarUnit.Hbar).toNumber()
         ).to.be.equal(new Hbar(expectedHbar).to(HbarUnit.Hbar).toNumber());
+    });
+
+    it("should load ntf transfers from bytes", function () {
+        const tokenId = new TokenId(1, 1, 1);
+        const serialNum = 111111111;
+        const fromAccount = new AccountId(1, 1, 1);
+        const toAccount = new AccountId(2, 2, 2);
+        const transferTransaction = new TransferTransaction();
+        transferTransaction.addNftTransfer(
+            tokenId,
+            serialNum,
+            fromAccount,
+            toAccount
+        );
+        transferTransaction.addNftTransfer(
+            tokenId,
+            serialNum,
+            fromAccount,
+            toAccount
+        );
+        transferTransaction.setTransactionId(
+            new TransactionId(new AccountId(3, 3, 3), new Timestamp(4, 4))
+        );
+        transferTransaction.setNodeAccountIds([new AccountId(4, 4, 4)]);
+        transferTransaction.freeze();
+
+        const transferTransactionFromBytes = Transaction.fromBytes(
+            transferTransaction.toBytes()
+        );
+
+        expect(transferTransaction.nftTransfers.keys()).to.eql(
+            transferTransactionFromBytes.nftTransfers.keys()
+        );
+        expect(transferTransaction.nftTransfers.values()).to.eql(
+            transferTransactionFromBytes.nftTransfers.values()
+        );
     });
 });


### PR DESCRIPTION
nft transfers do not get read in fromBytes 

- [x] fix bug 
- [x] make test
- [ ] dab irl

Fixes: #707 

bug reproduction:
```
        const tokenId = new TokenId(1,1,1);
        const serialNum = 111111111;
        const fromAccount = new AccountId(1,1,1);
        const toAccount = new AccountId(2,2,2);
        const transferTransaction = new TransferTransaction();
        transferTransaction.addNftTransfer(
            tokenId,
            serialNum,
            fromAccount,
            toAccount
        );
        transferTransaction.setTransactionId(new TransactionId(new AccountId(1,1,1),new Timestamp(4,4)));
        transferTransaction.setNodeAccountIds([new AccountId(3,3,3)]);
        transferTransaction.freeze();
        console.log(transferTransaction.nftTransfers);

        const transferTransactionFromBytes = Transaction.fromBytes(transferTransaction.toBytes());
        console.log(transferTransactionFromBytes);
```