### PR TITLE
Add checks inside parsing methods from evm address

### DIFF
--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -25,6 +25,7 @@ import CACHE from "../Cache.js";
 import * as hex from "../encoding/hex.js";
 import { arrayEqual } from "../array.js";
 import Long from "long";
+import { isLongZeroAddress } from "../util.js";
 
 /**
  * @typedef {import("../client/Client.js").default<*, *>} Client
@@ -64,7 +65,11 @@ export default class ContractId extends Key {
      * @returns {ContractId}
      */
     static fromEvmAddress(shard, realm, evmAddress) {
-        return new ContractId(shard, realm, 0, hex.decode(evmAddress));
+        if (isLongZeroAddress(hex.decode(evmAddress))) {
+            return this.fromSolidityAddress(evmAddress);
+        } else {
+            return new ContractId(shard, realm, 0, hex.decode(evmAddress));
+        }    
     }
 
     /**
@@ -149,8 +154,11 @@ export default class ContractId extends Key {
      * @returns {ContractId}
      */
     static fromSolidityAddress(address) {
-        const [shard, realm, contract] = entity_id.fromSolidityAddress(address);
-        return new ContractId(shard, realm, contract);
+        if (isLongZeroAddress(hex.decode(address))) {
+            return new ContractId(...entity_id.fromSolidityAddress(address));
+        } else {
+            return this.fromEvmAddress(0, 0, address);
+        }
     }
 
     /**

--- a/src/util.js
+++ b/src/util.js
@@ -137,6 +137,21 @@ export function isStringOrUint8Array(variable) {
 }
 
 /**
+ * Takes an address as `Uint8Array` and returns whether or not this is a long-zero address
+ *
+ * @param {Uint8Array} address
+ * @returns {boolean}
+ */
+export function isLongZeroAddress(address) {
+    for (let i = 0; i < 12; i++) {
+        if (address[i] != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
  * Takes any param and returns false if null or undefined.
  *
  * @template {Long | Hbar} T


### PR DESCRIPTION
**Description**:
Add checks in `AccountId/ContractId` parsing methods `fromEvmAddress()` and `fromSolidityAddress()` in order to handle cases where users pass the wrong format of evm address in Hedera to the inappropriate method

**Related issue(s)**:

Fixes #1742 

**Notes for reviewer**:
After this is merged, If a user passes an evm address with wrong format to one of these methods, the flow will be passed to the correct method 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
