### PR TITLE
Add keepalive_time property when we init grpc client

### DIFF
--- a/src/channel/NodeChannel.js
+++ b/src/channel/NodeChannel.js
@@ -56,6 +56,7 @@ export default class NodeChannel extends Channel {
                 // https://github.com/grpc/grpc-node/issues/1593
                 // https://github.com/grpc/grpc-node/issues/1545
                 // https://github.com/grpc/grpc/issues/13163
+                "grpc.keepalive_time_ms": 100000,
                 "grpc.keepalive_timeout_ms": 10000,
                 "grpc.keepalive_permit_without_calls": 1,
                 "grpc.enable_retries": 0,
@@ -63,6 +64,7 @@ export default class NodeChannel extends Channel {
         } else {
             security = credentials.createInsecure();
             options = {
+                "grpc.keepalive_time_ms": 100000,
                 "grpc.keepalive_timeout_ms": 10000,
                 "grpc.keepalive_permit_without_calls": 1,
                 "grpc.enable_retries": 0,


### PR DESCRIPTION
**Description**:
Add an interval in milliseconds between pings when we make calls to consensus nodes

**Related issue(s)**:

Fixes #1952 

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
