### PR TITLE
fix: don't use `>>> 32`

### DIFF
--- a/packages/cryptography/src/util/derive.js
+++ b/packages/cryptography/src/util/derive.js
@@ -18,7 +18,7 @@ export function legacy(seed, index) {
 
     if (index === 0xffffffffff) {
         view.setInt32(seed.length + 0, 0xff);
-        view.setInt32(seed.length + 4, index >>> 32);
+        view.setInt32(seed.length + 4, -1); // 0xffffffff
     } else {
         view.setInt32(seed.length + 0, index < 0 ? -1 : 0);
         view.setInt32(seed.length + 4, index);


### PR DESCRIPTION
**Description**:

_This shouldn't change the behavior at all, just a semantic / code style fix._

Fixes https://github.com/hashgraph/hedera-sdk-js/pull/441#discussion_r760734855

`index >>> 32` is always `0xFFFFFFFF` here.

1. Shifts operate on 32-bit numbers, so the arguments are cast to 32-bit integers.
2. Only 5 bits of the shift are effective, so `>>> 32` is equivalent to  `>>> 0`.
3. The is inside an `index === 0xffffffffff` check.

This way of writing down `0xFFFFFFFF` is confusing, as that's not what one might expect for `0xFFFFFFFFFF >>> 32` to be.


```console
> 0xFFFFFFFFFF >>> 32
4294967295
> 0xFFFFFFFFFF >>> 0
4294967295
> 0xFFFFFFFF
4294967295
> 0xFF
255
```

This PR changes that to a simple hardcoded value.

We could also have used `0xffffffff` there.
Not sure why it's using `view.setInt32` instead of a more semantically correct `view.setUint32` there though.

Refs: https://262.ecma-international.org/11.0/#sec-numeric-types-number-unsignedRightShift
Refs: https://262.ecma-international.org/11.0/#table-numeric-type-ops

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
