### PR TITLE
Removed unnecessary check

### DIFF
--- a/packages/cryptography/src/PrivateKey.js
+++ b/packages/cryptography/src/PrivateKey.js
@@ -337,8 +337,6 @@ export default class PrivateKey extends Key {
      * @returns {Uint8Array}
      */
     signTransaction(transaction) {
-        transaction._requireFrozen();
-
         if (!transaction.isFrozen()) {
             transaction.freeze();
         }

--- a/src/Status.js
+++ b/src/Status.js
@@ -617,6 +617,10 @@ export default class Status {
                 return "MAX_CHILD_RECORDS_EXCEEDED";
             case Status.InsufficientBalancesForRenewalFees:
                 return "INSUFFICIENT_BALANCES_FOR_RENEWAL_FEES";
+            case Status.TransactionHasUnknownFields:
+                return "TRANSACTION_HAS_UNKNOWN_FIELDS";
+            case Status.AccountIsImmutable:
+                return "ACCOUNT_IS_IMMUTABLE";
             default:
                 return `UNKNOWN (${this._code})`;
         }
@@ -1205,6 +1209,10 @@ export default class Status {
                 return Status.MaxChildRecordsExceeded;
             case 329:
                 return Status.InsufficientBalancesForRenewalFees;
+            case 330:
+                return Status.TransactionHasUnknownFields;
+            case 331:
+                return Status.AccountIsImmutable;
             default:
                 throw new Error(
                     `(BUG) Status.fromCode() does not handle code: ${code}`
@@ -2700,3 +2708,14 @@ Status.MaxChildRecordsExceeded = new Status(328);
  * the auto-renewal fees in a transaction.
  */
 Status.InsufficientBalancesForRenewalFees = new Status(329);
+
+/**
+ * A transaction's protobuf message includes unknown fields; could mean that a client
+ * expects not-yet-released functionality to be available.
+ */
+Status.TransactionHasUnknownFields = new Status(330);
+
+/**
+ * The account cannot be modified. Account's key is not set
+ */
+Status.AccountIsImmutable = new Status(331);


### PR DESCRIPTION
**Description**:
This PR removes an unnecessary check if a transaction is frozen

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
Previously we were performing a check if a transaction is frozen and throwing an error if its not. This check is not needed as right after the check, we automatically freeze the transaction if its not

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
