### PR TITLE
Fix for incorrect dates returned in receipts from ExchangeRate.js

### DIFF
--- a/src/ExchangeRate.js
+++ b/src/ExchangeRate.js
@@ -74,7 +74,7 @@ export default class ExchangeRate {
             hbarEquiv: this.hbars,
             centEquiv: this.cents,
             expirationTime: {
-                seconds: Long.fromNumber(this.expirationTime.getSeconds()),
+                seconds: Long.fromNumber(Math.trunc(this.expirationTime.getTime() / 1000)),
             },
         };
     }

--- a/test/unit/ExchangeRates.js
+++ b/test/unit/ExchangeRates.js
@@ -1,7 +1,7 @@
 import "mocha";
 import { expect } from "chai";
-
-import { ExchangeRates } from "../../src/exports.js";
+import Long from "long";
+import { ExchangeRates, ExchangeRate } from "../../src/exports.js";
 
 const exchangeRateSetBytes = Buffer.from(
     "0a1008b0ea0110b6b4231a0608f0bade9006121008b0ea01108cef231a060880d7de9006",
@@ -35,5 +35,16 @@ describe("ExchangeRates", function () {
         expect(exchangeRate).to.equal(
             exchangeRateSet.nextRate.exchangeRateInCents
         );
+    });
+});
+
+describe("ExchangeRate", function () {
+    it("fromBytes", function () {
+         const expirationTime = new Date("February 24, 2022 15:00:00 UTC");
+         const props = {
+             expirationTime: expirationTime,
+           }
+         const exchangeRate = new ExchangeRate(props);
+         expect(exchangeRate._toProtobuf().expirationTime.seconds).to.deep.equal(Long.fromValue({ low: 1645714800, high: 0, unsigned: false }));
     });
 });


### PR DESCRIPTION
**Description**:
This should fix the incorrect receipt problem with Exchange.js.  

This PR modifies exchange.js' expiration time to return time in seconds (default time for getTime() is in millis, so this is divided by 1000) instead of just the seconds field. Added a unit test to demonstrate the fix.
**Related issue(s)**:
https://github.com/hashgraph/hedera-sdk-js/issues/966


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [n/a ] Documented (Code comments, README, etc.)
- [ ✓] Tested (unit, integration, etc.)
