### PR TITLE
1090 Enable the SDK to retrieve a record even if a transaction failed

### DIFF
--- a/src/transaction/TransactionResponse.js
+++ b/src/transaction/TransactionResponse.js
@@ -98,7 +98,7 @@ export default class TransactionResponse {
     async getRecord(client) {
         await this.getReceipt(client);
 
-        return await this.getRecordQuery()
+        return this.getRecordQuery()
             .execute(client);
     }
 

--- a/src/transaction/TransactionResponse.js
+++ b/src/transaction/TransactionResponse.js
@@ -77,9 +77,7 @@ export default class TransactionResponse {
      * @returns {Promise<TransactionReceipt>}
      */
     async getReceipt(client) {
-        const receipt = await new TransactionReceiptQuery()
-            .setTransactionId(this.transactionId)
-            .setNodeAccountIds([this.nodeId])
+        const receipt = await this.getReceiptQuery()
             .execute(client);
 
         if (receipt.status !== Status.Success) {
@@ -100,9 +98,7 @@ export default class TransactionResponse {
     async getRecord(client) {
         await this.getReceipt(client);
 
-        return new TransactionRecordQuery()
-            .setTransactionId(this.transactionId)
-            .setNodeAccountIds([this.nodeId])
+        return await this.getRecordQuery()
             .execute(client);
     }
 

--- a/src/transaction/TransactionResponse.js
+++ b/src/transaction/TransactionResponse.js
@@ -107,6 +107,24 @@ export default class TransactionResponse {
     }
 
     /**
+     * @returns {TransactionReceiptQuery}
+     */
+    getReceiptQuery() {
+        return new TransactionReceiptQuery()
+            .setTransactionId(this.transactionId)
+            .setNodeAccountIds([this.nodeId]);
+    }
+
+    /**
+     * @returns {TransactionRecordQuery}
+     */
+    getRecordQuery() {
+        return new TransactionRecordQuery()
+            .setTransactionId(this.transactionId)
+            .setNodeAccountIds([this.nodeId]);
+    }
+
+    /**
      * @returns {TransactionResponseJSON}
      */
     toJSON() {

--- a/test/integration/TransactionResponseTest.js
+++ b/test/integration/TransactionResponseTest.js
@@ -41,4 +41,72 @@ describe("TransactionResponse", function () {
 
         await env.close();
     });
+
+    it("should make a transaction receipt query available", async function() {
+        this.timeout(120000);
+
+        const env = await IntegrationTestEnv.new();
+        const operatorId = env.operatorId;
+        expect(operatorId).to.not.be.null;
+
+        const key = PrivateKey.generateED25519();
+
+        const transaction = await new AccountCreateTransaction()
+            .setKey(key.publicKey)
+            .execute(env.client);
+
+        const transactionReceiptQuery = transaction.getReceiptQuery();
+        expect(transactionReceiptQuery).to.not.be.null;
+
+        const record = await transaction.getRecord(env.client);
+
+        const account = record.receipt.accountId;
+        expect(account).to.not.be.null;
+
+        await (
+            await (
+                await new AccountDeleteTransaction()
+                    .setAccountId(account)
+                    .setTransferAccountId(operatorId)
+                    .freezeWith(env.client)
+                    .sign(key)
+            ).execute(env.client)
+        ).getReceipt(env.client);
+
+        await env.close();
+    })
+
+    it("should make a transaction record query available", async function() {
+        this.timeout(120000);
+
+        const env = await IntegrationTestEnv.new();
+        const operatorId = env.operatorId;
+        expect(operatorId).to.not.be.null;
+
+        const key = PrivateKey.generateED25519();
+
+        const transaction = await new AccountCreateTransaction()
+            .setKey(key.publicKey)
+            .execute(env.client);
+
+        const transactionRecordQuery = transaction.getRecordQuery();
+        expect(transactionRecordQuery).to.not.be.null;
+
+        const record = await transaction.getRecord(env.client);
+
+        const account = record.receipt.accountId;
+        expect(account).to.not.be.null;
+
+        await (
+            await (
+                await new AccountDeleteTransaction()
+                    .setAccountId(account)
+                    .setTransferAccountId(operatorId)
+                    .freezeWith(env.client)
+                    .sign(key)
+            ).execute(env.client)
+        ).getReceipt(env.client);
+
+        await env.close();
+    })
 });


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR modifies the following:
- adds `getReceiptQuery()` to `TransactionResponse`
- adds `getRecordQuery()` to `TransactionResponse`
- adds applicable integration tests to ensure the new methods return their respective queries after a transaction has been executed.

**Related issue(s)**:

Fixes #1090 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
