### PR TITLE
Add a Pause Key to TokenUpdateTransaction's fromProtobuf method

### DIFF
--- a/src/token/TokenUpdateTransaction.js
+++ b/src/token/TokenUpdateTransaction.js
@@ -297,6 +297,10 @@ export default class TokenUpdateTransaction extends Transaction {
                     update.feeScheduleKey != null
                         ? Key._fromProtobufKey(update.feeScheduleKey)
                         : undefined,
+                pauseKey:
+                    update.pauseKey != null
+                        ? Key._fromProtobufKey(update.pauseKey)
+                        : undefined,
             }),
             transactions,
             signedTransactions,


### PR DESCRIPTION
**Description**:

Added missing pauseKey prop to the method

**Related issue(s)**:

Fixes #2094

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
