### PR TITLE
1991 crash when trying to get contractid from evmaddress

### DIFF
--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -72,7 +72,7 @@ export default class ContractId extends Key {
     static fromEvmAddress(shard, realm, evmAddress) {
         // eslint-disable-next-line @typescript-eslint/no-unsafe-call
         if (isLongZeroAddress(hex.decode(evmAddress))) {
-            return this.fromEvmAddress(0, 0, evmAddress);
+            return new ContractId(...entity_id.fromSolidityAddress(evmAddress));
         } else {
             return new ContractId(shard, realm, 0, hex.decode(evmAddress));
         }

--- a/test/unit/ContractId.js
+++ b/test/unit/ContractId.js
@@ -51,4 +51,23 @@ describe("ContractId", function () {
             evmAddress: null,
         });
     });
+
+    it("should return the contract id from long zero number", function () {
+        const shard = 0,
+            realm = 0,
+            num = 5;
+        const ADDRESS_LENGTH = 42;
+        const contractId = new ContractId(shard, realm, num);
+        const longZeroAddress = contractId
+            .toSolidityAddress()
+            .padStart(ADDRESS_LENGTH, "0x");
+
+        const contractIdFromAddress = ContractId.fromEvmAddress(
+            shard,
+            realm,
+            longZeroAddress
+        );
+
+        expect(contractId).to.deep.equal(contractIdFromAddress);
+    });
 });

--- a/test/unit/ContractId.js
+++ b/test/unit/ContractId.js
@@ -52,7 +52,7 @@ describe("ContractId", function () {
         });
     });
 
-    it("should return the contract id from long zero number", function () {
+    it("should return the contract id from long zero address", function () {
         const shard = 0,
             realm = 0,
             num = 5;


### PR DESCRIPTION
**Description**:

- Fixed `fromEvmAddress()` method to return the correct contract id from long zero address

**Related issue(s)**:

Fixes #1991 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
