### PR TITLE
Fix for TopicUpdateTransaction

### DIFF
--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -215,7 +215,7 @@ export default class TopicUpdateTransaction extends Transaction {
      * @returns {TopicUpdateTransaction}
      */
     setExpirationTime(expirationTime) {
-        this._requireFrozen();
+        // this._requireFrozen();
 
         this._expirationTime =
             expirationTime instanceof Date

--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -215,7 +215,7 @@ export default class TopicUpdateTransaction extends Transaction {
      * @returns {TopicUpdateTransaction}
      */
     setExpirationTime(expirationTime) {
-        // this._requireFrozen();
+        this._requireNotFrozen();
 
         this._expirationTime =
             expirationTime instanceof Date


### PR DESCRIPTION
**Description**:
Cannot setExpirationTime in TopicUpdateTransaction because frozen is required.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
I tried to remove this line and it seems to works normally. The other properties (i.e. setTopicId) checks for requireNotFrozen. So I think it might have been a typo.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
