### PR TITLE
Update the addressbook on SDK build

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,6 +73,7 @@ tasks:
 
     build:
         cmds:
+            - task: update:addressbooks
             - task: install
             - task: format
             - task: lint

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -73,8 +73,8 @@ tasks:
 
     build:
         cmds:
-            - task: update:addressbooks
             - task: install
+            - task: update:addressbooks
             - task: format
             - task: lint
             - ./node_modules/.bin/babel src -d lib --out-file-extension .cjs > /dev/null


### PR DESCRIPTION
**Description**:
This PR adds `task update:addressbooks` inside `task build` so that the address book of the SDK gets updated whenever `task build` is run, which basically prepares the SDK for use
**Related issue(s)**:

Fixes #1657 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
