### PR TITLE
This is some linting related changes.

### DIFF
--- a/test/integration/TokenBurnIntegrationTest.js
+++ b/test/integration/TokenBurnIntegrationTest.js
@@ -1,5 +1,4 @@
 import {
-    Hbar,
     Status,
     TokenBurnTransaction,
     TokenCreateTransaction,

--- a/test/integration/TokenMintIntegrationTest.js
+++ b/test/integration/TokenMintIntegrationTest.js
@@ -1,5 +1,4 @@
 import {
-    Hbar,
     Status,
     TokenCreateTransaction,
     TokenMintTransaction,

--- a/test/unit/TransferTransaction.js
+++ b/test/unit/TransferTransaction.js
@@ -164,7 +164,11 @@ describe("TransferTransaction", function () {
 
         const transaction = new TransferTransaction()
             // Insert in reverse order to confirm they get reordered
-            .addNftTransfer(tokenId4, serialNum1, accountId2, accountId4)
+            .addNftTransfer(
+                new NftId(tokenId4, serialNum1),
+                accountId2,
+                accountId4
+            )
             .addNftTransfer(tokenId4, serialNum1, accountId1, accountId3)
             .addNftTransfer(tokenId3, serialNum1, accountId1, accountId2)
             .addTokenTransferWithDecimals(tokenId2, accountId4, -1, 10)


### PR DESCRIPTION
**Description**:
Removes a couple of imports and formats stuff.

This PR modifies TransferTransaction, TokenMintIntegrationTest, TokenBurnIntegrationTest in order to remove unused imports and format a line for linting. It should be cosmetic besides maybe making linting less distracting.

**Related issue(s)**:
n/a
Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
