### PR TITLE
Added getters and deprecated old ones

### DIFF
--- a/src/topic/TopicCreateTransaction.js
+++ b/src/topic/TopicCreateTransaction.js
@@ -161,9 +161,17 @@ export default class TopicCreateTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getTopicMemo()` instead
      * @returns {?string}
      */
     get topicMemo() {
+        return this._topicMemo;
+    }
+
+    /**
+     * @returns {?string}
+     */
+    getTopicMemo() {
         return this._topicMemo;
     }
 
@@ -179,9 +187,17 @@ export default class TopicCreateTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getAdminKey()` instead
      * @returns {?Key}
      */
     get adminKey() {
+        return this._adminKey;
+    }
+
+    /**
+     * @returns {?Key}
+     */
+    getAdminKey() {
         return this._adminKey;
     }
 
@@ -197,9 +213,17 @@ export default class TopicCreateTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getSubmitKey()` instead
      * @returns {?Key}
      */
     get submitKey() {
+        return this._submitKey;
+    }
+
+    /**
+     * @returns {?Key}
+     */
+    getSubmitKey() {
         return this._submitKey;
     }
 
@@ -215,9 +239,17 @@ export default class TopicCreateTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getAutoRenewAccountId()` instead
      * @returns {?AccountId}
      */
     get autoRenewAccountId() {
+        return this._autoRenewAccountId;
+    }
+
+    /**
+     * @returns {?AccountId}
+     */
+    getAutoRenewAccountId() {
         return this._autoRenewAccountId;
     }
 
@@ -236,9 +268,17 @@ export default class TopicCreateTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getAutoRenewPeriod()` instead
      * @returns {Duration}
      */
     get autoRenewPeriod() {
+        return this._autoRenewPeriod;
+    }
+
+    /**
+     * @returns {Duration}
+     */
+    getAutoRenewPeriod() {
         return this._autoRenewPeriod;
     }
 

--- a/src/topic/TopicMessageSubmitTransaction.js
+++ b/src/topic/TopicMessageSubmitTransaction.js
@@ -162,9 +162,17 @@ export default class TopicMessageSubmitTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getMessage()` instead
      * @returns {?Uint8Array}
      */
     get message() {
+        return this._message;
+    }
+
+    /**
+     * @returns {?Uint8Array}
+     */
+    getMessage() {
         return this._message;
     }
 
@@ -181,9 +189,17 @@ export default class TopicMessageSubmitTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getMaxChunks()` instead
      * @returns {?number}
      */
     get maxChunks() {
+        return this._maxChunks;
+    }
+
+    /**
+     * @returns {?number}
+     */
+    getMaxChunks() {
         return this._maxChunks;
     }
 
@@ -198,9 +214,17 @@ export default class TopicMessageSubmitTransaction extends Transaction {
     }
 
     /**
+     * @deprecated  - Use `getChunkSize()` instead
      * @returns {?number}
      */
     get chunkSize() {
+        return this._chunkSize;
+    }
+
+    /**
+     * @returns {?number}
+     */
+    getChunkSize() {
         return this._chunkSize;
     }
 


### PR DESCRIPTION
**Description**:
Add getters in scope of getSomething() and marked the native getters as deprecated. The reason for that is because we want to keep consistent with the other SDKs.

**Related issue(s)**:

Fixes #1323 & #1324 

**Notes for reviewer**:
This was discussed with Simi, and we decided to keep the SDKs consistent and to bring back the getters of scope getSomething() instead of native JS getters where they are as class params.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
