### PR TITLE
Fix typo in deprecation suggestion

### DIFF
--- a/packages/cryptography/src/PrivateKey.js
+++ b/packages/cryptography/src/PrivateKey.js
@@ -87,7 +87,7 @@ export default class PrivateKey extends Key {
     }
 
     /**
-     * Depredated - Use `generateEd25519()` instead
+     * Depredated - Use `generateED25519()` instead
      * Generate a random Ed25519 private key.
      *
      * @returns {PrivateKey}
@@ -97,7 +97,7 @@ export default class PrivateKey extends Key {
     }
 
     /**
-     * Depredated - Use `generateEd25519Async()` instead
+     * Depredated - Use `generateED25519Async()` instead
      * Generate a random Ed25519 private key.
      *
      * @returns {Promise<PrivateKey>}

--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -68,7 +68,7 @@ export default class PrivateKey extends Key {
     }
 
     /**
-     * Depredated - Use `generateEd25519()` instead
+     * Depredated - Use `generateED25519()` instead
      * Generate a random Ed25519 private key.
      *
      * @returns {PrivateKey}
@@ -78,7 +78,7 @@ export default class PrivateKey extends Key {
     }
 
     /**
-     * Depredated - Use `generateEd25519Async()` instead
+     * Depredated - Use `generateED25519Async()` instead
      * Generate a random Ed25519 private key.
      *
      * @returns {Promise<PrivateKey>}


### PR DESCRIPTION
**Description**:
Fix typo in the deprecation suggestion for `PrivateKey::generate`

**Related issue(s)**:

Fixes #1341 

**Notes for reviewer**:

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
