### PR TITLE
Deprecating existing setMaxGasAllowance method and adding setMaxGasAl…

### DIFF
--- a/src/EthereumFlow.js
+++ b/src/EthereumFlow.js
@@ -81,7 +81,7 @@ export default class EthereumFlow {
         }
 
         if (props.maxGasAllowance != null) {
-            this.setMaxGasAllowance(props.maxGasAllowance);
+            this.setMaxGasAllowanceHbar(props.maxGasAllowance);
         }
     }
 
@@ -115,23 +115,31 @@ export default class EthereumFlow {
     }
 
     /**
-     * The maximum amount, in tinybars, that the payer of the hedera transaction
-     * is willing to pay to complete the transaction.
-     *
-     * Ordinarily the account with the ECDSA alias corresponding to the public
-     * key that is extracted from the ethereum_data signature is responsible for
-     * fees that result from the execution of the transaction. If that amount of
-     * authorized fees is not sufficient then the payer of the transaction can be
-     * charged, up to but not exceeding this amount. If the ethereum_data
-     * transaction authorized an amount that was insufficient then the payer will
-     * only be charged the amount needed to make up the difference. If the gas
-     * price in the transaction was set to zero then the payer will be assessed
-     * the entire fee.
-     *
+     * @deprecated - use masGasAllowanceHbar instead.
      * @param {number | string | Long | BigNumber | Hbar} maxGasAllowance
      * @returns {this}
      */
     setMaxGasAllowance(maxGasAllowance) {
+        return this.setMaxGasAllowanceHbar(maxGasAllowance);
+    }
+
+    /** 
+    * The maximum amount, in tinybars, that the payer of the hedera transaction
+    * is willing to pay to complete the transaction.
+    *
+    * Ordinarily the account with the ECDSA alias corresponding to the public
+    * key that is extracted from the ethereum_data signature is responsible for
+    * fees that result from the execution of the transaction. If that amount of
+    * authorized fees is not sufficient then the payer of the transaction can be
+    * charged, up to but not exceeding this amount. If the ethereum_data
+    * transaction authorized an amount that was insufficient then the payer will
+    * only be charged the amount needed to make up the difference. If the gas
+    * price in the transaction was set to zero then the payer will be assessed
+    * the entire fee.
+    * @param {number | string | Long | BigNumber | Hbar} maxGasAllowance
+    * @returns {this}
+    */
+    setMaxGasAllowanceHbar(maxGasAllowance){
         this._maxGasAllowance =
             maxGasAllowance instanceof Hbar
                 ? maxGasAllowance
@@ -156,7 +164,7 @@ export default class EthereumFlow {
         const ethereumTransactionDataBytes = this._ethereumData.toBytes();
 
         if (this._maxGasAllowance != null) {
-            ethereumTransaction.setMaxGasAllowance(this._maxGasAllowance);
+            ethereumTransaction.setMaxGasAllowanceHbar(this._maxGasAllowance);
         }
 
         if (this._callDataFileId != null) {

--- a/src/EthereumTransaction.js
+++ b/src/EthereumTransaction.js
@@ -85,7 +85,7 @@ export default class EthereumTransaction extends Transaction {
         }
 
         if (props.maxGasAllowance != null) {
-            this.setMaxGasAllowance(props.maxGasAllowance);
+            this.setMaxGasAllowanceHbar(props.maxGasAllowance);
         }
     }
 
@@ -156,7 +156,6 @@ export default class EthereumTransaction extends Transaction {
 
     /**
      * @deprecated - Use `callDataFileId` instead
-     *
      * @returns {?FileId}
      */
     get callData() {
@@ -171,7 +170,6 @@ export default class EthereumTransaction extends Transaction {
      * the callData element as a zero length string with the original contents in
      * the referenced file at time of execution. The callData will need to be
      * "rehydrated" with the callData for signature validation to pass.
-     *
      * @param {FileId} callDataFileId
      * @returns {this}
      */
@@ -210,6 +208,15 @@ export default class EthereumTransaction extends Transaction {
     }
 
     /**
+     * @deprecated -- use setMaxGasAllowanceHbar instead
+     * @param {number | string | Long | BigNumber | Hbar} maxGasAllowance
+     * @returns {this}
+     */
+         setMaxGasAllowance(maxGasAllowance) {
+            return this.setMaxGasAllowanceHbar(maxGasAllowance);
+        }
+
+    /**
      * The maximum amount, in tinybars, that the payer of the hedera transaction
      * is willing to pay to complete the transaction.
      *
@@ -226,7 +233,7 @@ export default class EthereumTransaction extends Transaction {
      * @param {number | string | Long | BigNumber | Hbar} maxGasAllowance
      * @returns {this}
      */
-    setMaxGasAllowance(maxGasAllowance) {
+    setMaxGasAllowanceHbar(maxGasAllowance) {
         this._requireNotFrozen();
         this._maxGasAllowance =
             maxGasAllowance instanceof Hbar

--- a/test/unit/EthereumTransaction.js
+++ b/test/unit/EthereumTransaction.js
@@ -29,7 +29,7 @@ describe("EthereumTransaction", function () {
             .setNodeAccountIds([nodeAccountId])
             .setEthereumData(ethereumData)
             .setCallDataFileId(callData)
-            .setMaxGasAllowance(maxGasAllowance)
+            .setMaxGasAllowanceHbar(maxGasAllowance)
             .freeze();
 
         transaction = Transaction.fromBytes(transaction.toBytes());
@@ -56,7 +56,7 @@ describe("EthereumTransaction", function () {
             )
             .setNodeAccountIds([nodeAccountId])
             .setEthereumData(ethereumData)
-            .setMaxGasAllowance(maxGasAllowance)
+            .setMaxGasAllowanceHbar(maxGasAllowance)
             .freeze();
 
         transaction = Transaction.fromBytes(transaction.toBytes());


### PR DESCRIPTION
…lowanceHbar to be consistent with java sdk.

Signed-off-by: Keira Black <keirablack@Keiras-MacBook-Pro.local>

**Description**:
Deprecated existing setMaxGasAllowance methods 
added setMaxGasAllowanceHbar (same functionality new name, old functions still work but passed through and annotated deprecated)

This bugfix modifies EthereumFlow, EthereumTransaction and the EthereumTransaction unit tests to support issue #1131 

**Related issue(s)**:

Fixes #1131 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ x] Documented (Code comments, README, etc.)
- [ x] Tested (unit, integration, etc.)
