### PR TITLE
KeyList now handles single key properly as first parameter

### DIFF
--- a/packages/cryptography/src/KeyList.js
+++ b/packages/cryptography/src/KeyList.js
@@ -15,7 +15,12 @@ export default class KeyList extends Key {
          * @private
          * @type {Key[]}
          */
-        this._keys = keys == null ? [] : keys;
+        // @ts-ignore
+        if (keys == null) this._keys = [];
+        //checks if the value for `keys` is passed as a single key
+        //rather than a list that contains just one key
+        else if (keys instanceof Key) this._keys = [keys];
+        else this._keys = keys;
 
         /**
          * @type {?number}
@@ -103,6 +108,7 @@ export default class KeyList extends Key {
      * @returns {Key[]}
      */
     toArray() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this._keys.slice();
     }
 

--- a/packages/cryptography/src/primitive/bip39.js
+++ b/packages/cryptography/src/primitive/bip39.js
@@ -8,7 +8,7 @@ import * as pbkdf2 from "./pbkdf2.js";
  */
 export async function toSeed(words, passphrase) {
     const input = words.join(" ");
-    const salt = (`mnemonic${passphrase}`).normalize("NFKD");
+    const salt = `mnemonic${passphrase}`.normalize("NFKD");
 
     return pbkdf2.deriveKey(hmac.HashAlgorithm.Sha512, input, salt, 2048, 64);
 }

--- a/packages/cryptography/test/unit/bip39.js
+++ b/packages/cryptography/test/unit/bip39.js
@@ -26,7 +26,7 @@ describe("bip39", function () {
         );
     });
 
-    it("mnemonic passphrase NFKD normalization compliant test", async function (){
+    it("mnemonic passphrase NFKD normalization compliant test", async function () {
         const words = [
             "inmate",
             "flip",
@@ -51,13 +51,15 @@ describe("bip39", function () {
             "replace",
             "reduce",
             "plate",
-            "home"
+            "home",
         ];
-        
-        const unicodePassphrase = "\u0070\u0061\u0073\u0073\u0070\u0068\u0072\u0061\u0073\u0065";
-        const expectedPrivateKey = "1ed95521b3406aa1e34db78be696db32f09d9f8ec3115fc12314082a44a3e8d6d4551a1905758b45bc315430f7d9c095da93645f1b0004c393370e0a878dfd4c";
 
-        const seed = await bip39.toSeed(words, unicodePassphrase)
+        const unicodePassphrase =
+            "\u0070\u0061\u0073\u0073\u0070\u0068\u0072\u0061\u0073\u0065";
+        const expectedPrivateKey =
+            "1ed95521b3406aa1e34db78be696db32f09d9f8ec3115fc12314082a44a3e8d6d4551a1905758b45bc315430f7d9c095da93645f1b0004c393370e0a878dfd4c";
+
+        const seed = await bip39.toSeed(words, unicodePassphrase);
 
         expect(hex.encode(seed)).to.be.equal(expectedPrivateKey);
     });

--- a/src/KeyList.js
+++ b/src/KeyList.js
@@ -43,7 +43,12 @@ export default class KeyList extends Key {
          * @private
          * @type {Key[]}
          */
-        this._keys = keys == null ? [] : keys;
+        // @ts-ignore
+        if (keys == null) this._keys = [];
+        //checks if the value for `keys` is passed as a single key
+        //rather than a list that contains just one key
+        else if (keys instanceof Key) this._keys = [keys];
+        else this._keys = keys;
 
         /**
          * @type {?number}
@@ -131,6 +136,7 @@ export default class KeyList extends Key {
      * @returns {Key[]}
      */
     toArray() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return
         return this._keys.slice();
     }
 
@@ -148,6 +154,7 @@ export default class KeyList extends Key {
      * @returns {HashgraphProto.proto.IKey}
      */
     _toProtobufKey() {
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return
         const keys = this._keys.map((key) => key._toProtobufKey());
 
         if (this.threshold == null) {


### PR DESCRIPTION
Signed-off-by: Petar Tonev <petar.tonev@limechain.tech>

**Description**:
There was an issue when passing a single key object as a first parameter to `KeyList`, since the SDK could not proceed when getting a non-list value. Now the SDK acts properly in these cases

**Related issue(s)**:

Fixes #1343 

**Notes for reviewer**:
Added some checks and proper handles based on parameter

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
