### PR TITLE
Added fromStringDer() method (and tests) and deprecated fromString() method

### DIFF
--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -155,7 +155,7 @@ export default class PrivateKey extends Key {
     }
 
     /**
-     * Construct a private key from a hex string with a der prefix
+     * Construct a private key from a HEX-encoded string with a der prefix
      *
      * @param {string} text
      * @returns {PrivateKey}

--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -140,13 +140,17 @@ export default class PrivateKey extends Key {
     }
 
     /**
-     * @deprecated - Use fromStringECDSA() or fromStringED25519() or fromStringDer() instead.
+     * @deprecated - Use fromStringECDSA() or fromStringED2551() on a HEX-encoded string
+     * and fromStringDer() on a HEX-encoded string with DER prefix instead.
      * Construct a private key from a hex-encoded string. Requires DER header.
      *
      * @param {string} text
      * @returns {PrivateKey}
      */
     static fromString(text) {
+        console.warn(
+            "WARNING: Consider using fromStringECDSA() or fromStringED2551() on a HEX-encoded string and fromStringDer() on a HEX-encoded string with DER prefix instead."
+        );
         return new PrivateKey(cryptography.PrivateKey.fromString(text));
     }
 

--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -140,12 +140,23 @@ export default class PrivateKey extends Key {
     }
 
     /**
+     * @deprecated - Use fromStringECDSA() or fromStringED25519() or fromStringDer() instead.
      * Construct a private key from a hex-encoded string. Requires DER header.
      *
      * @param {string} text
      * @returns {PrivateKey}
      */
     static fromString(text) {
+        return new PrivateKey(cryptography.PrivateKey.fromString(text));
+    }
+
+    /**
+     * Construct a private key from a hex string with a der prefix
+     *
+     * @param {string} text
+     * @returns {PrivateKey}
+     */
+    static fromStringDer(text) {
         return new PrivateKey(cryptography.PrivateKey.fromString(text));
     }
 

--- a/test/unit/EcdsaPrivateKey.js
+++ b/test/unit/EcdsaPrivateKey.js
@@ -22,7 +22,17 @@ describe("EcdsaPrivateKey", function () {
         );
     });
 
-    it("public key fro a private key", function () {
+    it("should return a public key from a der private key", function () {
+        const DER_PRIVATE_KEY =
+            "3030020100300706052b8104000a04220420e06ecd79f00124bfc030b0321006683a6a579be7602f2eb52ca73e2901880682";
+        const DER_PUBLIC_KEY =
+            "302d300706052b8104000a032200033697a2b3f9f0b9f4831b39986f7f3885636a3e8622a0bc3814a4a56f7ecdc4f1";
+        const publicKey =
+            PrivateKey.fromStringDer(DER_PRIVATE_KEY).publicKey.toStringDer();
+        expect(publicKey).to.be.equal(DER_PUBLIC_KEY);
+    });
+
+    it("should return a public key from a raw private key", function () {
         expect(
             PrivateKey.fromStringECDSA(RAW_KEY).publicKey.toStringRaw()
         ).to.be.equal(

--- a/test/unit/Ed25519PrivateKey.js
+++ b/test/unit/Ed25519PrivateKey.js
@@ -21,7 +21,17 @@ describe("Ed25519PrivateKey", function () {
         );
     });
 
-    it("public key from a private key", function () {
+    it("should return a public key from a der private key", function () {
+        const DER_PRIVATE_KEY =
+            "302e020100300506032b6570042204203a056f85d71921be62466f5e93a4af0aa2e09a9eb4b2d839e06d805366659a74";
+        const DER_PUBLIC_KEY =
+            "302a300506032b65700321004a6892f034d2d1c9b1a76acca8e34884055172f4210a0c02e3c7d55084f224d1";
+        const publicKey =
+            PrivateKey.fromStringDer(DER_PRIVATE_KEY).publicKey.toStringDer();
+        expect(publicKey).to.be.equal(DER_PUBLIC_KEY);
+    });
+
+    it("should return a public key from a raw private key", function () {
         expect(
             PrivateKey.fromStringED25519(RAW_KEY).publicKey.toStringRaw()
         ).to.be.equal(


### PR DESCRIPTION
**Description**:

- deprecated `fromString()` method to prevent future confusion
- regardless of the method being deprecated, a warning message was added that suggests the developer use one of the other methods
- added a new `fromStringDer()` method that is used for a HEX-encoded string with a DER prefix for developer convenience
- tests for `fromStringDer()` method

**Related issue(s)**:

Fixes #2027

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
