### PR TITLE
Add setDefaultMaxQueryPayment() and deprecate setMaxQueruPayment()

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -108,7 +108,7 @@ export default class Client {
          * @private
          * @type {Hbar}
          */
-        this._maxQueryPayment = new Hbar(1);
+        this._defaultMaxQueryPayment = new Hbar(1);
 
         if (props != null) {
             if (props.operator != null) {
@@ -360,30 +360,18 @@ export default class Client {
     }
 
     /**
-     * @deprecated - Use `defaultMaxTransactionFee` instead
-     * @returns {?Hbar}
-     */
-    get maxTransactionFee() {
-        return this._defaultMaxTransactionFee;
-    }
-
-    /**
-     * @deprecated - Use `setDefaultMaxTransactionFee()` instead
-     * Set the maximum fee to be paid for transactions
-     * executed by this client.
-     * @param {Hbar} maxTransactionFee
-     * @returns {this}
-     */
-    setMaxTransactionFee(maxTransactionFee) {
-        this._defaultMaxTransactionFee = maxTransactionFee;
-        return this;
-    }
-
-    /**
      * @returns {?Hbar}
      */
     get defaultMaxTransactionFee() {
         return this._defaultMaxTransactionFee;
+    }
+
+    /**
+     * @deprecated - Use `defaultMaxTransactionFee` instead
+     * @returns {?Hbar}
+     */
+    get maxTransactionFee() {
+        return this.defaultMaxTransactionFee;
     }
 
     /**
@@ -394,8 +382,22 @@ export default class Client {
      * @returns {this}
      */
     setDefaultMaxTransactionFee(defaultMaxTransactionFee) {
+        if (defaultMaxTransactionFee.toTinybars().toInt() < 0) {
+            throw new Error("defaultMaxTransactionFee must be non-negative");
+        }
         this._defaultMaxTransactionFee = defaultMaxTransactionFee;
         return this;
+    }
+
+    /**
+     * @deprecated - Use `setDefaultMaxTransactionFee()` instead
+     * Set the maximum fee to be paid for transactions
+     * executed by this client.
+     * @param {Hbar} maxTransactionFee
+     * @returns {this}
+     */
+    setMaxTransactionFee(maxTransactionFee) {
+        return this.setDefaultMaxTransactionFee(maxTransactionFee);
     }
 
     /**
@@ -420,19 +422,39 @@ export default class Client {
     /**
      * @returns {Hbar}
      */
+    get defaultMaxQueryPayment() {
+        return this._defaultMaxQueryPayment;
+    }
+
+    /**
+     * @deprecated in a favor of defaultMaxQueryPayment
+     * @returns {Hbar}
+     */
     get maxQueryPayment() {
-        return this._maxQueryPayment;
+        return this.defaultMaxQueryPayment;
     }
 
     /**
      * Set the maximum payment allowable for queries.
      *
+     * @param {Hbar} defaultMaxQueryPayment
+     * @returns {Client<ChannelT, MirrorChannelT>}
+     */
+    setDefaultMaxQueryPayment(defaultMaxQueryPayment) {
+        if (defaultMaxQueryPayment.toTinybars().toInt() < 0) {
+            throw new Error("defaultMaxQueryPayment must be non-negative");
+        }
+        this._defaultMaxQueryPayment = defaultMaxQueryPayment;
+        return this;
+    }
+    /**
+     * @deprecated in a favor of setDefaultMaxQueryPayment()
+     * Set the maximum payment allowable for queries.
      * @param {Hbar} maxQueryPayment
      * @returns {Client<ChannelT, MirrorChannelT>}
      */
     setMaxQueryPayment(maxQueryPayment) {
-        this._maxQueryPayment = maxQueryPayment;
-        return this;
+        return this.setDefaultMaxQueryPayment(maxQueryPayment);
     }
 
     /**

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -309,7 +309,7 @@ export default class Query extends Executable {
         const maxQueryPayment =
             this._maxQueryPayment != null
                 ? this._maxQueryPayment
-                : client.maxQueryPayment;
+                : client.defaultMaxQueryPayment;
 
         if (this._queryPayment != null) {
             cost = this._queryPayment;

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -125,7 +125,7 @@ describe("AccountInfoMocking", function () {
             ],
         ]));
 
-        client.setMaxQueryPayment(Hbar.fromTinybars(10));
+        client.setDefaultMaxQueryPayment(Hbar.fromTinybars(10));
 
         let err = false;
 
@@ -183,7 +183,7 @@ describe("AccountInfoMocking", function () {
             ],
         ]));
 
-        client.setMaxQueryPayment(Hbar.fromTinybars(24));
+        client.setDefaultMaxQueryPayment(Hbar.fromTinybars(24));
 
         let err = false;
 

--- a/test/unit/Transaction.js
+++ b/test/unit/Transaction.js
@@ -111,7 +111,7 @@ describe("Transaction", function () {
         const nodeAccountId = new AccountId(3);
         const client = Client.forTestnet({
             scheduleNetworkUpdate: false,
-        }).setMaxTransactionFee(Hbar.fromTinybars(1));
+        }).setDefaultMaxTransactionFee(Hbar.fromTinybars(1));
 
         const transaction = new FileCreateTransaction()
             .setNodeAccountIds([nodeAccountId])


### PR DESCRIPTION
**Description**:

Deprecating `setMaxQueryPayment()` method in a favor of `setDefaultMaxQueryPayment()` method.
Deprecating `setMaxTransactionFee()` method in a favor of `setDefaultMaxTransactionFee()` method.

**Related issue(s)**: [#1297](https://github.com/hashgraph/hedera-sdk-js/issues/1297) 

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
