### PR TITLE
fix: undeprecate `*ContractId.fromSolidityAddress()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.18.0
+
+### Fixed
+
+ * #1188 - Undeprecate `*ContractId.fromSolidityAddress()`
+
 ## v2.17.3
 
 ### Fixed

--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -144,13 +144,10 @@ export default class ContractId extends Key {
     }
 
     /**
-     * @deprecated - Use `ContractId.fromEvmAddress()` instead
      * @param {string} address
      * @returns {ContractId}
      */
     static fromSolidityAddress(address) {
-        console.warn("Deprecated: use `ContractId.fromEvmAdress()` instead");
-
         const [shard, realm, contract] = entity_id.fromSolidityAddress(address);
         return new ContractId(shard, realm, contract);
     }

--- a/src/contract/DelegateContractId.js
+++ b/src/contract/DelegateContractId.js
@@ -80,7 +80,6 @@ export default class DelegateContractId extends ContractId {
     }
 
     /**
-     * @deprecated - Use `DelegateContractId.fromEvmAddress()` instead
      * @param {string} address
      * @returns {DelegateContractId}
      */


### PR DESCRIPTION
**Related issue(s)**:

Fixes #1188

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
