### PR TITLE
Bug fix for issue #1087 - "Cannot find setExpirationTime in TopicUpdateTransaction"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## v2.13.0-beta.1
 
+### Fixed
+ 
+ * `TopicUpdateTransaction` should be able to call [get|set]ExpirationTime().
+ * `Status` should contain a return code for 314. 
+
 ### Added 
 
  * `ContractFunctionResult.[gas|amount|functionParameters]`

--- a/src/Status.js
+++ b/src/Status.js
@@ -585,6 +585,8 @@ export default class Status {
                 return "WRONG_NONCE";
             case Status.AccessListUnsupported:
                 return "ACCESS_LIST_UNSUPPORTED";
+            case Status.SchedulePendingExpiration:
+                return "SCHEDULE_PENDING_EXPIRATION";
             default:
                 return `UNKNOWN (${this._code})`;
         }
@@ -1141,6 +1143,8 @@ export default class Status {
                 return Status.WrongNonce;
             case 313:
                 return Status.AccessListUnsupported;
+            case 314:
+                return Status.SchedulePendingExpiration;
             default:
                 throw new Error(
                     `(BUG) Status.fromCode() does not handle code: ${code}`
@@ -2551,3 +2555,8 @@ Status.WrongNonce = new Status(312);
  * The ethereum transaction specified an access list, which the network does not support.
  */
 Status.AccessListUnsupported = new Status(313);
+
+/**
+ * The scheduled transaction is pending expiration.
+ */
+Status.SchedulePendingExpiration = new Status(314);

--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -25,6 +25,7 @@ import AccountId from "../account/AccountId.js";
 import TopicId from "./TopicId.js";
 import Duration from "../Duration.js";
 import Key from "../Key.js";
+import Timestamp from "../Timestamp.js";
 
 /**
  * @namespace proto
@@ -61,6 +62,7 @@ export default class TopicUpdateTransaction extends Transaction {
      * @param {Duration | Long | number} [props.autoRenewPeriod]
      * @param {AccountId | string} [props.autoRenewAccountId]
      * @param {string} [props.topicMemo]
+     * @param {Timestamp | Date} [props.expirationTime]
      */
     constructor(props = {}) {
         super();
@@ -124,6 +126,16 @@ export default class TopicUpdateTransaction extends Transaction {
         if (props.autoRenewPeriod != null) {
             this.setAutoRenewPeriod(props.autoRenewPeriod);
         }
+
+        /**
+         * @private
+         * @type {?Timestamp}
+         */
+        this._expirationTime = null;
+
+        if (props.expirationTime != null) {
+            this.setExpirationTime(props.expirationTime);
+        }
     }
 
     /**
@@ -178,6 +190,10 @@ export default class TopicUpdateTransaction extends Transaction {
                             ? update.memo.value
                             : undefined
                         : undefined,
+                expirationTime:
+                    update.expirationTime != null
+                        ? Timestamp._fromProtobuf(update.expirationTime)
+                        : undefined
             }),
             transactions,
             signedTransactions,
@@ -185,6 +201,28 @@ export default class TopicUpdateTransaction extends Transaction {
             nodeIds,
             bodies
         );
+    }
+
+    /**
+     * @returns {?Timestamp}
+     */
+    get expirationTime() {
+        return this._expirationTime;
+    }
+
+    /**
+     * @param {Timestamp | Date | null} expirationTime
+     * @returns {TopicUpdateTransaction}
+     */
+    setExpirationTime(expirationTime) {
+        this._requireFrozen();
+
+        this._expirationTime =
+            expirationTime instanceof Date
+                ? Timestamp.fromDate(expirationTime)
+                : expirationTime;
+
+        return this;
     }
 
     /**
@@ -416,6 +454,10 @@ export default class TopicUpdateTransaction extends Transaction {
             autoRenewPeriod:
                 this._autoRenewPeriod != null
                     ? this._autoRenewPeriod._toProtobuf()
+                    : null,
+            expirationTime:
+                this._expirationTime != null
+                    ? this._expirationTime._toProtobuf()
                     : null,
         };
     }


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR modifies `TopicUpdateTransaction` with the ability to get and set the expiration time for a given transaction. Also fixes a failing unit test for `Status` by adding a response code for `Status.SCHEDULE_PENDING_EXPIRATION` set to `314`.

**Related issue(s)**:

Fixes #1087 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
