### PR TITLE
Add zero padding for nanos

### DIFF
--- a/src/transaction/TransactionId.js
+++ b/src/transaction/TransactionId.js
@@ -159,10 +159,11 @@ export default class TransactionId {
      */
     toString() {
         if (this.accountId != null && this.validStart != null) {
+            const zeroPaddedNanos = String(this.validStart.nanos).padStart(9, "0");
             const nonce =
                 this.nonce != null ? "/".concat(this.nonce.toString()) : "";
             const scheduled = this.scheduled ? "?scheduled" : "";
-            return `${this.accountId.toString()}@${this.validStart.seconds.toString()}.${this.validStart.nanos.toString()}${scheduled}${nonce}`;
+            return `${this.accountId.toString()}@${this.validStart.seconds.toString()}.${zeroPaddedNanos}${scheduled}${nonce}`;
         } else {
             throw new Error("neither `accountId` nor `validStart` are set");
         }

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -399,7 +399,7 @@ describe("AccountInfoMocking", function () {
         } catch (error) {
             if (
                 error.message !==
-                "transaction 0.0.1854@1651168054.29348185 failed precheck with status TRANSACTION_EXPIRED"
+                "transaction 0.0.1854@1651168054.029348185 failed precheck with status TRANSACTION_EXPIRED"
             ) {
                 throw error;
             }

--- a/test/unit/TransactionId.js
+++ b/test/unit/TransactionId.js
@@ -66,25 +66,25 @@ describe("TransactionId", function () {
     it("should parse {shard}.{realm}.{num}@{seconds}.{nanos}", function () {
         const transactionId = TransactionId.fromString("1.2.3@4.5");
 
-        expect(transactionId.toString()).to.be.equal("1.2.3@4.5");
+        expect(transactionId.toString()).to.be.equal("1.2.3@4.000000005");
     });
 
     it("should parse {num}@{seconds}.{nanos}", function () {
         const transactionId = TransactionId.fromString("3@4.5");
 
-        expect(transactionId.toString()).to.be.equal("0.0.3@4.5");
+        expect(transactionId.toString()).to.be.equal("0.0.3@4.000000005");
     });
 
     it("should parse {shard}.{realm}.{num}@{seconds}.{nanos}?scheduled", function () {
         const transactionId = TransactionId.fromString("1.2.3@4.5?scheduled");
 
-        expect(transactionId.toString()).to.be.equal("1.2.3@4.5?scheduled");
+        expect(transactionId.toString()).to.be.equal("1.2.3@4.000000005?scheduled");
     });
 
     it("should parse {num}@{seconds}.{nanos}?scheduled", function () {
         const transactionId = TransactionId.fromString("3@4.5?scheduled");
 
-        expect(transactionId.toString()).to.be.equal("0.0.3@4.5?scheduled");
+        expect(transactionId.toString()).to.be.equal("0.0.3@4.000000005?scheduled");
     });
 
     it("should construct with nonce", function () {
@@ -106,11 +106,11 @@ describe("TransactionId", function () {
         const validStart = new Timestamp(5, 4);
         let transactionId = new TransactionId(accountId, validStart, true);
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4?scheduled");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004?scheduled");
 
         transactionId = new TransactionId(accountId, validStart, true, null);
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4?scheduled");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004?scheduled");
 
         transactionId = new TransactionId(
             accountId,
@@ -119,7 +119,7 @@ describe("TransactionId", function () {
             undefined
         );
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4?scheduled");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004?scheduled");
     });
 
     it("should construct with nonce without scheduled", function () {
@@ -133,11 +133,11 @@ describe("TransactionId", function () {
             nonce
         );
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4/117");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004/117");
 
         transactionId = new TransactionId(accountId, validStart, NaN, nonce);
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4/117");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004/117");
 
         transactionId = new TransactionId(
             accountId,
@@ -146,7 +146,7 @@ describe("TransactionId", function () {
             nonce
         );
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4/117");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004/117");
     });
 
     it("should construct without scheduled and nonce", function () {
@@ -159,7 +159,7 @@ describe("TransactionId", function () {
             null
         );
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004");
 
         transactionId = new TransactionId(
             accountId,
@@ -168,35 +168,35 @@ describe("TransactionId", function () {
             undefined
         );
 
-        expect(transactionId.toString()).to.equal("1.1.1@5.4");
+        expect(transactionId.toString()).to.equal("1.1.1@5.000000004");
     });
 
     it("should construct fromString", function () {
         let stringId = "1.1.1@5.4?scheduled/117";
         let transactionId = TransactionId.fromString(stringId).toString();
 
-        expect(transactionId).to.eql(stringId);
+        expect(transactionId).to.eql("1.1.1@5.000000004?scheduled/117");
     });
 
     it("should construct fromString without nonce", function () {
         let stringId = "1.1.1@5.4?scheduled";
         let transactionId = TransactionId.fromString(stringId).toString();
 
-        expect(transactionId).to.eql(stringId);
+        expect(transactionId).to.eql("1.1.1@5.000000004?scheduled");
     });
 
     it("should construct fromString without scheduled", function () {
         let stringId = "1.1.1@5.4/117";
         let transactionId = TransactionId.fromString(stringId).toString();
 
-        expect(transactionId).to.eql(stringId);
+        expect(transactionId).to.eql("1.1.1@5.000000004/117");
     });
 
     it("should construct fromString without nonce and scheduled", function () {
         let stringId = "1.1.1@5.4";
         let transactionId = TransactionId.fromString(stringId).toString();
 
-        expect(transactionId).to.eql(stringId);
+        expect(transactionId).to.eql("1.1.1@5.000000004");
     });
 
     it("should be able to update nonce with a number or date", function () {

--- a/test/unit/TransactionReceiptMocking.js
+++ b/test/unit/TransactionReceiptMocking.js
@@ -95,7 +95,7 @@ describe("TransactionReceiptMocking", function () {
         } catch (error) {
             err =
                 error.message ===
-                "receipt for transaction 0.0.3@4.5 contained error status INVALID_SIGNATURE";
+                "receipt for transaction 0.0.3@4.000000005 contained error status INVALID_SIGNATURE";
         }
 
         expect(err).to.be.true;


### PR DESCRIPTION
**Description**:
Fixes an issue where if the generated nanos in a `transactionId` start with `0`,  after casting the object `toString()` the `0` gets trimmed and it returns wrong `transactionId`

**Related issue(s)**:

Fixes #1564 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
