### PR TITLE
fix typo in function name

### DIFF
--- a/src/contract/ContractCreateFlow.js
+++ b/src/contract/ContractCreateFlow.js
@@ -226,7 +226,7 @@ export default class ContractCreateFlow {
      * @param {number} maxAutomaticTokenAssociation
      * @returns {this}
      */
-    setMaxAutomaticTokenAssociation(maxAutomaticTokenAssociation) {
+    setMaxAutomaticTokenAssociations(maxAutomaticTokenAssociation) {
         this._contractCreate.setMaxAutomaticTokenAssociations(
             maxAutomaticTokenAssociation
         );


### PR DESCRIPTION
Fix function name according to documentation.

[Docs](https://docs.hedera.com/guides/docs/sdks/smart-contracts/create-a-smart-contract) state ContractCreateFlow inherits names from ContractCreateTransaction:

> Note: Please refer to ContractCreateTransaction()  for a complete list of applicable methods.

Function's name in ContractCreateTransaction is `setMaxAutomaticTokenAssociations`. Therefore the same name must be used in ContractCreateFlow