### PR TITLE
Fix inaccurate cost calculation

### DIFF
--- a/examples/create-stateful-contract.js
+++ b/examples/create-stateful-contract.js
@@ -155,8 +155,7 @@ async function main() {
         .setGas(75000)
         // Set the function to call on the contract
         .setFunction("get_message")
-        // Set the query payment explicitly since sometimes automatic payment calculated
-        // is too low
+        // Set query payment explicitly
         .setQueryPayment(new Hbar(3))
         .executeWithSigner(wallet);
 


### PR DESCRIPTION
Signed-off-by: Petar Tonev <petar.tonev@limechain.tech>

**Description**:
Fixes inaccurate cost calculation of queries. There was an issue with queries if query payment is not  explicitly set with `setQueryPayment()`, the query will fail with `INSUFFICIENT_TX_FEE`

**Related issue(s)**:

Fixes #1425 

**Notes for reviewer**:
There was also an issue where if the `nodeAccountIds` is not empty, the check whether or not the list is locked fails because we lock it only when we set the `nodeAccountIds` which only happens if the list is empty

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
