### PR TITLE
Change param of getNftInfo from allowanceSpenderAccountId to spenderId

### DIFF
--- a/src/token/TokenNftInfo.js
+++ b/src/token/TokenNftInfo.js
@@ -47,7 +47,7 @@ export default class TokenNftInfo {
      * @param {Timestamp} props.creationTime
      * @param {Uint8Array | null} props.metadata
      * @param {LedgerId|null} props.ledgerId
-     * @param {AccountId|null} props.allowanceSpenderAccountId
+     * @param {AccountId|null} props.spenderId
      */
     constructor(props) {
         /**
@@ -74,7 +74,7 @@ export default class TokenNftInfo {
 
         this.ledgerId = props.ledgerId;
 
-        this.allowanceSpenderAccountId = props.allowanceSpenderAccountId;
+        this.spenderId = props.spenderId;
 
         Object.freeze(this);
     }
@@ -102,7 +102,7 @@ export default class TokenNftInfo {
                 info.ledgerId != null
                     ? LedgerId.fromBytes(info.ledgerId)
                     : null,
-            allowanceSpenderAccountId:
+            spenderId:
                 info.spenderId != null
                     ? AccountId._fromProtobuf(info.spenderId)
                     : null,
@@ -120,9 +120,7 @@ export default class TokenNftInfo {
             metadata: this.metadata,
             ledgerId: this.ledgerId != null ? this.ledgerId.toBytes() : null,
             spenderId:
-                this.allowanceSpenderAccountId != null
-                    ? this.allowanceSpenderAccountId._toProtobuf()
-                    : null,
+                this.spenderId != null ? this.spenderId._toProtobuf() : null,
         };
     }
 
@@ -133,7 +131,7 @@ export default class TokenNftInfo {
      * @property {string} creationTime
      * @property {string | null} metadata
      * @property {string | null} ledgerId
-     * @property {string | null} allowanceSpenderAccountId
+     * @property {string | null} spenderId
      * @returns {TokenNftInfoJson}
      */
     toJson() {
@@ -143,10 +141,8 @@ export default class TokenNftInfo {
             creationTime: this.creationTime.toString(),
             metadata: this.metadata != null ? hex.encode(this.metadata) : null,
             ledgerId: this.ledgerId != null ? this.ledgerId.toString() : null,
-            allowanceSpenderAccountId:
-                this.allowanceSpenderAccountId != null
-                    ? this.allowanceSpenderAccountId.toString()
-                    : null,
+            spenderId:
+                this.spenderId != null ? this.spenderId.toString() : null,
         };
     }
 


### PR DESCRIPTION
**Description**:
Change param of getNftInfo from allowanceSpenderAccountId to spenderId as listed in protobuf.

**Related issue(s)**:

Fixes #1332 

**Notes for reviewer**:
The change is needed because we want to be consistent with the protobuf specification

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
