### PR TITLE
Fix the offset for uint24 & int24 datatypes in contract functions params

### DIFF
--- a/src/contract/ContractFunctionParameters.js
+++ b/src/contract/ContractFunctionParameters.js
@@ -1644,14 +1644,14 @@ function argumentToBytes(param, ty) {
         case ArgumentType.uint24:
             numberToBytes(
                 /** @type {number | BigNumber } */ (param),
-                29,
+                28,
                 valueView.setUint32.bind(valueView)
             );
             return value;
         case ArgumentType.int24:
             numberToBytes(
                 /** @type {number | BigNumber } */ (param),
-                29,
+                28,
                 valueView.setInt32.bind(valueView)
             );
             return value;

--- a/test/unit/ContractFunctionParameters.js
+++ b/test/unit/ContractFunctionParameters.js
@@ -31,6 +31,30 @@ describe("ContractFunctionParameters", function () {
         expect(cfp._arguments[0].value).to.eql(cfp._arguments[1].value);
     });
 
+    it("should convert number to BigNumber in addUint24()", function () {
+        const contractFunctionParameters = new ContractFunctionParameters();
+
+        const num = 111;
+        const cfp = contractFunctionParameters.addUint24(num);
+
+        const bigNum = BigNumber(111);
+        contractFunctionParameters.addUint24(bigNum);
+
+        expect(cfp._arguments[0].value).to.eql(cfp._arguments[1].value);
+    });
+
+    it("should convert number to BigNumber in addInt24()", function () {
+        const contractFunctionParameters = new ContractFunctionParameters();
+
+        const num = 111;
+        const cfp = contractFunctionParameters.addInt24(num);
+
+        const bigNum = BigNumber(111);
+        contractFunctionParameters.addInt24(bigNum);
+
+        expect(cfp._arguments[0].value).to.eql(cfp._arguments[1].value);
+    });
+
     it("should convert number to BigNumber in addUint256Array()", function () {
         const contractFunctionParameters = new ContractFunctionParameters();
 


### PR DESCRIPTION
**Description**:

Fix the offset for the Uint24 & Int24 Contract Function Params

**Related issue(s)**:

Fixes #1294 

**Notes for reviewer**:
The offset of Uint24 & Int24 needs to be changed. It is because they are cast to Uint32 & Int32. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
