### PR TITLE
Fix operator and operator account id override in beforeExecute

### DIFF
--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -1169,12 +1169,17 @@ export default class Transaction extends Executable {
             this._validateChecksums(client);
         }
 
-        // Set the operator if the client has one
-        this._operator ??= client != null ? client._operator : null;
-        this._operatorAccountId ??=
-            client != null && client._operator != null
-                ? client._operator.accountId
-                : null;
+        // Set the operator if the client has one and the current operator is nullish
+        if (this._operator == null || this._operator == undefined) {
+            this._operator = client != null ? client._operator : null;
+        }
+
+        if (this._operatorAccountId == null || this._operatorAccountId == undefined) {
+            this._operatorAccountId =
+                client != null && client._operator != null
+                    ? client._operator.accountId
+                    : null;
+        }
 
         // If the client has an operator, sign this request with the operator
         if (this._operator != null) {

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -1159,7 +1159,7 @@ export default class Transaction extends Executable {
      * @returns {Promise<void>}
      */
     async _beforeExecute(client) {
-        // Makes ure we're frozen
+        // Make sure we're frozen
         if (!this._isFrozen()) {
             this.freezeWith(client);
         }
@@ -1170,13 +1170,13 @@ export default class Transaction extends Executable {
         }
 
         // Set the operator if the client has one
-        this._operator = client != null ? client._operator : null;
-        this._operatorAccountId =
+        this._operator ??= client != null ? client._operator : null;
+        this._operatorAccountId ??=
             client != null && client._operator != null
                 ? client._operator.accountId
                 : null;
 
-        // If the client has an operaator, sign this request with the operator
+        // If the client has an operator, sign this request with the operator
         if (this._operator != null) {
             await this.signWith(
                 this._operator.publicKey,

--- a/test/integration/TransactionIntegrationTest.js
+++ b/test/integration/TransactionIntegrationTest.js
@@ -184,5 +184,6 @@ describe("TransactionIntegration", function () {
         const transferRecord = await tx.getRecord(env.client)
         expect(transferRecord.transactionId.accountId).to.eql(signerId)
 
+        await env.close();
     })
 });

--- a/test/integration/TransactionIntegrationTest.js
+++ b/test/integration/TransactionIntegrationTest.js
@@ -8,6 +8,7 @@ import {
     TokenCreateTransaction,
     TransferTransaction,
 } from "../../src/exports.js";
+import { Wallet, LocalProvider } from "../../src/index.js";
 import * as hex from "../../src/encoding/hex.js";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
 
@@ -150,4 +151,38 @@ describe("TransactionIntegration", function () {
 
         await env.close();
     });
+
+    it("issue-1530", async function () {
+        this.timeout(30000)
+        const env = await IntegrationTestEnv.new();
+
+        // Generate a key for the signer
+        const signerKey = PrivateKey.generateED25519();
+
+        // Create account id for the signer
+        let createTransaction = await new AccountCreateTransaction()
+            .setKey(signerKey)
+            .setInitialBalance(new Hbar(5))
+            .signWithOperator(env.client);
+
+        const response = await createTransaction.execute(env.client);
+        const record = await response.getRecord(env.client);
+        const signerId = record.receipt.accountId;
+
+        const wallet = new Wallet(signerId, signerKey, new LocalProvider());
+        
+        // The operator and the signer are different
+        expect(env.operatorId).not.to.eql(signerId)
+
+        let transferTx = new TransferTransaction()
+            .addHbarTransfer(signerId, new Hbar(-1))
+            .addHbarTransfer(env.operatorId, new Hbar(1))
+
+        wallet.populateTransaction(transferTx)
+
+        const tx = await wallet.call(transferTx)
+        const transferRecord = await tx.getRecord(env.client)
+        expect(transferRecord.transactionId.accountId).to.eql(signerId)
+
+    })
 });


### PR DESCRIPTION
**Description**:
Fixes the override of `operator` and `operatorAccountId` in `Transaction._beforeExecute()`. This was causing the transaction to fail when using a wallet as a signer.

**Related issue(s)**:

Fixes #1530 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
