### PR TITLE
Add max execution time setter for NodeChannel GRPC

### DIFF
--- a/src/channel/NodeChannel.js
+++ b/src/channel/NodeChannel.js
@@ -36,11 +36,13 @@ export default class NodeChannel extends Channel {
      * @internal
      * @param {string} address
      * @param {string=} cert
+     * @param {number=} maxExecutionTime
      */
-    constructor(address, cert) {
+    constructor(address, cert, maxExecutionTime) {
         super();
 
         this.cert = cert;
+        this.maxExecutionTime = maxExecutionTime;
 
         let security;
         let options;
@@ -96,7 +98,7 @@ export default class NodeChannel extends Channel {
                     //Removed close of the client because taking more than 10s does not mean that the node is unavailable.
                     callback(new GrpcServicesError(GrpcStatus.Timeout));
                 }
-            }, 10_000);
+            }, this.maxExecutionTime);
 
             this._client.makeUnaryRequest(
                 `/proto.${serviceName}/${method.name}`,

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -83,6 +83,9 @@ export default class NodeClient extends Client {
     constructor(props) {
         super(props);
 
+        /** @private */
+        this._maxExecutionTime = 10000;
+
         if (props != null) {
             if (typeof props.network === "string") {
                 this._setNetworkFromName(props.network);
@@ -221,6 +224,17 @@ export default class NodeClient extends Client {
     }
 
     /**
+     * Available only for NodeClient
+     *
+     * @param {number} maxExecutionTime
+     * @returns {this}
+     */
+    setMaxExecutionTime(maxExecutionTime) {
+        this._maxExecutionTime = maxExecutionTime;
+        return this;
+    }
+
+    /**
      * @private
      * @param {string} name
      * @returns {this}
@@ -302,7 +316,8 @@ export default class NodeClient extends Client {
      * @returns {(address: string, cert?: string) => NodeChannel}
      */
     _createNetworkChannel() {
-        return (address, cert) => new NodeChannel(address, cert);
+        return (address, cert) =>
+            new NodeChannel(address, cert, this._maxExecutionTime);
     }
 
     /**

--- a/test/integration/AccountCreateIntegrationTest.js
+++ b/test/integration/AccountCreateIntegrationTest.js
@@ -203,7 +203,7 @@ describe("AccountCreate", function () {
         await (await transaction.execute(env.client)).getReceipt(env.client);
     });
 
-    it("should create account with a single key passed to `KeyList`", async function() {
+    it("should create account with a single key passed to `KeyList`", async function () {
         const env = await IntegrationTestEnv.new();
         const publicKey = PrivateKey.generateED25519().publicKey;
         const thresholdKey = new KeyList(publicKey, 1);


### PR DESCRIPTION
**Description**:
Added timeout setter in NodeChannel._createUnaryClient.

**Related issue(s)**:

Fixes #1276 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
