### PR TITLE
fix: remove the insecure port of mirror nodes

### DIFF
--- a/src/ManagedNode.js
+++ b/src/ManagedNode.js
@@ -125,24 +125,6 @@ export default class ManagedNode {
     }
 
     /**
-     * @abstract
-     * @returns {ManagedNode<ChannelT>}
-     */
-    // eslint-disable-next-line jsdoc/require-returns-check
-    toInsecure() {
-        throw new Error("not implemented");
-    }
-
-    /**
-     * @abstract
-     * @returns {ManagedNode<ChannelT>}
-     */
-    // eslint-disable-next-line jsdoc/require-returns-check
-    toSecure() {
-        throw new Error("not implemented");
-    }
-
-    /**
      * @param {string} ledgerId
      * @returns {this}
      */

--- a/src/ManagedNodeAddress.js
+++ b/src/ManagedNodeAddress.js
@@ -76,30 +76,12 @@ export default class ManagedNodeAddress {
     }
 
     toInsecure() {
-        let port = this.port;
-
-        switch (this.port) {
-            case 50212:
-                port = 50211;
-                break;
-            case 443:
-                port = 5600;
-        }
-
+        let port = (this.port === 50212) ? 50211 : this.port
         return new ManagedNodeAddress({ host: this.address, port });
     }
 
     toSecure() {
-        let port = this.port;
-
-        switch (this.port) {
-            case 50211:
-                port = 50212;
-                break;
-            case 5600:
-                port = 443;
-        }
-
+        let port = (this.port === 50211) ? 50212 : this.port
         return new ManagedNodeAddress({ host: this.address, port });
     }
 

--- a/src/MirrorNode.js
+++ b/src/MirrorNode.js
@@ -56,22 +56,4 @@ export default class MirrorNode extends ManagedNode {
     getKey() {
         return this._address.toString();
     }
-
-    /**
-     * @returns {MirrorNode}
-     */
-    toInsecure() {
-        return new MirrorNode({
-            cloneNode: { node: this, address: this._address.toInsecure() },
-        });
-    }
-
-    /**
-     * @returns {MirrorNode}
-     */
-    toSecure() {
-        return new MirrorNode({
-            cloneNode: { node: this, address: this._address.toSecure() },
-        });
-    }
 }

