### PR TITLE
fix: requests should retry on `INTERNAL` and switch nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+### Unreleased
+
+### Fixed
+
+ * Requests should retry on `INTERNAL` consistently
+
 ## v2.6.0
 
 ### Added

--- a/src/Executable.js
+++ b/src/Executable.js
@@ -16,7 +16,7 @@ export const ExecutionState = {
     Error: "Error",
 };
 
-export const RST_STREAM = /\brst[^0-9a-zA-Z]stream\b/gi;
+export const RST_STREAM = /\brst[^0-9a-zA-Z]stream\b/i;
 
 /**
  * @abstract

--- a/src/query/CostQuery.js
+++ b/src/query/CostQuery.js
@@ -30,6 +30,7 @@ export default class CostQuery extends Executable {
         super();
 
         this._query = query;
+        this._nodeIds = query._nodeIds;
 
         /**
          * @type {proto.IQueryHeader | null}
@@ -149,7 +150,15 @@ export default class CostQuery extends Executable {
      * @returns {AccountId}
      */
     _getNodeAccountId() {
-        return this._query._getNodeAccountId();
+        if (this._nodeIds.length > 0) {
+            // if there are payment transactions,
+            // we need to use the node of the current payment transaction
+            return this._nodeIds[this._nextNodeIndex];
+        } else {
+            throw new Error(
+                "(BUG) nodeAccountIds were not set for query before executing"
+            );
+        }
     }
 }
 

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -1,43 +1,45 @@
-import { AccountInfoQuery } from "../src/exports.js";
-import Mocker, { UNAVAILABLE, PRIVATE_KEY } from "./Mocker.js";
+import { AccountInfoQuery, AccountId } from "../src/exports.js";
+import Mocker, { UNAVAILABLE, INTERNAL, PRIVATE_KEY } from "./Mocker.js";
 import Long from "long";
+
+const ACCOUNT_INFO_QUERY_COST_RESPONSE = {
+    cryptoGetInfo: {
+        header: {
+            nodeTransactionPrecheckCode: 0,
+            responseType: 2,
+            cost: Long.fromNumber(25),
+        },
+    },
+};
+
+const ACCOUNT_INFO_QUERY_RESPONSE = {
+    cryptoGetInfo: {
+        header: { nodeTransactionPrecheckCode: 0 },
+        accountInfo: {
+            accountID: {
+                shardNum: Long.ZERO,
+                realmNum: Long.ZERO,
+                accountNum: Long.fromNumber(10),
+            },
+            key: {
+                ed25519: PRIVATE_KEY.publicKey.toBytes(),
+            },
+            expirationTime: {
+                seconds: Long.fromNumber(10),
+                nanos: 9,
+            },
+        },
+    },
+};
 
 describe("AccountInfo", function () {
     it("should retry on `UNAVAILABLE`", async function () {
-        const { client, server } = await Mocker.withResponses([
-            { error: UNAVAILABLE },
-            {
-                response: {
-                    cryptoGetInfo: {
-                        header: {
-                            nodeTransactionPrecheckCode: 0,
-                            responseType: 2,
-                            cost: Long.fromNumber(25),
-                        },
-                    },
-                },
-            },
-            {
-                response: {
-                    cryptoGetInfo: {
-                        header: { nodeTransactionPrecheckCode: 0 },
-                        accountInfo: {
-                            accountID: {
-                                shardNum: Long.ZERO,
-                                realmNum: Long.ZERO,
-                                accountNum: Long.fromNumber(10),
-                            },
-                            key: {
-                                ed25519: PRIVATE_KEY.publicKey.toBytes(),
-                            },
-                            expirationTime: {
-                                seconds: Long.fromNumber(10),
-                                nanos: 9,
-                            },
-                        },
-                    },
-                },
-            },
+        const { client, servers } = await Mocker.withResponses([
+            [
+                { error: UNAVAILABLE },
+                { response: ACCOUNT_INFO_QUERY_COST_RESPONSE },
+                { response: ACCOUNT_INFO_QUERY_RESPONSE },
+            ],
         ]);
 
         const info = await new AccountInfoQuery()
@@ -46,6 +48,37 @@ describe("AccountInfo", function () {
 
         expect(info.accountId.toString()).to.be.equal("0.0.10");
 
-        server.close();
+        servers.close();
+    });
+
+    it("should retry on `INTERNAL` and retry multiple nodes", async function () {
+        this.timeout(10000);
+
+        const responses1 = [
+            { error: INTERNAL },
+            { response: ACCOUNT_INFO_QUERY_COST_RESPONSE },
+            { error: INTERNAL },
+            { error: INTERNAL },
+        ];
+
+        const responses2 = [
+            { error: INTERNAL },
+            { error: INTERNAL },
+            { response: ACCOUNT_INFO_QUERY_RESPONSE },
+        ];
+
+        const { client, servers } = await Mocker.withResponses([
+            responses1,
+            responses2,
+        ]);
+
+        const info = await new AccountInfoQuery()
+            .setNodeAccountIds([new AccountId(3), new AccountId(4)])
+            .setAccountId("0.0.3")
+            .execute(client);
+
+        expect(info.accountId.toString()).to.be.equal("0.0.10");
+
+        servers.close();
     });
 });


### PR DESCRIPTION
Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #622 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
We technically did retry on `INTERNAL`, but because `RST_STREAM` regex had a `/g` flag `RST_STREAM.test(error.message)` would only pass on the first call. Any subsequent calls to `RST_STREAM.test(error.message)` would fail even if the message is identical. This is why it was not caught by our previous tests. Added a new test that uses two nodes, and returns `INTERNAL` errors multiple times from each node. I think this test can be used to cover the fact we retry on `INTERNAL` *and* switch nodes each time.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
