### PR TITLE
Added proxies for different networks

### DIFF
--- a/src/client/WebClient.js
+++ b/src/client/WebClient.js
@@ -50,14 +50,27 @@ export const Network = {
 
     MAINNET: {
         "https://grpc-web.myhbarwallet.com:443": new AccountId(3),
+        "https://node01-00-grpc.swirlds.com:443": new AccountId(4)
     },
 
     TESTNET: {
-        "https://grpc-web.testnet.myhbarwallet.com:443": new AccountId(3),
+        "https://testnet-node00-00-grpc.hedera.com:443": new AccountId(3),
+        "https://testnet-node01-00-grpc.hedera.com:443": new AccountId(4),
+        "https://testnet-node02-00-grpc.hedera.com:443": new AccountId(5),
+        "https://testnet-node03-00-grpc.hedera.com:443": new AccountId(6),
+        "https://testnet-node04-00-grpc.hedera.com:443": new AccountId(7),
+        "https://testnet-node05-00-grpc.hedera.com:443": new AccountId(8),
+        "https://testnet-node06-00-grpc.hedera.com:443": new AccountId(9)
     },
 
     PREVIEWNET: {
-        "https://grpc-web.previewnet.myhbarwallet.com:443": new AccountId(3),
+        "https://previewnet-node00-00-grpc.hedera.com:443": new AccountId(3),
+        "https://previewnet-node01-00-grpc.hedera.com:443": new AccountId(4),
+        "https://previewnet-node02-00-grpc.hedera.com:443": new AccountId(5),
+        "https://previewnet-node03-00-grpc.hedera.com:443": new AccountId(6),
+        "https://previewnet-node04-00-grpc.hedera.com:443": new AccountId(7),
+        "https://previewnet-node05-00-grpc.hedera.com:443": new AccountId(8),
+        "https://previewnet-node06-00-grpc.hedera.com:443": new AccountId(9)
     },
 };
 


### PR DESCRIPTION
Signed-off-by: Petar Tonev <petar.tonev@limechain.tech>

**Description**:
Added several additional proxy URLs for mainnet, testnet and previewnet in regards to the web gRPC

**Related issue(s)**:

Fixes #1310

**Notes for reviewer**:
After the clarification about web gRPC, we added one additional proxy URL for `mainnet` and 7 proxy URLs for each node on `testnet` and `previewnet`

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
