### PR TITLE
Add new status codes

### DIFF
--- a/src/Status.js
+++ b/src/Status.js
@@ -617,6 +617,10 @@ export default class Status {
                 return "MAX_CHILD_RECORDS_EXCEEDED";
             case Status.InsufficientBalancesForRenewalFees:
                 return "INSUFFICIENT_BALANCES_FOR_RENEWAL_FEES";
+            case Status.TransactionHasUnknownFields:
+                return "TRANSACTION_HAS_UNKNOWN_FIELDS";
+            case Status.AccountIsImmutable:
+                return "ACCOUNT_IS_IMMUTABLE";
             default:
                 return `UNKNOWN (${this._code})`;
         }
@@ -1205,6 +1209,10 @@ export default class Status {
                 return Status.MaxChildRecordsExceeded;
             case 329:
                 return Status.InsufficientBalancesForRenewalFees;
+            case 330:
+                return Status.TransactionHasUnknownFields;
+            case 331:
+                return Status.AccountIsImmutable;
             default:
                 throw new Error(
                     `(BUG) Status.fromCode() does not handle code: ${code}`
@@ -2700,3 +2708,14 @@ Status.MaxChildRecordsExceeded = new Status(328);
  * the auto-renewal fees in a transaction.
  */
 Status.InsufficientBalancesForRenewalFees = new Status(329);
+
+/**
+ * A transaction's protobuf message includes unknown fields; could mean that a client
+ * expects not-yet-released functionality to be available.
+ */
+Status.TransactionHasUnknownFields = new Status(330);
+
+/**
+ * The account cannot be modified. Account's key is not set
+ */
+Status.AccountIsImmutable = new Status(331);


### PR DESCRIPTION
Signed-off-by: Petar Tonev <petar.tonev@limechain.tech>

**Description**:
This PR adds mapping of the new status codes (`TRANSACTION_HAS_UNKNOWN_FIELDS and  ACCOUNT_IS_IMMUTABLE`) defined inside the [protobufs](https://github.com/hashgraph/hedera-protobufs/blob/ba840e5d37afd9f5b8283b862519587319bf994a/services/response_code.proto)

**Related issue(s)**:

Fixes #1399 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
