### PR TITLE
fix: serialization before signing

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
         "test": "run-s test:node test:browser",
         "test:node": "env HEDERA_SDK_TEST='' run-s test:unit:node test:integration:node",
         "test:unit:node": "env HEDERA_SDK_TEST='' nyc mocha -r @babel/register -r chai/register-expect 'test/unit/*.js'",
-        "test:unit:single": "env HEDERA_SDK_TEST='' nyc mocha -r @babel/register -r chai/register-expect",
         "test:integration:node": "env HEDERA_SDK_TEST='' nyc mocha -r @babel/register -r chai/register-expect 'test/integration/*.js'",
         "test:browser": "run-s test:unit:browser test:integration:browser",
         "test:browser:chrome": "run-s test:unit:browser:chrome test:integration:browser:chrome",

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
         "test": "run-s test:node test:browser",
         "test:node": "env HEDERA_SDK_TEST='' run-s test:unit:node test:integration:node",
         "test:unit:node": "env HEDERA_SDK_TEST='' nyc mocha -r @babel/register -r chai/register-expect 'test/unit/*.js'",
+        "test:unit:single": "env HEDERA_SDK_TEST='' nyc mocha -r @babel/register -r chai/register-expect",
         "test:integration:node": "env HEDERA_SDK_TEST='' nyc mocha -r @babel/register -r chai/register-expect 'test/integration/*.js'",
         "test:browser": "run-s test:unit:browser test:integration:browser",
         "test:browser:chrome": "run-s test:unit:browser:chrome test:integration:browser:chrome",

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -883,20 +883,13 @@ export default class Transaction extends Executable {
             for (let i = this._transactions.length; i < index; i++) {
                 this._transactions.push(null);
             }
-        } else if (
-            this._transactions.length > index &&
-            this._transactions[index] != null &&
-            /** @type {proto.ITransaction} */ (this._transactions[index])
-                .signedTransactionBytes != null
-        ) {
-            return;
         }
 
