### PR TITLE
Fix _maxAutomaticTokenAssociations in contract create and contract up…

### DIFF
--- a/src/contract/ContractCreateTransaction.js
+++ b/src/contract/ContractCreateTransaction.js
@@ -128,7 +128,7 @@ export default class ContractCreateTransaction extends Transaction {
          * @private
          * @type {number}
          */
-        this._maxAutomaticTokenAssociations = 0;
+        this._maxAutomaticTokenAssociations;
 
         this._defaultMaxTransactionFee = new Hbar(20);
 

--- a/src/contract/ContractCreateTransaction.js
+++ b/src/contract/ContractCreateTransaction.js
@@ -126,9 +126,9 @@ export default class ContractCreateTransaction extends Transaction {
 
         /**
          * @private
-         * @type {number}
+         * @type {?number}
          */
-        this._maxAutomaticTokenAssociations;
+        this._maxAutomaticTokenAssociations = null;
 
         this._defaultMaxTransactionFee = new Hbar(20);
 

--- a/src/contract/ContractUpdateTransaction.js
+++ b/src/contract/ContractUpdateTransaction.js
@@ -113,7 +113,7 @@ export default class ContractUpdateTransaction extends Transaction {
          * @private
          * @type {?number}
          */
-        this._maxAutomaticTokenAssociations;
+        this._maxAutomaticTokenAssociations = null;
 
         /**
          * @private

--- a/src/contract/ContractUpdateTransaction.js
+++ b/src/contract/ContractUpdateTransaction.js
@@ -113,7 +113,7 @@ export default class ContractUpdateTransaction extends Transaction {
          * @private
          * @type {?number}
          */
-        this._maxAutomaticTokenAssociations = 0;
+        this._maxAutomaticTokenAssociations;
 
         /**
          * @private


### PR DESCRIPTION
…date transactions

Signed-off-by: ochikov <ognyan@limechain.tech>

**Description**:
Set the _maxAutomaticTokenAssociations as null by default.

**Related issue(s)**:

Fixes #1443 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
