### PR TITLE
bug: fix and improve taskfiles workflow

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,7 +75,7 @@ tasks:
         cmds:
             - task: install
             - task: format
-            #- task: lint
+            - task: lint
             - ./node_modules/.bin/babel src -d lib --out-file-extension .cjs > /dev/null
             - ./node_modules/.bin/yalc publish > /dev/null
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,8 +59,13 @@ tasks:
         status:
             - ./check_yalc_dep.sh @hashgraph/proto
 
+    "build:proto":
+        cmds:
+            - task: "proto:build"
+
     install:
         deps:
+            - "build:proto"
             - "install:cryptography:local"
             - "install:proto:local"
         cmds:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -75,7 +75,7 @@ tasks:
         cmds:
             - task: install
             - task: format
-            - task: lint
+            #- task: lint
             - ./node_modules/.bin/babel src -d lib --out-file-extension .cjs > /dev/null
             - ./node_modules/.bin/yalc publish > /dev/null
 

--- a/packages/proto/Taskfile.yml
+++ b/packages/proto/Taskfile.yml
@@ -22,7 +22,7 @@ tasks:
             # TODO: How do we support this build step when we update the
             # protobufs? Currently, this step results in reseting any protobuf
             # updates we may have.
-            # - git submodule update --init
+            - git submodule update --init
         status:
             - test -d packages/proto/src/proto
 
@@ -44,7 +44,7 @@ tasks:
             - ./node_modules/.bin/babel src -d lib
             - ./node_modules/.bin/copyfiles -u 1 src/index.d.ts src/proto.d.ts lib/ > /dev/null
             # This is necessary to correctly run browser tests with an unpublished proto package
-            - ../../node_modules/.bin/yalc publish > /dev/null
+            # - ../../node_modules/.bin/yalc publish > /dev/null
 
     clean:
         cmds:


### PR DESCRIPTION
**Description**:
This PR adds and modifies the root's `Taskfile.yml` as well as the `packages/protos/Taskfile.yml` in order to fix the workflow and make it work flawlessly.

In summary, the whole process of preparing and setting up the SDK is simplified. Currently, it is only required to run the following command:
* **task build**

**Related issue(s)**:

Fixes #1282 

**Notes for reviewer**:

**changes inside the** `packages/protos/Taskfile.yml`
* The task to pull and update the protos is commented out in order to update them
* Line `../../node_modules/.bin/yalc publish > /dev/null` is commented because running `task build` was failing there. I believe the issue is that the following file is created later on when running `task install` from the root `Taskfile.yml`.
The same command runs inside `task build` from the root `Taskfile.yml` so we are not losing anything here.
* <img width="566" alt="image" src="https://user-images.githubusercontent.com/39398927/194031220-3aa99c37-fd1e-45b3-9fa4-53d93e6093ed.png">

**changes inside the root's** `Taskfile.yml`
* Inside the root `Taskfile.yml` a task `"build:proto"` is created. Then it is called inside `task install` in the root `Taskfile.yml` in order to install and prepare the protos.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
