### PR TITLE
Fix for fromBytes to return the range in PrngTransaction

### DIFF
--- a/src/PrngTransaction.js
+++ b/src/PrngTransaction.js
@@ -113,12 +113,10 @@ export default class PrngTransaction extends Transaction {
         nodeIds,
         bodies
     ) {
-        const body =
-            /** @type {HashgraphProto.proto.UtilPrngTransactionBody} */ (
-                bodies[0]
-            );
-
-        const transactionRange = body.range;
+        const body = /** @type {HashgraphProto.proto.ITransactionBody} */ (
+            bodies[0]
+        );
+        const transactionRange = body.utilPrng?.range;
 
         return Transaction._fromProtobufTransactions(
             new PrngTransaction({

--- a/test/unit/PrngTransaction.js
+++ b/test/unit/PrngTransaction.js
@@ -1,0 +1,28 @@
+import {
+    PrngTransaction,
+    Transaction,
+    AccountId,
+    Timestamp,
+    TransactionId,
+} from "../../src/index.js";
+
+describe("PrngTransaction", function () {
+    it("should return range when create transaction from Bytes", async function () {
+        const spenderAccountId = new AccountId(1);
+        const timestamp = new Timestamp(14, 15);
+
+        let transaction = await new PrngTransaction()
+            .setTransactionId(
+                TransactionId.withValidStart(spenderAccountId, timestamp)
+            )
+            .setNodeAccountIds([spenderAccountId])
+            .setRange(100)
+            .freeze();
+
+        const transactionToBytes = transaction.toBytes();
+
+        const transactionFromBytes = Transaction.fromBytes(transactionToBytes);
+
+        expect(transactionFromBytes.range).to.eql(100);
+    });
+});


### PR DESCRIPTION
**Description**:
Fix the `.fromBytes()` to return the range in a transaction created from `.toBytes`

**Related issue(s)**:

Fixes #1287

**Notes for reviewer**:
The problem was in wrong returning the range and wrong setter of the protobuf.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
