### PR TITLE
chore: drop unused byteToHex

### DIFF
--- a/packages/cryptography/src/encoding/hex.js
+++ b/packages/cryptography/src/encoding/hex.js
@@ -1,13 +1,4 @@
 /**
- * @type {string[]}
- */
-const byteToHex = [];
-
-for (let n = 0; n <= 0xff; n += 1) {
-    byteToHex.push(n.toString(16).padStart(2, "0"));
-}
-
-/**
  * @param {Uint8Array} data
  * @returns {string}
  */

--- a/src/encoding/hex.js
+++ b/src/encoding/hex.js
@@ -1,13 +1,4 @@
 /**
- * @type {string[]}
- */
-const byteToHex = [];
-
-for (let n = 0; n <= 0xff; n += 1) {
-    byteToHex.push(n.toString(16).padStart(2, "0"));
-}
-
-/**
  * @param {Uint8Array} data
  * @returns {string}
  */


### PR DESCRIPTION
**Description**:

This removes `byteToHex` code from files where it's unused.

Only `hex.browser.js` and `hex.native.js` uses it, `hex.js` doesn't need it.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
