### PR TITLE
Add assessment method support for custom fractional fees

### DIFF
--- a/src/token/CustomFractionalFee.js
+++ b/src/token/CustomFractionalFee.js
@@ -233,6 +233,9 @@ export default class CustomFractionalFee extends CustomFee {
                 },
                 minimumAmount: this._min,
                 maximumAmount: this._max,
+                netOfTransfers: this._assessmentMethod
+                    ? this._assessmentMethod.valueOf()
+                    : false,
             },
         };
     }


### PR DESCRIPTION
**Description**:
This PR fixes an issue where there is no impact no matter the value being set to `setAssessmentMethod()`

**Related issue(s)**:

Fixes #1598 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
