### PR TITLE
Fix for optional param of transaction range

### DIFF
--- a/src/PrngTransaction.js
+++ b/src/PrngTransaction.js
@@ -116,11 +116,13 @@ export default class PrngTransaction extends Transaction {
         const body = /** @type {HashgraphProto.proto.ITransactionBody} */ (
             bodies[0]
         );
-        const transactionRange = body.utilPrng?.range;
-
+        const transactionRange =
+            /** @type {HashgraphProto.proto.IUtilPrngTransactionBody} */ (
+                body.utilPrng
+            );
         return Transaction._fromProtobufTransactions(
             new PrngTransaction({
-                range: transactionRange,
+                range: transactionRange.range,
             }),
             transactions,
             signedTransactions,


### PR DESCRIPTION
Signed-off-by: ochikov <ognyan@limechain.tech>

**Description**:
Fix for optimal param of transaction range when using PrngTransaction
**Related issue(s)**:

Fixes #1338 

**Notes for reviewer**:
Using `?.` the sdk can be build, but it cannot be used into React. 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
