### PR TITLE
Fix: list is locked when trying to get the hash before signing the transaction

### DIFF
--- a/src/transaction/List.js
+++ b/src/transaction/List.js
@@ -78,14 +78,8 @@ export default class List {
 
     /**
      * Clear the list
-     *
-     * @throws if the list is locked
      */
     clear() {
-        if (this.locked) {
-            throw new Error("list is locked");
-        }
-
         this.list = [];
         this.index = 0;
     }
@@ -103,16 +97,11 @@ export default class List {
     /**
      * Set value at index
      *
-     * @throws if the list is locked
      * @param {number} index
      * @param {T} item
      * @returns {this}
      */
     set(index, item) {
-        if (this.locked) {
-            throw new Error("list is locked");
-        }
-
         // QoL: If the index is at the end simply push the element to the end
         if (index === this.length) {
             this.list.push(item);


### PR DESCRIPTION
**Description**:
An exception `list is locked` is no more thrown while trying to get the transaction hash before signing the transaction

**Related issue(s)**:

Fixes #1410 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
