### PR TITLE
Enhance AccountId.toSolidityAddress() to handle alias field

### DIFF
--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -263,6 +263,8 @@ export default class AccountId {
     toSolidityAddress() {
         if (this.evmAddress != null) {
             return this.evmAddress.toString();
+        } else if (this.aliasKey != null) {
+            return this.aliasKey.toEvmAddress();
         } else {
             return entity_id.toSolidityAddress([
                 this.shard,


### PR DESCRIPTION
**Description**:
This PR fixes an issue where if you have an `AccountId` with populated `alias` field it won't yield the regular evm address when `toSolidityAddress()` is called

**Related issue(s)**:

Fixes #1821 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
