### PR TITLE
Bug/1121 deprecate allowancefields

### DIFF
--- a/src/account/AccountInfo.js
+++ b/src/account/AccountInfo.js
@@ -31,11 +31,8 @@ import PublicKey from "../PublicKey.js";
 import LedgerId from "../LedgerId.js";
 
 /**
- * @deprecated - no longer supported 
  * @typedef {import("./HbarAllowance.js").default} HbarAllowance
- * @deprecated - no longer supported
  * @typedef {import("./TokenAllowance.js").default} TokenAllowance
- * @deprecated - no longer supported
  * @typedef {import("./TokenNftAllowance.js").default} TokenNftAllowance
  */
 
@@ -86,11 +83,8 @@ export default class AccountInfo {
      * @param {Long} props.maxAutomaticTokenAssociations
      * @param {PublicKey | null} props.aliasKey
      * @param {LedgerId | null} props.ledgerId
-     * @deprecated - no longer supported
      * @param {HbarAllowance[]} props.hbarAllowances
-     * @deprecated - no longer supported
      * @param {TokenAllowance[]} props.tokenAllowances
-     * @deprecated - no longer supported
      * @param {TokenNftAllowance[]} props.nftAllowances
      */
     constructor(props) {
@@ -209,17 +203,17 @@ export default class AccountInfo {
 
         this.ledgerId = props.ledgerId;
         /*
-        *@deprecated - no longer supported
-        */
+         * @deprecated - no longer supported
+         */
         this.hbarAllowances = props.hbarAllowances;
         /*
-        *@deprecated - no longer supported
-        */
+         * @deprecated - no longer supported
+         */
         this.tokenAllowances = props.tokenAllowances;
         /*
-        *@deprecated - no longer supported
-        */
-       this.nftAllowances = props.nftAllowances;
+         * @deprecated - no longer supported
+         */
+        this.nftAllowances = props.nftAllowances;
 
         Object.freeze(this);
     }
@@ -314,16 +308,16 @@ export default class AccountInfo {
                     ? LedgerId.fromBytes(info.ledgerId)
                     : null,
             /*
-            *@deprecated - no longer supported
-            */
+             * @deprecated - no longer supported
+             */
             hbarAllowances: [],
             /*
-            *@deprecated - no longer supported
-            */
+             * @deprecated - no longer supported
+             */
             tokenAllowances: [],
             /*
-            *@deprecated - no longer supported
-            */
+             * @deprecated - no longer supported
+             */
             nftAllowances: [],
         });
     }

--- a/src/account/AccountInfo.js
+++ b/src/account/AccountInfo.js
@@ -307,17 +307,8 @@ export default class AccountInfo {
                 info.ledgerId != null
                     ? LedgerId.fromBytes(info.ledgerId)
                     : null,
-            /*
-             * @deprecated - no longer supported
-             */
             hbarAllowances: [],
-            /*
-             * @deprecated - no longer supported
-             */
             tokenAllowances: [],
-            /*
-             * @deprecated - no longer supported
-             */
             nftAllowances: [],
         });
     }

--- a/src/account/AccountInfo.js
+++ b/src/account/AccountInfo.js
@@ -31,8 +31,11 @@ import PublicKey from "../PublicKey.js";
 import LedgerId from "../LedgerId.js";
 
 /**
+ * @deprecated - no longer supported 
  * @typedef {import("./HbarAllowance.js").default} HbarAllowance
+ * @deprecated - no longer supported
  * @typedef {import("./TokenAllowance.js").default} TokenAllowance
+ * @deprecated - no longer supported
  * @typedef {import("./TokenNftAllowance.js").default} TokenNftAllowance
  */
 
@@ -83,8 +86,11 @@ export default class AccountInfo {
      * @param {Long} props.maxAutomaticTokenAssociations
      * @param {PublicKey | null} props.aliasKey
      * @param {LedgerId | null} props.ledgerId
+     * @deprecated - no longer supported
      * @param {HbarAllowance[]} props.hbarAllowances
+     * @deprecated - no longer supported
      * @param {TokenAllowance[]} props.tokenAllowances
+     * @deprecated - no longer supported
      * @param {TokenNftAllowance[]} props.nftAllowances
      */
     constructor(props) {
@@ -202,12 +208,18 @@ export default class AccountInfo {
         this.aliasKey = props.aliasKey;
 
         this.ledgerId = props.ledgerId;
-
+        /*
+        *@deprecated - no longer supported
+        */
         this.hbarAllowances = props.hbarAllowances;
-
+        /*
+        *@deprecated - no longer supported
+        */
         this.tokenAllowances = props.tokenAllowances;
-
-        this.nftAllowances = props.nftAllowances;
+        /*
+        *@deprecated - no longer supported
+        */
+       this.nftAllowances = props.nftAllowances;
 
         Object.freeze(this);
     }
@@ -301,9 +313,17 @@ export default class AccountInfo {
                 info.ledgerId != null
                     ? LedgerId.fromBytes(info.ledgerId)
                     : null,
-
+            /*
+            *@deprecated - no longer supported
+            */
             hbarAllowances: [],
+            /*
+            *@deprecated - no longer supported
+            */
             tokenAllowances: [],
+            /*
+            *@deprecated - no longer supported
+            */
             nftAllowances: [],
         });
     }


### PR DESCRIPTION
**Description**:
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR adds deprecation comments to AccountInfo to let people know that hbarallowance, tokenallowance and nftallowance are presently deprecated as they cannot presently be removed


**Related issue(s)**:

Fixes #1121 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ X] Documented (Code comments, README, etc.)
- [ X] Tested (unit, integration, etc.)
