### PR TITLE
Add assessment method support for custom fractional fees

### DIFF
--- a/src/token/CustomFractionalFee.js
+++ b/src/token/CustomFractionalFee.js
@@ -20,11 +20,8 @@
 
 import CustomFee from "./CustomFee.js";
 import AccountId from "../account/AccountId.js";
+import FeeAssessmentMethod from "./FeeAssessmentMethod.js";
 import Long from "long";
-
-/**
- * @typedef {import("./FeeAssessmentMethod.js").default} FeeAssessmentMethod
- */
 
 /**
  * @namespace proto
@@ -211,6 +208,10 @@ export default class CustomFractionalFee extends CustomFee {
                     : undefined,
             min: fee.minimumAmount != null ? fee.minimumAmount : undefined,
             max: fee.maximumAmount != null ? fee.maximumAmount : undefined,
+            assessmentMethod:
+                fee.netOfTransfers != null
+                    ? new FeeAssessmentMethod(fee.netOfTransfers)
+                    : undefined,
         });
     }
 
@@ -233,6 +234,10 @@ export default class CustomFractionalFee extends CustomFee {
                 },
                 minimumAmount: this._min,
                 maximumAmount: this._max,
+                netOfTransfers:
+                    this._assessmentMethod != null
+                        ? this._assessmentMethod.valueOf()
+                        : false,
             },
         };
     }


### PR DESCRIPTION
**Description**:
This PR fixes an issue where there is no impact no matter the value being set to `setAssessmentMethod()`

**Related issue(s)**:

Fixes #1598 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)