### PR TITLE
fix: use arr.buffer safely

### DIFF
--- a/packages/cryptography/src/encoding/der.js
+++ b/packages/cryptography/src/encoding/der.js
@@ -141,18 +141,14 @@ function decodeInt(intBytes) {
         return intBytes[0];
     }
 
-    let view = new DataView(
-        intBytes.buffer,
-        intBytes.byteOffset,
-        intBytes.byteLength
-    );
+    let view = new DataView(intBytes.buffer, intBytes.byteOffset, intBytes.byteLength);
 
     if (len === 2) return view.getUint16(0, false);
 
     if (len === 3) {
         // prefix a zero byte and we'll treat it as a 32-bit int
         const data = Uint8Array.of(0, ...intBytes);
-        view = new DataView(data.buffer);
+        view = new DataView(data.buffer, data.byteOffset, data.byteLength);
     }
 
     if (len > 4) {

--- a/packages/cryptography/src/encoding/der.js
+++ b/packages/cryptography/src/encoding/der.js
@@ -141,7 +141,11 @@ function decodeInt(intBytes) {
         return intBytes[0];
     }
 
-    let view = new DataView(intBytes.buffer, intBytes.byteOffset, intBytes.byteLength);
+    let view = new DataView(
+        intBytes.buffer,
+        intBytes.byteOffset,
+        intBytes.byteLength
+    );
 
     if (len === 2) return view.getUint16(0, false);
 

--- a/packages/cryptography/src/encoding/hex.native.js
+++ b/packages/cryptography/src/encoding/hex.native.js
@@ -321,6 +321,6 @@ export function decodeFromByteString(text) {
     for (let i = 0; i < text.length; i++) {
         view.setUint8(i, text.charCodeAt(i));
     }
-    
+
     return buffer;
 }

--- a/packages/cryptography/src/primitive/slip10.js
+++ b/packages/cryptography/src/primitive/slip10.js
@@ -12,7 +12,11 @@ export async function derive(parentKey, chainCode, index) {
     // 0x00 + parentKey + index(BE)
     input[0] = 0;
     input.set(parentKey, 1);
-    new DataView(input.buffer, input.byteOffset, input.byteLength).setUint32(33, index, false);
+    new DataView(input.buffer, input.byteOffset, input.byteLength).setUint32(
+        33,
+        index,
+        false
+    );
 
     // set the index to hardened
     input[33] |= 128;

--- a/packages/cryptography/src/primitive/slip10.js
+++ b/packages/cryptography/src/primitive/slip10.js
@@ -12,7 +12,7 @@ export async function derive(parentKey, chainCode, index) {
     // 0x00 + parentKey + index(BE)
     input[0] = 0;
     input.set(parentKey, 1);
-    new DataView(input.buffer).setUint32(33, index, false);
+    new DataView(input.buffer, input.byteOffset, input.byteLength).setUint32(33, index, false);
 
     // set the index to hardened
     input[33] |= 128;

--- a/packages/cryptography/src/util/array.js
+++ b/packages/cryptography/src/util/array.js
@@ -12,8 +12,16 @@ export function arrayEqual(array1, array2) {
         return false;
     }
 
-    const view1 = new DataView(array1.buffer, array1.byteOffset, array1.byteLength);
-    const view2 = new DataView(array2.buffer, array2.byteOffset, array2.byteLength);
+    const view1 = new DataView(
+        array1.buffer,
+        array1.byteOffset,
+        array1.byteLength
+    );
+    const view2 = new DataView(
+        array2.buffer,
+        array2.byteOffset,
+        array2.byteLength
+    );
 
     let i = array1.byteLength;
 

--- a/packages/cryptography/src/util/array.js
+++ b/packages/cryptography/src/util/array.js
@@ -12,8 +12,8 @@ export function arrayEqual(array1, array2) {
         return false;
     }
 
-    const view1 = new DataView(array1.buffer);
-    const view2 = new DataView(array2.buffer);
+    const view1 = new DataView(array1.buffer, array1.byteOffset, array1.byteLength);
+    const view2 = new DataView(array2.buffer, array2.byteOffset, array2.byteLength);
 
     let i = array1.byteLength;
 

--- a/packages/cryptography/src/util/derive.js
+++ b/packages/cryptography/src/util/derive.js
@@ -10,18 +10,14 @@ export function legacy(seed, index) {
     const password = new Uint8Array(seed.length + 8);
     password.set(seed, 0);
 
-    const view = new DataView(
-        password.buffer,
-        password.byteOffset + seed.length,
-        8
-    );
+    const view = new DataView(password.buffer, password.byteOffset, password.byteLength);
 
     if (index === 0xffffffffff) {
-        view.setInt32(0, 0xff);
-        view.setInt32(4, index >>> 32);
+        view.setInt32(seed.length + 0, 0xff);
+        view.setInt32(seed.length + 4, index >>> 32);
     } else {
-        view.setInt32(0, index < 0 ? -1 : 0);
-        view.setInt32(4, index);
+        view.setInt32(seed.length + 0, index < 0 ? -1 : 0);
+        view.setInt32(seed.length + 4, index);
     }
 
     const salt = Uint8Array.from([0xff]);

--- a/packages/cryptography/src/util/derive.js
+++ b/packages/cryptography/src/util/derive.js
@@ -10,7 +10,11 @@ export function legacy(seed, index) {
     const password = new Uint8Array(seed.length + 8);
     password.set(seed, 0);
 
-    const view = new DataView(password.buffer, password.byteOffset, password.byteLength);
+    const view = new DataView(
+        password.buffer,
+        password.byteOffset,
+        password.byteLength
+    );
 
     if (index === 0xffffffffff) {
         view.setInt32(seed.length + 0, 0xff);

--- a/src/EntityIdHelper.js
+++ b/src/EntityIdHelper.js
@@ -152,7 +152,7 @@ export function fromSolidityAddress(address) {
  */
 export function toSolidityAddress(address) {
     const buffer = new Uint8Array(20);
-    const view = new DataView(buffer.buffer, 0, 20);
+    const view = util.safeView(buffer);
     const [shard, realm, num] = address;
 
     view.setUint32(0, util.convertToNumber(shard));

--- a/src/array.js
+++ b/src/array.js
@@ -12,8 +12,16 @@ export function arrayEqual(array1, array2) {
         return false;
     }
 
-    const view1 = new DataView(array1.buffer, array1.byteOffset, array1.byteLength);
-    const view2 = new DataView(array2.buffer, array2.byteOffset, array2.byteLength);
+    const view1 = new DataView(
+        array1.buffer,
+        array1.byteOffset,
+        array1.byteLength
+    );
+    const view2 = new DataView(
+        array2.buffer,
+        array2.byteOffset,
+        array2.byteLength
+    );
 
     let i = array1.byteLength;
 

--- a/src/array.js
+++ b/src/array.js
@@ -12,8 +12,8 @@ export function arrayEqual(array1, array2) {
         return false;
     }
 
-    const view1 = new DataView(array1.buffer);
-    const view2 = new DataView(array2.buffer);
+    const view1 = new DataView(array1.buffer, array1.byteOffset, array1.byteLength);
+    const view2 = new DataView(array2.buffer, array2.byteOffset, array2.byteLength);
 
     let i = array1.byteLength;
 

--- a/src/channel/Channel.js
+++ b/src/channel/Channel.js
@@ -233,9 +233,12 @@ export function encodeRequest(data) {
 
 /**
  * @param {ArrayBuffer} data
+ * @param {number} byteOffset
+ * @param {number} byteLength
  * @returns {Uint8Array}
  */
-export function decodeUnaryResponse(data) {
+export function decodeUnaryResponse(data, byteOffset = 0, byteLength = data.byteLength) {
+    const dataView = new DataView(data, byteOffset, byteLength);
     let dataOffset = 0;
 
     /** @type {?Uint8Array} */
@@ -244,11 +247,10 @@ export function decodeUnaryResponse(data) {
     // 0 = successful
     let status = 0;
 
-    while (dataOffset < data.byteLength) {
-        const dataView = new DataView(data, dataOffset);
-        const frameByte = dataView.getUint8(0);
+    while (dataOffset < dataView.byteLength) {
+        const frameByte = dataView.getUint8(dataOffset + 0);
         const frameType = frameByte >> 7;
-        const frameByteLength = dataView.getUint32(1);
+        const frameByteLength = dataView.getUint32(dataOffset + 1);
         const frameData = new Uint8Array(data, dataOffset + 5, frameByteLength);
 
         if (frameType === 0) {

--- a/src/channel/Channel.js
+++ b/src/channel/Channel.js
@@ -237,7 +237,11 @@ export function encodeRequest(data) {
  * @param {number} byteLength
  * @returns {Uint8Array}
  */
-export function decodeUnaryResponse(data, byteOffset = 0, byteLength = data.byteLength) {
+export function decodeUnaryResponse(
+    data,
+    byteOffset = 0,
+    byteLength = data.byteLength
+) {
     const dataView = new DataView(data, byteOffset, byteLength);
     let dataOffset = 0;
 

--- a/src/channel/NativeChannel.js
+++ b/src/channel/NativeChannel.js
@@ -86,7 +86,11 @@ export default class NativeChannel extends Channel {
                 );
             }
 
-            const unaryResponse = decodeUnaryResponse(responseBuffer.buffer, responseBuffer.byteOffset, responseBuffer.byteLength);
+            const unaryResponse = decodeUnaryResponse(
+                responseBuffer.buffer,
+                responseBuffer.byteOffset,
+                responseBuffer.byteLength
+            );
 
             callback(null, unaryResponse);
         };

--- a/src/channel/NativeChannel.js
+++ b/src/channel/NativeChannel.js
@@ -86,7 +86,7 @@ export default class NativeChannel extends Channel {
                 );
             }
 
-            const unaryResponse = decodeUnaryResponse(responseBuffer.buffer);
+            const unaryResponse = decodeUnaryResponse(responseBuffer.buffer, responseBuffer.byteOffset, responseBuffer.byteLength);
 
             callback(null, unaryResponse);
         };

--- a/src/contract/ContractFunctionParameters.js
+++ b/src/contract/ContractFunctionParameters.js
@@ -383,10 +383,7 @@ export default class ContractFunctionParameters {
 
         for (const [i, { dynamic, value }] of this._arguments.entries()) {
             if (dynamic) {
-                const view = new DataView(
-                    func.buffer,
-                    nameOffset + i * 32 + 28
-                );
+                const view = util.safeView(func, nameOffset + i * 32 + 28);
                 view.setUint32(0, offset);
                 func.set(value, view.getUint32(0) + nameOffset);
                 offset += value.length;
@@ -406,7 +403,7 @@ export default class ContractFunctionParameters {
  */
 function argumentToBytes(param, ty) {
     let value = new Uint8Array(32);
-    let valueView = new DataView(value.buffer, 0);
+    let valueView = util.safeView(value);
     /** @type {Uint8Array} */
     let par;
 
@@ -463,7 +460,7 @@ function argumentToBytes(param, ty) {
                 );
         }
 
-        valueView = new DataView(value.buffer, 28);
+        valueView = util.safeView(value, 28);
         valueView.setUint32(0, values.length);
 
         let offset = 32 * values.length;
@@ -489,7 +486,7 @@ function argumentToBytes(param, ty) {
                 case ArgumentType.bytes:
                 case ArgumentType.string:
                     // eslint-disable-next-line no-case-declarations
-                    const view = new DataView(value.buffer, (i + 1) * 32 + 28);
+                    const view = util.safeView(value, (i + 1) * 32 + 28);
                     view.setUint32(0, offset);
                     value.set(e, view.getUint32(0) + 32);
                     offset += e.length;
@@ -623,7 +620,7 @@ function argumentToBytes(param, ty) {
 
             value.set(par, 32);
 
-            valueView = new DataView(value.buffer, 28);
+            valueView = util.safeView(value, 28);
             valueView.setUint32(0, par.length);
             return value;
         default:

--- a/src/contract/ContractFunctionResult.js
+++ b/src/contract/ContractFunctionResult.js
@@ -3,6 +3,7 @@ import ContractId from "./ContractId.js";
 import BigNumber from "bignumber.js";
 import * as hex from "../encoding/hex.js";
 import * as utf8 from "../encoding/utf8.js";
+import * as util from "../util.js";
 import Long from "long";
 
 /**
@@ -110,11 +111,7 @@ export default class ContractFunctionResult {
         // Arrays in solidity cannot be longer than 1024:
         // https://solidity.readthedocs.io/en/v0.4.21/introduction-to-smart-contracts.html
         const offset = this.getInt32(index);
-        const len = new DataView(
-            this.bytes.buffer,
-            this.bytes.byteOffset + offset + 28,
-            4
-        ).getInt32(0);
+        const len = util.safeView(this.bytes).getInt32(offset + 28);
 
         return this.bytes.subarray(offset + 32, offset + 32 + len);
     }
@@ -154,11 +151,8 @@ export default class ContractFunctionResult {
         // .getInt32() interprets as big-endian
         // Using DataView instead of Uint32Array because the latter interprets
         // using platform endianness which is little-endian on x86
-        return new DataView(
-            this.bytes.buffer,
-            this.bytes.byteOffset + (index != null ? index : 0) * 32 + 28,
-            4
-        ).getInt32(0);
+        const position = (index != null ? index : 0) * 32 + 28
+        return util.safeView(this.bytes).getInt32(position);
     }
 
     /**
@@ -201,11 +195,8 @@ export default class ContractFunctionResult {
         // .getUint32() interprets as big-endian
         // Using DataView instead of Uint32Array because the latter interprets
         // using platform endianness which is little-endian on x86
-        return new DataView(
-            this.bytes.buffer,
-            this.bytes.byteOffset + (index != null ? index : 0) * 32 + 28,
-            4
-        ).getUint32(0);
+        const position = (index != null ? index : 0) * 32 + 28
+        return util.safeView(this.bytes).getUint32(position);
     }
 
     /**

--- a/src/contract/ContractFunctionResult.js
+++ b/src/contract/ContractFunctionResult.js
@@ -151,7 +151,7 @@ export default class ContractFunctionResult {
         // .getInt32() interprets as big-endian
         // Using DataView instead of Uint32Array because the latter interprets
         // using platform endianness which is little-endian on x86
-        const position = (index != null ? index : 0) * 32 + 28
+        const position = (index != null ? index : 0) * 32 + 28;
         return util.safeView(this.bytes).getInt32(position);
     }
 
@@ -195,7 +195,7 @@ export default class ContractFunctionResult {
         // .getUint32() interprets as big-endian
         // Using DataView instead of Uint32Array because the latter interprets
         // using platform endianness which is little-endian on x86
-        const position = (index != null ? index : 0) * 32 + 28
+        const position = (index != null ? index : 0) * 32 + 28;
         return util.safeView(this.bytes).getUint32(position);
     }
 

--- a/src/util.js
+++ b/src/util.js
@@ -307,7 +307,13 @@ export function convertToNumber(variable) {
  * @returns {DataView}
  */
 export function safeView(arr, offset = 0, length = arr.byteLength) {
-    if (!(Number.isInteger(offset) && offset >= 0)) throw new Error('Invalid offset!')
-    if (!(Number.isInteger(length) && length > 0)) throw new Error('Invalid length!')
-    return new DataView(arr.buffer, arr.byteOffset + offset, Math.min(length, arr.byteLength - offset));
+    if (!(Number.isInteger(offset) && offset >= 0))
+        throw new Error("Invalid offset!");
+    if (!(Number.isInteger(length) && length > 0))
+        throw new Error("Invalid length!");
+    return new DataView(
+        arr.buffer,
+        arr.byteOffset + offset,
+        Math.min(length, arr.byteLength - offset)
+    );
 }

--- a/src/util.js
+++ b/src/util.js
@@ -297,3 +297,17 @@ export function convertToNumber(variable) {
         throw new Error(FUNCTION_CONVERT_TO_NUMBER_ERROR);
     }
 }
+
+/**
+ * Creates a DataView on top of an Uint8Array that could be or not be pooled, ensuring that we don't get out of bounds.
+ *
+ * @param {Uint8Array} arr
+ * @param {number | undefined} offset
+ * @param {number | undefined} length
+ * @returns {DataView}
+ */
+export function safeView(arr, offset = 0, length = arr.byteLength) {
+    if (!(Number.isInteger(offset) && offset >= 0)) throw new Error('Invalid offset!')
+    if (!(Number.isInteger(length) && length > 0)) throw new Error('Invalid length!')
+    return new DataView(arr.buffer, arr.byteOffset + offset, Math.min(length, arr.byteLength - offset));
+}


### PR DESCRIPTION
**Description**:

This SDK both
1. Uses `Buffer.from` in some places and treats them as `Uint8Array` instances:
   ```
    src/channel/NodeMirrorChannel.js
    src/channel/NodeChannel.js
    src/encoding/hex.js
    src/encoding/utf8.js
    packages/cryptography/src/encoding/base64.js
    packages/cryptography/src/encoding/hex.js
    packages/cryptography/src/encoding/utf8.js
    ```
    Note that `Buffer.from` isn't the only source of this, as this SDK also creates pooled `Uint8Array` instances manually, e.g.: 
  https://github.com/hashgraph/hedera-sdk-js/blob/9c9ace7ddb67f46f72105066d2be2fbc37991d5c/src/channel/Channel.js#L252


2. Treats `Uint8Array` instances as non-pooled in most places across the codebase (see the diff of this PR for exact locations).

This seems very fragile, as accidentally treating a pooled `Uint8Array` instance as a non-pooled one might result in a catastrophic failure, e.g. leaking unrelated data over the network.

E.g.:
```console
> Buffer.from('x')
<Buffer 78>
> Buffer.from('x').buffer
ArrayBuffer {
  [Uint8Contents]: <2f 00 00 00 00 00 00 00 2f 00 00 00 00 00 00 00 78 00 00 00 00 00 00 00 78 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 ... 8092 more bytes>,
  byteLength: 8192
}
```

This PR fixes that by ensuring that each time `arr.buffer` is used, we use appropriate `arr.byteOffset` and `arr.byteLength`.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