-        this._transactions.push({
+        this._transactions[index] = {
             signedTransactionBytes: ProtoSignedTransaction.encode(
                 this._signedTransactions[index]
             ).finish(),
-        });
+        };
     }
 
     /**

--- a/test/unit/Serialize.js
+++ b/test/unit/Serialize.js
@@ -52,23 +52,23 @@ describe("Mix signing and serialization", function () {
         const tx = buildTx(params);
         sign(tx, PRIVATE_KEY1);
         sign(tx, PRIVATE_KEY2);
-        const serialized = serialize(tx, "hex");
+        const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
     it("Call serialize before signing without using it", function () {
         const tx = buildTx(params);
-        serialize(tx, "hex");
+        serialize(tx);
         sign(tx, PRIVATE_KEY1);
         sign(tx, PRIVATE_KEY2);
-        const serialized = serialize(tx, "hex");
+        const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
     it("Call serialize between signing without using it", function () {
         const tx = buildTx(params);
         sign(tx, PRIVATE_KEY1);
-        serialize(tx, "hex");
+        serialize(tx);
         sign(tx, PRIVATE_KEY2);
-        const serialized = serialize(tx, "hex");
+        const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
     it("Serialize, deserialize then sign", function () {
@@ -76,7 +76,7 @@ describe("Mix signing and serialization", function () {
         tx = deserialize(serialize(tx));
         sign(tx, PRIVATE_KEY1);
         sign(tx, PRIVATE_KEY2);
-        const serialized = serialize(tx, "hex");
+        const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
     it("Sign, serialize, deserialize then sign again", function () {
@@ -84,7 +84,7 @@ describe("Mix signing and serialization", function () {
         sign(tx, PRIVATE_KEY1);
         tx = deserialize(serialize(tx));
         sign(tx, PRIVATE_KEY2);
-        const serialized = serialize(tx, "hex");
+        const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
     it("Sign then serialize, deserialize", function () {
@@ -92,7 +92,7 @@ describe("Mix signing and serialization", function () {
         sign(tx, PRIVATE_KEY1);
         sign(tx, PRIVATE_KEY2);
         tx = deserialize(serialize(tx));
-        const serialized = serialize(tx, "hex");
+        const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
 });

--- a/test/unit/Serialize.js
+++ b/test/unit/Serialize.js
@@ -27,12 +27,21 @@ const params = {
     memo: "Transaction (de)serialization test",
 };
 
-const serialize = (tx) => tx.toBytes().toString("hex");
-const deserialize = (s) => Transaction.fromBytes(Buffer.from(s, "hex"));
-const sign = (tx, privateKeyHex) =>
-    PrivateKey.fromBytes(Buffer.from(privateKeyHex, "hex")).signTransaction(tx);
+function serialize(tx) {
+    return tx.toBytes().toString("hex");
+}
 
-const buildTx = (params) => {
+function deserialize(s) {
+    return Transaction.fromBytes(Buffer.from(s, "hex"));
+}
+
+function sign(tx, privateKeyHex) {
+    return PrivateKey.fromBytes(
+        Buffer.from(privateKeyHex, "hex")
+    ).signTransaction(tx);
+}
+
+function buildTx(params) {
     const transactionId = TransactionId.withValidStart(
         params.operatorId,
         params.validStart
@@ -45,7 +54,7 @@ const buildTx = (params) => {
         .addHbarTransfer(params.senderId, params.amount.negated())
         .addHbarTransfer(params.recipientId, params.amount);
     return unbuiltTx.freeze();
-};
+}
 
 describe("Mix signing and serialization", function () {
     it("Sign then serialize", function () {
@@ -55,6 +64,7 @@ describe("Mix signing and serialization", function () {
         const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
+
     it("Call serialize before signing without using it", function () {
         const tx = buildTx(params);
         serialize(tx);
@@ -63,6 +73,7 @@ describe("Mix signing and serialization", function () {
         const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
+
     it("Call serialize between signing without using it", function () {
         const tx = buildTx(params);
         sign(tx, PRIVATE_KEY1);
@@ -71,6 +82,7 @@ describe("Mix signing and serialization", function () {
         const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
+
     it("Serialize, deserialize then sign", function () {
         let tx = buildTx(params);
         tx = deserialize(serialize(tx));
@@ -79,6 +91,7 @@ describe("Mix signing and serialization", function () {
         const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
+
     it("Sign, serialize, deserialize then sign again", function () {
         let tx = buildTx(params);
         sign(tx, PRIVATE_KEY1);
@@ -87,6 +100,7 @@ describe("Mix signing and serialization", function () {
         const serialized = serialize(tx);
         expect(serialized).equals(SERIALIZED);
     });
+
     it("Sign then serialize, deserialize", function () {
         let tx = buildTx(params);
         sign(tx, PRIVATE_KEY1);

--- a/test/unit/Serialize.js
+++ b/test/unit/Serialize.js
@@ -1,0 +1,98 @@
+import { expect } from "chai";
+import {
+    AccountId,
+    Hbar,
+    PrivateKey,
+    Timestamp,
+    Transaction,
+    TransactionId,
+    TransferTransaction,
+} from "../src/exports.js";
+
+const PRIVATE_KEY1 =
+    "302e020100300506032b657004220420ba0cc58a039afe36f3bd1f1c4ef44750268b35b5388dcae326752816da33be3f";
+const PRIVATE_KEY2 =
+    "302e020100300506032b6570042204202421c0faec4b8cb59214ed6c46e351637678d5b5cff811fd9855fa25b98519b6";
+const SERIALIZED =
+    "0ac8022ac5020a740a130a080880d4818e061000120708001000189a0512060800100018071880c2d72f2202087832225472616e73616374696f6e202864652973657269616c697a6174696f6e207465737472280a260a110a080800100018c0c4071091a6afa5f8020a110a080800100018f1f7271092a6afa5f80212cc010a640a20d6868558baa9c23e2308ccc75a0f11176727a16cbb1e8312c2eb727cc517b1c91a4065953badd76ceccbefa03de68034d87295da494c16bfdb4f42ce2259d6aee507cf623b89931f564741aa96a776f339709e7ee9eb5cb6ccd83cba2d588c87d9030a640a2036d767d5857eaf6a665886103f434464cd06ce56f00bf6b6b67ca0906350aea11a405f4d536e6b1b7bc00c1d30f34ac3f3e9d8fac471509f86d1bb7a5343d52564559da3cb69a2f2f069541891e8ea367a12c605c6fdcd2c719b058299112ecd0004";
+
+const params = {
+    nodeId: AccountId.fromString("0.0.7"),
+    operatorId: AccountId.fromString("0.0.666"),
+    senderId: AccountId.fromString("0.0.123456"),
+    recipientId: AccountId.fromString("0.0.654321"),
+    validStart: Timestamp.fromDate(new Date(1640000000000)),
+    amount: Hbar.fromTinybars("50505050505"),
+    fee: Hbar.fromTinybars("100000000"),
+    memo: "Transaction (de)serialization test",
+};
+
+const serialize = (tx) => tx.toBytes().toString("hex");
+const deserialize = (s) => Transaction.fromBytes(Buffer.from(s, "hex"));
+const sign = (tx, privateKeyHex) =>
+    PrivateKey.fromBytes(Buffer.from(privateKeyHex, "hex")).signTransaction(tx);
+
+const buildTx = (params) => {
+    const transactionId = TransactionId.withValidStart(
+        params.operatorId,
+        params.validStart
+    );
+    const unbuiltTx = new TransferTransaction()
+        .setMaxTransactionFee(params.fee)
+        .setTransactionId(transactionId)
+        .setNodeAccountIds([params.nodeId])
+        .setTransactionMemo(params.memo)
+        .addHbarTransfer(params.senderId, params.amount.negated())
+        .addHbarTransfer(params.recipientId, params.amount);
+    return unbuiltTx.freeze();
+};
+
+describe("Mix signing and serialization", function () {
+    it("Sign then serialize", function () {
+        const tx = buildTx(params);
+        sign(tx, PRIVATE_KEY1);
+        sign(tx, PRIVATE_KEY2);
+        const serialized = serialize(tx, "hex");
+        expect(serialized).equals(SERIALIZED);
+    });
+    it("Call serialize before signing without using it", function () {
+        const tx = buildTx(params);
+        serialize(tx, "hex");
+        sign(tx, PRIVATE_KEY1);
+        sign(tx, PRIVATE_KEY2);
+        const serialized = serialize(tx, "hex");
+        expect(serialized).equals(SERIALIZED);
+    });
+    it("Call serialize between signing without using it", function () {
+        const tx = buildTx(params);
+        sign(tx, PRIVATE_KEY1);
+        serialize(tx, "hex");
+        sign(tx, PRIVATE_KEY2);
+        const serialized = serialize(tx, "hex");
+        expect(serialized).equals(SERIALIZED);
+    });
+    it("Serialize, deserialize then sign", function () {
+        let tx = buildTx(params);
+        tx = deserialize(serialize(tx));
+        sign(tx, PRIVATE_KEY1);
+        sign(tx, PRIVATE_KEY2);
+        const serialized = serialize(tx, "hex");
+        expect(serialized).equals(SERIALIZED);
+    });
+    it("Sign, serialize, deserialize then sign again", function () {
+        let tx = buildTx(params);
+        sign(tx, PRIVATE_KEY1);
+        tx = deserialize(serialize(tx));
+        sign(tx, PRIVATE_KEY2);
+        const serialized = serialize(tx, "hex");
+        expect(serialized).equals(SERIALIZED);
+    });
+    it("Sign then serialize, deserialize", function () {
+        let tx = buildTx(params);
+        sign(tx, PRIVATE_KEY1);
+        sign(tx, PRIVATE_KEY2);
+        tx = deserialize(serialize(tx));
+        const serialized = serialize(tx, "hex");
+        expect(serialized).equals(SERIALIZED);
+    });
+});


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
Serializing a Transaction object with  `toBytes()`  before signing it will corrupt the object in a way which will prevent any further signing. Also serializing after signing and then attempting a second signature fails for the same reason. Here I submit test cases that should all be successful and a proposed solution. Maybe there is a better fix for this.

It is not only `toBytes()` that corrupts the transaction object, it is also `getSignatures()` and `getTransactionhash()`. Which is not expected, as they are get-functions.

The use case for mixed signing and serializing is when we want to send a transaction through IPC for signing by a different process. This used to work in the 1.x verion of the Javascript SDK.

To reproduce the issue revert the commit that modifies `Transaction.js`, then run:
```
npm run test:unit:single test/unit/Serialize.js 
```
Some test will fail, after enabling the fix, all will succeed which is the expected behaviour.


