### PR TITLE
Add mapi call that queries the mirror node to get the actual evm address field

### DIFF
--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -209,6 +209,34 @@ export default class AccountId {
     }
 
     /**
+     * @description Populates `evmAddress` field of the `AccountId` extracted from the Mirror Node.
+     * @param {Client} client
+     * @returns {Promise<AccountId>}
+     */
+    async populateAccountEvmAddress(client) {
+        if (this.num === null) {
+            throw new Error("field `num` should not be null");
+        }
+        const mirrorUrl = client.mirrorNetwork[0].slice(
+            0,
+            client.mirrorNetwork[0].indexOf(":")
+        );
+
+        await new Promise((resolve) => {
+            setTimeout(resolve, 3000);
+        });
+
+        /* eslint-disable */
+        const url = `https://${mirrorUrl}/api/v1/accounts/${this.num.toString()}`;
+        const mirrorAccountId = (await axios.get(url)).data.evm_address;
+
+        this.evmAddress = EvmAddress.fromString(mirrorAccountId);
+        /* eslint-enable */
+
+        return this;
+    }
+
+    /**
      * @deprecated - Use `validateChecksum` instead
      * @param {Client} client
      */

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -196,6 +196,10 @@ export default class AccountId {
             client.mirrorNetwork[0].indexOf(":")
         );
 
+        await new Promise((resolve) => {
+            setTimeout(resolve, 3000);
+        });
+
         /* eslint-disable */
         const url = `https://${mirrorUrl}/api/v1/accounts/${this.evmAddress.toString()}`;
         const mirrorAccountId = (await axios.get(url)).data.account;


### PR DESCRIPTION
**Description**:
Add `populateAccountEvmAddress()` method to AccountId class that queries and gets the actual evm address field from the mirror node

**Related issue(s)**:

Fixes #1817 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
