### PR TITLE
fix: `PublicKey.equals()` should use `other._key`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.18.1
+
+### Fixed
+
+ * `PublicKey.equals()`
+
 ## v2.18.0
 
 ### Added

--- a/packages/cryptography/src/PublicKey.js
+++ b/packages/cryptography/src/PublicKey.js
@@ -229,14 +229,14 @@ export default class PublicKey extends Key {
     equals(other) {
         if (
             this._key instanceof Ed25519PublicKey &&
-            other instanceof Ed25519PublicKey
+            other._key instanceof Ed25519PublicKey
         ) {
-            return this._key.equals(other);
+            return this._key.equals(other._key);
         } else if (
             this._key instanceof EcdsaPublicKey &&
-            other instanceof EcdsaPublicKey
+            other._key instanceof EcdsaPublicKey
         ) {
-            return this._key.equals(other);
+            return this._key.equals(other._key);
         } else {
             return false;
         }

--- a/packages/cryptography/test/unit/PublicKey.js
+++ b/packages/cryptography/test/unit/PublicKey.js
@@ -1,3 +1,4 @@
+import PrivateKey from "../../src/PrivateKey.js";
 import PublicKey from "../../src/PublicKey.js";
 import * as hex from "../../src/encoding/hex.js";
 
@@ -23,5 +24,16 @@ describe("PublicKey", function () {
         const key = PublicKey.fromBytesECDSA(TRUFFLE_KEY_BYTES);
 
         expect(key.toEthereumAddress()).to.be.equal(TRUFFLE_ADDRESS);
+    });
+
+    it("equals", async function () {
+        const ed25519 = PrivateKey.generate().publicKey;
+        const ed25519Copy = PublicKey.fromString(ed25519.toStringRaw());
+        const ecdsa = PrivateKey.generateECDSA().publicKey;
+
+        expect(ed25519.toStringRaw()).to.be.equal(ed25519Copy.toStringRaw());
+
+        expect(ed25519.equals(ed25519Copy)).to.be.true;
+        expect(ed25519.equals(ecdsa)).to.be.false;
     });
 });


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #1245 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
