### PR TITLE
fix: update keccak256 implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-### v2.7.0-beta.3
+## v2.7.0-beta.4
+
+### Fixed
+
+ * Signing data which contains bytes larger than a value of 127
+ * `[Private|Public]Key.fromBytesEcdsa()` checking for the wrong bytes length
+
+## v2.7.0-beta.3
 
 ### Added
 
@@ -16,13 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
  * `TokenUpdateTransaction.setsupplyKey()` - use `setSupplyKey()` instead
 
-### v2.7.0-beta.2
+## v2.7.0-beta.2
 
 ### Added
 
  * `[Private|Public]Key.toAccountId()`
 
-### v2.7.0-beta.1
+## v2.7.0-beta.1
 
 ### Added
 

--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     },
     "dependencies": {
         "@grpc/grpc-js": "^1.4.4",
-        "@hashgraph/cryptography": "^1.1.0-beta.4",
+        "@hashgraph/cryptography": "link:packages/cryptography",
         "@hashgraph/proto": "2.1.1",
         "bignumber.js": "^9.0.1",
         "crypto-js": "^4.1.1",

--- a/packages/cryptography/src/EcdsaPrivateKey.js
+++ b/packages/cryptography/src/EcdsaPrivateKey.js
@@ -70,7 +70,7 @@ export default class EcdsaPrivateKey {
         switch (data.length) {
             case 32:
                 return EcdsaPrivateKey.fromBytesRaw(data);
-            case 45:
+            case 50:
                 return EcdsaPrivateKey.fromBytesDer(data);
             default:
                 throw new BadKeyError(

--- a/packages/cryptography/src/EcdsaPublicKey.js
+++ b/packages/cryptography/src/EcdsaPublicKey.js
@@ -70,7 +70,7 @@ export default class EcdsaPublicKey extends Key {
      * @returns {EcdsaPublicKey}
      */
     static fromBytesRaw(data) {
-        if (data.length != 32) {
+        if (data.length != 33) {
             throw new BadKeyError(
                 `invalid public key length: ${data.length} bytes`
             );
@@ -107,10 +107,12 @@ export default class EcdsaPublicKey extends Key {
      * @returns {Uint8Array}
      */
     toBytesDer() {
-        const bytes = new Uint8Array(derPrefixBytes.length + 32);
+        const bytes = new Uint8Array(
+            derPrefixBytes.length + this._keyData.length
+        );
 
         bytes.set(derPrefixBytes, 0);
-        bytes.set(this._keyData.subarray(0, 32), derPrefixBytes.length);
+        bytes.set(this._keyData, derPrefixBytes.length);
 
         return bytes;
     }
@@ -119,7 +121,7 @@ export default class EcdsaPublicKey extends Key {
      * @returns {Uint8Array}
      */
     toBytesRaw() {
-        return this._keyData.slice();
+        return new Uint8Array(this._keyData.subarray());
     }
 
     /**

--- a/packages/cryptography/src/PrivateKey.js
+++ b/packages/cryptography/src/PrivateKey.js
@@ -357,7 +357,14 @@ export default class PrivateKey extends Key {
                 sigPair.pubKeyPrefix != null &&
                 hex.encode(sigPair.pubKeyPrefix) === publicKeyHex
             ) {
-                return /** @type {Uint8Array} */ (sigPair.ed25519);
+                switch (this._type) {
+                    case "ED25519":
+                        return /** @type {Uint8Array} */ (sigPair.ed25519);
+                    case "secp256k1":
+                        return /** @type {Uint8Array} */ (
+                            sigPair.ECDSASecp256k1
+                        );
+                }
             }
         }
 
@@ -370,10 +377,13 @@ export default class PrivateKey extends Key {
             pubKeyPrefix: this.publicKey.toBytesRaw(),
         };
 
-        if (this._key instanceof Ed25519PrivateKey) {
-            protoSignature.ed25519 = siganture;
-        } else {
-            protoSignature.ECDSASecp256k1 = siganture;
+        switch (this._type) {
+            case "ED25519":
+                protoSignature.ed25519 = siganture;
+                break;
+            case "secp256k1":
+                protoSignature.ECDSASecp256k1 = siganture;
+                break;
         }
 
         tx.sigMap.sigPair.push(protoSignature);

--- a/packages/cryptography/src/primitive/ecdsa.js
+++ b/packages/cryptography/src/primitive/ecdsa.js
@@ -49,7 +49,8 @@ export function fromBytes(data) {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function sign(keydata, message) {
-    const data = keccak256(message);
+    const msg = hex.encode(message);
+    const data = hex.decode(keccak256(`0x${msg}`));
     const keypair = secp256k1.keyFromPrivate(keydata);
     const signature = keypair.sign(data);
 
@@ -70,7 +71,8 @@ export function sign(keydata, message) {
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export function verify(keydata, message, signature) {
-    const data = keccak256(message);
+    const msg = hex.encode(message);
+    const data = hex.decode(keccak256(`0x${msg}`));
     const keypair = secp256k1.keyFromPublic(keydata);
 
     return keypair.verify(data, {

--- a/packages/cryptography/test/unit/EcdsaPrivateKey.js
+++ b/packages/cryptography/test/unit/EcdsaPrivateKey.js
@@ -36,4 +36,19 @@ describe("EcdsaPrivateKey", function () {
         expect(key.publicKey.verify(message, signature)).to.be.true;
         expect(key.publicKey.toBytesRaw().length).to.be.equal(33);
     });
+
+    it("can sign and verify body bytes", function () {
+        const key = EcdsaPrivateKey.fromStringRaw(RAW_KEY);
+        const message = hex.decode(
+            "0a0e0a0408011001120608001000180412060800100018031880c2d72f220208783200721a0a180a0a0a0608001000180410130a0a0a060800100018051014"
+        );
+        const signature = key.sign(message);
+
+        expect(signature.length).to.be.equal(64);
+        expect(hex.encode(signature)).to.be.equal(
+            "63201532040178a60e2738bdaaa00d628004b15d109162fa42e066fcb6720190bc7b8c440eaa028009404d56bebeea7f9c94d4dc07042c63cb0bcf0cab0ee737"
+        );
+        expect(key.publicKey.verify(message, signature)).to.be.true;
+        expect(key.publicKey.toBytesRaw().length).to.be.equal(33);
+    });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ specifiers:
   '@babel/register': ^7.16.0
   '@grpc/grpc-js': ^1.4.4
   '@grpc/proto-loader': ^0.6.7
-  '@hashgraph/cryptography': ^1.1.0-beta.4
+  '@hashgraph/cryptography': link:packages/cryptography
   '@hashgraph/proto': 2.1.1
   '@types/chai': ^4.2.22
   '@types/crypto-js': ^4.0.2
@@ -53,7 +53,7 @@ specifiers:
 
 dependencies:
   '@grpc/grpc-js': 1.4.4
-  '@hashgraph/cryptography': 1.1.0-beta.4
+  '@hashgraph/cryptography': link:packages/cryptography
   '@hashgraph/proto': 2.1.1
   bignumber.js: 9.0.1
   crypto-js: 4.1.1
@@ -450,20 +450,6 @@ packages:
       long: 4.0.0
       protobufjs: 6.11.2
       yargs: 16.2.0
-
-  /@hashgraph/cryptography/1.1.0-beta.4:
-    resolution: {integrity: sha512-3HwMDzxH6TZIbOmpKpuIL5OXj9yaz3qBqO/SUWbyIg+CTZf5ge6y/qex4+n+4wXdAtL4qcyR0rbQN0TZO+udhw==}
-    engines: {node: '>=12.0.0'}
-    dependencies:
-      bignumber.js: 9.0.1
-      crypto-js: 4.1.1
-      elliptic: 6.5.4
-      expo-crypto: 9.2.0
-      expo-random: 11.2.0
-      js-base64: 3.7.2
-      tweetnacl: 1.0.3
-      utf8: 3.0.0
-    dev: false
 
   /@hashgraph/proto/2.1.1:
     resolution: {integrity: sha512-SdaBzVJtQH3v9oS+qHtwSYbhoxE/1BpNwfoOaKCS+S2MebjeyVTPMKBUgIiPa1AQScdeZdj5KTn4saUy+X9adg==}
@@ -1976,6 +1962,7 @@ packages:
 
   /base64-js/1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
+    dev: true
 
   /bcrypt-pbkdf/1.0.2:
     resolution: {integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=}
@@ -2008,10 +1995,6 @@ packages:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
     dev: true
 
-  /bn.js/4.12.0:
-    resolution: {integrity: sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA==}
-    dev: false
-
   /brace-expansion/1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
     dependencies:
@@ -2025,10 +2008,6 @@ packages:
     dependencies:
       fill-range: 7.0.1
     dev: true
-
-  /brorand/1.1.0:
-    resolution: {integrity: sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=}
-    dev: false
 
   /browser-stdout/1.3.1:
     resolution: {integrity: sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==}
@@ -2814,18 +2793,6 @@ packages:
     resolution: {integrity: sha512-YKaB+t8ul5crdh6OeqT2qXdxJGI0fAYb6/X8pDIyye+c3a7ndOCk5gVeKX+ABwivCGNS56vOAif3TN0qJMpEHw==}
     dev: true
 
-  /elliptic/6.5.4:
-    resolution: {integrity: sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==}
-    dependencies:
-      bn.js: 4.12.0
-      brorand: 1.1.0
-      hash.js: 1.1.7
-      hmac-drbg: 1.0.1
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
-    dev: false
-
   /emoji-regex/7.0.3:
     resolution: {integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==}
     dev: true
@@ -3382,16 +3349,6 @@ packages:
       signal-exit: 3.0.6
       strip-final-newline: 2.0.0
     dev: true
-
-  /expo-crypto/9.2.0:
-    resolution: {integrity: sha512-jc9E7jHlOT8fYs64DIsSOdnLtxtIK1pV78O/nBamPwKdGrvFSNqMSFndxyVSuEimBNoPPNRwN+4Pb4W1RRltJA==}
-    dev: false
-
-  /expo-random/11.2.0:
-    resolution: {integrity: sha512-kgBJBB02iCX/kpoTHN57V7b4hWOCj4eACIQDl7bN94lycUcZu62T00P/rVZIcE/29x0GAi+Pw5ZWj0NlqBsMQQ==}
-    dependencies:
-      base64-js: 1.5.1
-    dev: false
 
   /extend/3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3954,13 +3911,6 @@ packages:
       function-bind: 1.1.1
     dev: true
 
-  /hash.js/1.1.7:
-    resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
-    dependencies:
-      inherits: 2.0.4
-      minimalistic-assert: 1.0.1
-    dev: false
-
   /hasha/5.2.2:
     resolution: {integrity: sha512-Hrp5vIK/xr5SkeN2onO32H0MgNZ0f17HRNH39WfL0SYUNOTZ5Lz1TJ8Pajo/87dYGEFlLMm7mIc/k/s6Bvz9HQ==}
     engines: {node: '>=8'}
@@ -3973,14 +3923,6 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: true
-
-  /hmac-drbg/1.0.1:
-    resolution: {integrity: sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=}
-    dependencies:
-      hash.js: 1.1.7
-      minimalistic-assert: 1.0.1
-      minimalistic-crypto-utils: 1.0.1
-    dev: false
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -4129,6 +4071,7 @@ packages:
 
   /inherits/2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+    dev: true
 
   /ini/1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
@@ -4979,14 +4922,6 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
     dev: true
-
-  /minimalistic-assert/1.0.1:
-    resolution: {integrity: sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==}
-    dev: false
-
-  /minimalistic-crypto-utils/1.0.1:
-    resolution: {integrity: sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo=}
-    dev: false
 
   /minimatch/3.0.4:
     resolution: {integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==}
@@ -6982,10 +6917,6 @@ packages:
   /tweetnacl/0.14.5:
     resolution: {integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=}
     dev: true
-
-  /tweetnacl/1.0.3:
-    resolution: {integrity: sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==}
-    dev: false
 
   /type-check/0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}

--- a/src/account/AccountBalance.js
+++ b/src/account/AccountBalance.js
@@ -27,10 +27,6 @@ import TokenDecimalMap from "./TokenDecimalMap.js";
  * @property {TokenBalanceJson[]} tokens
  */
 
-/**
- * @typedef {import("@hashgraph/cryptography").Key} Key
- */
-
 export default class AccountBalance {
     /**
      * @private

--- a/src/account/LiveHashDeleteTransaction.js
+++ b/src/account/LiveHashDeleteTransaction.js
@@ -14,7 +14,6 @@ import AccountId from "./AccountId.js";
  */
 
 /**
- * @typedef {import("@hashgraph/cryptography").Key} Key
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId

--- a/src/contract/ContractExecuteTransaction.js
+++ b/src/contract/ContractExecuteTransaction.js
@@ -21,7 +21,6 @@ import Long from "long";
 
 /**
  * @typedef {import("bignumber.js").default} BigNumber
- * @typedef {import("@hashgraph/cryptography").Key} Key
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../client/Client.js").default<*, *>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId

--- a/src/contract/ContractFunctionSelector.js
+++ b/src/contract/ContractFunctionSelector.js
@@ -1,4 +1,5 @@
 import { keccak256 } from "../cryptography/keccak.js";
+import * as hex from "../encoding/hex.js";
 
 /**
  * @enum {number}
@@ -267,7 +268,7 @@ export default class ContractFunctionSelector {
             throw new Error("`name` required for ContractFunctionSelector");
         }
 
-        return new Uint8Array(keccak256(this.toString()).slice(0, 4));
+        return hex.decode(keccak256(this.toString()).slice(0, 4));
     }
 
     /**

--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -1,5 +1,5 @@
 import * as entity_id from "../EntityIdHelper.js";
-import { Key } from "@hashgraph/cryptography";
+import Key from "../Key.js";
 import * as proto from "@hashgraph/proto";
 import CACHE from "../Cache.js";
 

--- a/src/token/TokenFeeScheduleUpdateTransaction.js
+++ b/src/token/TokenFeeScheduleUpdateTransaction.js
@@ -19,7 +19,6 @@ import CustomRoyaltyFee from "./CustomRoyaltyFee.js";
 
 /**
  * @typedef {import("bignumber.js").default} BigNumber
- * @typedef {import("@hashgraph/cryptography").Key} Key
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("./CustomFee.js").default} CustomFee

--- a/src/token/TokenNftInfo.js
+++ b/src/token/TokenNftInfo.js
@@ -17,9 +17,6 @@ import * as hex from "../encoding/hex.js";
  * @typedef {import("@hashgraph/proto").IDuration} proto.IDuration
  */
 
-/**
- * @typedef {import("@hashgraph/cryptography").Key} Key
- */
 export default class TokenNftInfo {
     /**
      * @private

--- a/src/transaction/NodeAccountIdSignatureMap.js
+++ b/src/transaction/NodeAccountIdSignatureMap.js
@@ -1,4 +1,4 @@
-import { PublicKey } from "@hashgraph/cryptography";
+import PublicKey from "../PublicKey.js";
 import ObjectMap from "../ObjectMap.js";
 
 /**
@@ -19,11 +19,18 @@ export default class NodeAccountIdSignatureMap extends ObjectMap {
         const sigPairs = sigMap.sigPair != null ? sigMap.sigPair : [];
 
         for (const sigPair of sigPairs) {
-            if (sigPair.pubKeyPrefix != null && sigPair.ed25519 != null) {
-                signatures._set(
-                    PublicKey.fromBytes(sigPair.pubKeyPrefix),
-                    sigPair.ed25519
-                );
+            if (sigPair.pubKeyPrefix != null) {
+                if (sigPair.ed25519 != null) {
+                    signatures._set(
+                        PublicKey.fromBytesED25519(sigPair.pubKeyPrefix),
+                        sigPair.ed25519
+                    );
+                } else if (sigPair.ECDSASecp256k1 != null) {
+                    signatures._set(
+                        PublicKey.fromBytesECDSA(sigPair.pubKeyPrefix),
+                        sigPair.ECDSASecp256k1
+                    );
+                }
             }
         }
 

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -800,7 +800,11 @@ export default class Transaction extends Executable {
             this._nextTransactionIndex * this._nodeIds.length +
             this._nextNodeIndex;
 
-        await this._buildTransactionAsync(index);
+        if (this._signOnDemand) {
+            await this._buildTransactionAsync(index);
+        } else {
+            this._buildTransaction(index);
+        }
 
         return /** @type {proto.ITransaction} */ (this._transactions[index]);
     }
@@ -884,6 +888,8 @@ export default class Transaction extends Executable {
                 this._transactions.push(null);
             }
         }
+
+        // console.log(JSON.stringify(this._signedTransactions[index]));
 
         this._transactions[index] = {
             signedTransactionBytes: ProtoSignedTransaction.encode(

--- a/test/integration/AccountCreateIntegrationTest.js
+++ b/test/integration/AccountCreateIntegrationTest.js
@@ -1,6 +1,7 @@
 import {
     AccountCreateTransaction,
     AccountDeleteTransaction,
+    TransferTransaction,
     AccountInfoQuery,
     Hbar,
     PrivateKey,
@@ -51,6 +52,51 @@ describe("AccountCreate", function () {
                     .sign(key)
             ).execute(env.client)
         ).getReceipt(env.client);
+
+        await env.close();
+    });
+
+    it("should be able to create an account with an ECDSA private key", async function () {
+        this.timeout(120000);
+
+        const env = await IntegrationTestEnv.new();
+
+        const key = PrivateKey.generateECDSA();
+
+        const response = await new AccountCreateTransaction()
+            .setKey(key.publicKey)
+            .setInitialBalance(new Hbar(2))
+            .execute(env.client);
+
+        const receipt = await response.getReceipt(env.client);
+
+        expect(receipt.accountId).to.not.be.null;
+        const account = receipt.accountId;
+
+        const info = await new AccountInfoQuery()
+            .setNodeAccountIds([response.nodeId])
+            .setAccountId(account)
+            .execute(env.client);
+
+        expect(info.accountId.toString()).to.be.equal(account.toString());
+        expect(info.isDeleted).to.be.false;
+        expect(info.key.toString()).to.be.equal(key.publicKey.toString());
+        expect(info.balance.toTinybars().toNumber()).to.be.equal(
+            new Hbar(2).toTinybars().toNumber()
+        );
+        expect(info.autoRenewPeriod.seconds.toNumber()).to.be.equal(7776000);
+        expect(info.proxyAccountId).to.be.null;
+        expect(info.proxyReceived.toTinybars().toNumber()).to.be.equal(0);
+
+        const transaction = new TransferTransaction()
+            .setNodeAccountIds([response.nodeId])
+            .setTransactionId(TransactionId.generate(account))
+            .addHbarTransfer(account, Hbar.fromTinybars(10).negated())
+            .addHbarTransfer(env.operatorId, Hbar.fromTinybars(10))
+            .freezeWith(env.client);
+
+        await transaction.sign(key);
+        await transaction.execute(env.client);
 
         await env.close();
     });

--- a/test/unit/AccountId.js
+++ b/test/unit/AccountId.js
@@ -1,7 +1,7 @@
 import AccountId from "../src/account/AccountId.js";
 import BigNumber from "bignumber.js";
 import { Client } from "../integration/client/NodeIntegrationTestEnv.js";
-import { PublicKey } from "@hashgraph/cryptography";
+import PublicKey from "../src/PublicKey.js";
 
 describe("AccountId", function () {
     it("constructors", function () {

--- a/test/unit/EcdsaPrivateKey.js
+++ b/test/unit/EcdsaPrivateKey.js
@@ -1,0 +1,29 @@
+import PrivateKey from "../src/PrivateKey.js";
+import * as hex from "../src/encoding/hex.js";
+
+const RAW_KEY =
+    "8776c6b831a1b61ac10dac0304a2843de4716f54b1919bb91a2685d0fe3f3048";
+
+describe("PrivateKey", function () {
+    it("generate should return  object", function () {
+        PrivateKey.generateECDSA();
+    });
+
+    it("generateAsync should return  object", async function () {
+        await PrivateKey.generateECDSAAsync();
+    });
+
+    it("fromStringRaw and fromStringDer work", function () {
+        PrivateKey.fromString(
+            hex.encode(PrivateKey.fromStringECDSA(RAW_KEY).toBytesDer())
+        );
+    });
+
+    it("public key fro a private key", function () {
+        expect(
+            PrivateKey.fromStringECDSA(RAW_KEY).publicKey.toStringRaw()
+        ).to.be.equal(
+            "02703a9370b0443be6ae7c507b0aec81a55e94e4a863b9655360bd65358caa6588"
+        );
+    });
+});

--- a/test/unit/PublicKey.js
+++ b/test/unit/PublicKey.js
@@ -7,7 +7,8 @@ import {
 
 describe("PublicKey", function () {
     it("`verifyTransaction` works", async function () {
-        const key = PrivateKey.generateED25519();
+        const key1 = PrivateKey.generateED25519();
+        const key2 = PrivateKey.generateECDSA();
 
         const transaction = new TransferTransaction()
             .setTransactionId(TransactionId.generate(new AccountId(5)))
@@ -16,15 +17,19 @@ describe("PublicKey", function () {
             .addHbarTransfer("0.0.4", 1)
             .freeze();
 
-        await transaction.sign(key);
+        await transaction.sign(key1);
+        await transaction.sign(key2);
 
-        expect(key.publicKey.verifyTransaction(transaction)).to.be.true;
+        expect(key1.publicKey.verifyTransaction(transaction)).to.be.true;
+        expect(key2.publicKey.verifyTransaction(transaction)).to.be.true;
 
         const signatures = transaction.getSignatures();
+        expect(signatures.size).to.be.equal(1);
 
         for (const [nodeAccountId, nodeSignatures] of signatures) {
             expect(nodeAccountId.toString()).equals("0.0.6");
 
+            expect(nodeSignatures.size).to.be.equal(2);
             for (const [publicKey] of nodeSignatures) {
                 expect(publicKey.verifyTransaction(transaction)).to.be.true;
             }

--- a/test/unit/keccak256.js
+++ b/test/unit/keccak256.js
@@ -3,11 +3,32 @@ import * as hex from "../src/encoding/hex.js";
 
 describe("keccak256", function () {
     it("should hash to the expected value", function () {
-        const hashBytes = keccak256("method");
-        const hash = hex.encode(hashBytes);
+        const hash = keccak256("method");
 
         expect(hash).to.eql(
-            "9c87604675c4160b0aac6ee753604a7ebe1728c804a0ac841ff8bb02e543aa3a"
+            "0x9c87604675c4160b0aac6ee753604a7ebe1728c804a0ac841ff8bb02e543aa3a"
+        );
+    });
+
+    it("should hash to the expected value for bytes larger than 127", function () {
+        const hash = keccak256(
+            hex.decode("0x00112233445566778899aabbccddeeff")
+        );
+
+        expect(hash).to.eql(
+            "0x22bce46032802af0abfacf3768f7be04a34f5f01df60f44ffd52d3ca937350c0"
+        );
+    });
+
+    it("should hash body bytes correctly", function () {
+        const hash = keccak256(
+            hex.decode(
+                "0x0a0e0a0408011001120608001000180412060800100018031880c2d72f220208783200721a0a180a0a0a0608001000180410130a0a0a060800100018051014"
+            )
+        );
+
+        expect(hash).to.eql(
+            "0x90c1c5bb75d76d3cfed2c136525ffbcf381b4b3909cefd11b68b26ce6f9999b6"
         );
     });
 });


### PR DESCRIPTION
Signed-off-by: Daniel Akhterov <daniel@launchbadge.com>

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #844 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

Took a bit to get through this rabbit hole, but ended up discovering that our `keccak256` implementation (copied from [eth-lib](https://github.com/MaiaVictor/eth-lib/blob/da0971f5b09964d9c8449975fa87933f0c9fef35/src/hash.js)) only worked on data where no byte exceeded 127. This could of been a result of us trying to add types and clean up the code, but honestly not sure. Anyways, copied the current implementation and added tests for larger bytes and also a realistic set of bytes. Also added a simple e2e test from the issue linked above.

While I was testing this though, I discovered we were checking for the wrong byte lengths in `[Private|Public]Key.fromBytesECDSA()` when raw bytes were provided; was a quick fix.

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
