### PR TITLE
Add two grpc-web endpoints for node27/28 to ClientConstants.js

### DIFF
--- a/src/constants/ClientConstants.js
+++ b/src/constants/ClientConstants.js
@@ -29,8 +29,8 @@ export const MAINNET = {
     "https://node24.swirldslabs.com:443": new AccountId(27),
     "https://node25.swirldslabs.com:443": new AccountId(28),
     "https://node26.swirldslabs.com:443": new AccountId(29),
-    //"https://node27.swirldslabs.com:443": new AccountId(30),
-    //"https://node28.swirldslabs.com:443": new AccountId(31),
+    "https://node27.swirldslabs.com:443": new AccountId(30),
+    "https://node28.swirldslabs.com:443": new AccountId(31),
 };
 
 export const WEB_TESTNET = {


### PR DESCRIPTION
**Description**:
This PR adds two new grpc-web endpoints to ClientConstants.js. The endpoints have been created in Cloudflare and are pointing to the correct IPs.

**Related issue(s)**:
https://github.com/swirlds/infrastructure/issues/4299

**Notes for reviewer**:
You can e.g. `dig node28.swirldslabs.com +short` and see that the entry points to Cloudflare's DNS balancers. 

<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
