### PR TITLE
Allow ed25519 keys to generate long-zero address from alias

### DIFF
--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -263,7 +263,10 @@ export default class AccountId {
     toSolidityAddress() {
         if (this.evmAddress != null) {
             return this.evmAddress.toString();
-        } else if (this.aliasKey != null) {
+        } else if (
+            this.aliasKey != null &&
+            this.aliasKey._key._type == "secp256k1"
+        ) {
             return this.aliasKey.toEvmAddress();
         } else {
             return entity_id.toSolidityAddress([


### PR DESCRIPTION
Enhanced AccountId.toSolidityAddress() so that it does not throw error if there is an alias but the key is ED25519, instead generate the long-zero format

**Related issue(s)**:

Fixes #1821 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
