### PR TITLE
chore: drop direct protobufjs dep, it's unused

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,6 @@
         "crypto-js": "^4.0.0",
         "js-base64": "^3.6.1",
         "long": "^4.0.0",
-        "protobufjs": "^6.11.2",
         "utf8": "^3.0.0"
     },
     "devDependencies": {


### PR DESCRIPTION
**Description**:

This removes direct `protobufjs` from `@hashgraph/sdk` itself.

Only `@hashgraph/proto` depends on `protobufjs`, and the version specified in `@hashgraph/sdk` is ineffective -- the code uses the `protobufjs` version from `@hashgraph/proto` deps either way, as all the imports of `protobufjs` are done by `@hashgraph/proto`.

There are no direct `protobufjs` imports in `@hashgraph/sdk`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