--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -267,7 +267,6 @@ export default class Client {
      */
     setTransportSecurity(transportSecurity) {
         this._network.setTransportSecurity(transportSecurity);
-        this._mirrorNetwork.setTransportSecurity(transportSecurity);
         return this;
     }
 

--- a/src/client/ManagedNetwork.js
+++ b/src/client/ManagedNetwork.js
@@ -90,64 +90,10 @@ export default class ManagedNetwork {
         /** @type {number} */
         this._maxNodeAttempts = -1;
 
-        this._transportSecurity = false;
-
         this._nodeMinReadmitPeriod = this._minBackoff;
         this._nodeMaxReadmitPeriod = this._maxBackoff;
 
         this._earliestReadmitTime = Date.now() + this._nodeMinReadmitPeriod;
-    }
-
-    /**
-     * @returns {boolean}
-     */
-    isTransportSecurity() {
-        return this._transportSecurity;
-    }
-
-    /**
-     * @param {boolean} transportSecurity
-     * @returns {this}
-     */
-    setTransportSecurity(transportSecurity) {
-        if (this._transportSecurity == transportSecurity) {
-            return this;
-        }
-
-        this._network.clear();
-
-        for (let i = 0; i < this._nodes.length; i++) {
-            let node = this._nodes[i];
-            node.close();
-
-            node = /** @type {NetworkNodeT} */ (
-                transportSecurity
-                    ? node
-                          .toSecure()
-                          .setCert(
-                              this._ledgerId != null
-                                  ? this._ledgerId.toString()
-                                  : ""
-                          )
-                    : node.toInsecure()
-            );
-            this._nodes[i] = node;
-
-            const nodes =
-                this._network.get(node.getKey()) != null
-                    ? /** @type {NetworkNodeT[]} */ (
-                          this._network.get(node.getKey())
-                      )
-                    : [];
-            nodes.push(node);
-            this._network.set(node.getKey(), nodes);
-        }
-
-        // Overwrite healthy node list since new ports might make the node work again
-        this._healthyNodes = [...this._nodes];
-
-        this._transportSecurity = transportSecurity;
-        return this;
     }
 
     /**

--- a/src/client/Network.js
+++ b/src/client/Network.js
@@ -46,6 +46,10 @@ export default class Network extends ManagedNetwork {
 
         /** @type {NodeAddressBook | null} */
         this._addressBook = null;
+
+
+        /** @type {boolean} */
+        this._transportSecurity = false;
     }
 
     /**
@@ -238,6 +242,58 @@ export default class Network extends ManagedNetwork {
      */
     setMaxNodeAttempts(maxNodeAttempts) {
         this._maxNodeAttempts = maxNodeAttempts;
+        return this;
+    }
+
+    /**
+     * @returns {boolean}
+     */
+    isTransportSecurity() {
+        return this._transportSecurity;
+    }
+
+    /**
+     * @param {boolean} transportSecurity
+     * @returns {this}
+     */
+    setTransportSecurity(transportSecurity) {
+        if (this._transportSecurity == transportSecurity) {
+            return this;
+        }
+
+        this._network.clear();
+
+        for (let i = 0; i < this._nodes.length; i++) {
+            let node = this._nodes[i];
+            node.close();
+
+            node = /** @type {Node} */ (
+                transportSecurity
+                    ? node
+                          .toSecure()
+                          .setCert(
+                              this._ledgerId != null
+                                  ? this._ledgerId.toString()
+                                  : ""
+                          )
+                    : node.toInsecure()
+            );
+            this._nodes[i] = node;
+
+            const nodes =
+                this._network.get(node.getKey()) != null
+                    ? /** @type {Node[]} */ (
+                          this._network.get(node.getKey())
+                      )
+                    : [];
+            nodes.push(node);
+            this._network.set(node.getKey(), nodes);
+        }
+
+        // Overwrite healthy node list since new ports might make the node work again
+        this._healthyNodes = [...this._nodes];
+
+        this._transportSecurity = transportSecurity;
         return this;
     }
 

--- a/test/unit/ManagedNodeAddress.js
+++ b/test/unit/ManagedNodeAddress.js
@@ -60,15 +60,6 @@ describe("ManagedNodeAddress", function () {
             "testnet.mirrornode.hedera.com:443"
         );
 
-        const mirrorNodeAddressInsecure = mirrorNodeAddressSecure.toInsecure();
-        expect(mirrorNodeAddressInsecure.address).to.be.equal(
-            "testnet.mirrornode.hedera.com"
-        );
-        expect(mirrorNodeAddressInsecure.port).to.be.equal(5600);
-        expect(mirrorNodeAddressInsecure.toString()).to.be.equal(
-            "testnet.mirrornode.hedera.com:5600"
-        );
-
         let err = false;
         try {
             ManagedNodeAddress.fromString(

--- a/test/unit/NodeClient.js
+++ b/test/unit/NodeClient.js
@@ -196,15 +196,5 @@ describe("Client", function () {
         expect(client.mirrorNetwork).to.deep.equal([
             "mainnet-public.mirrornode.hedera.com:443",
         ]);
-
-        client.setTransportSecurity(false);
-        expect(client.mirrorNetwork).to.deep.equal([
-            "mainnet-public.mirrornode.hedera.com:5600",
-        ]);
-
-        client.setTransportSecurity(true);
-        expect(client.mirrorNetwork).to.deep.equal([
-            "mainnet-public.mirrornode.hedera.com:443",
-        ]);
     });
 });


### PR DESCRIPTION
**Description**:
Changes:
- `transportSecurity` moved from `ManagedNetwork` to `Network`
- `toInsecure()` and `toSecure()` moved from `ManagedNode` to `Node`

**Related issue(s)**:

Fixes #1446 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
