### PR TITLE
Possible fix. changed 'freeze' to 'seal' in constructor.

### DIFF
--- a/src/transaction/TransactionId.js
+++ b/src/transaction/TransactionId.js
@@ -65,7 +65,7 @@ export default class TransactionId {
             this.setNonce(nonce);
         }
 
-        Object.freeze(this);
+        Object.seal(this);
     }
 
     /**


### PR DESCRIPTION
**Description**:
setNonce isn't working on main because the constructor freezes the object during creation. I changed the line to seal the object instead which still allows writing to writeable fields.

This PR modifies TransactionID in order to support writeability generally

**Related issue(s)**:

Fixes #1186 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.) - n/a just a one line change
- [X] Tested (unit, integration, etc.) - ran unit tests, they passed okay. The example code given to demo the error on 1186 passes after this change and there are no new 'bugs' as such. 
