### PR TITLE
chore: ensure CI release workflow properly handles prerelease builds

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -30,6 +30,7 @@ jobs:
       tag: ${{ steps.tag.outputs.name }}
       version: ${{ steps.tag.outputs.version }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
+      type: ${{ steps.tag.outputs.type }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -71,9 +72,21 @@ jobs:
           
           RELEASE_VERSION="$(semver get release "${REF_NAME}")"
           PREREL_VERSION="$(semver get prerel "${REF_NAME}")"
+          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
           
           IS_PRERELEASE="false"
           [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
+          
+          PREREL_TYPE="unknown"
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
+              PREREL_TYPE="beta"
+            else
+              PREREL_TYPE="unknown"
+            fi
+          else
+            PREREL_TYPE="production"
+          fi
           
           FINAL_VERSION="${RELEASE_VERSION}"
           [[ -n "${PREREL_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PREREL_VERSION}"
@@ -83,6 +96,7 @@ jobs:
           echo "name=${TAG_NAME}" >>"${GITHUB_OUTPUT}"
           echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
+          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
 
       - name: Validate Tag and Package Versions
         run: |
@@ -90,6 +104,11 @@ jobs:
           if [[ "${COMPARISON_RESULT}" -ne 0 ]]; then
             echo "::error title=Version Mismatch::The version in package.json (${{ steps.npm-package.outputs.version }}) does not match the version in the tag (${{ steps.tag.outputs.version }})."
             exit 1
+          fi
+          
+          if [[ "${{ steps.tag.outputs.type }}" != "production" && "${{ steps.tag.outputs.type }}" != "beta" ]]; then
+            echo "::error title=Unsupported PreRelease::The tag '${{ steps.tag.outputs.name }}' is an unsupported prerelease tag. Only 'beta' prereleases are supported."
+            exit 2
           fi
 
   run-safety-checks:
@@ -158,6 +177,8 @@ jobs:
         run: |
           PUBLISH_ARGS="--access public --no-git-checks"
           [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+          [[ "${{ needs.validate-release.outputs.prerelease }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --tag ${{ needs.validate-release.outputs.type }}"
+          
           echo "args=${PUBLISH_ARGS}" >>"${GITHUB_OUTPUT}"
           # Add the registry authentication stanza with variable substitution to the .npmrc configuration file.
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
@@ -172,7 +193,7 @@ jobs:
         if: ${{ github.event.inputs.dry-run-enabled != 'true' }}
         with:
           tag: ${{ steps.validate-release.outputs.tag }}
-          prerelease: ${{ steps.validate-release.outputs.prerelease == 'true' }}
+          prerelease: ${{ needs.validate-release.outputs.prerelease == 'true' }}
           draft: false
           generateReleaseNotes: true
           skipIfReleaseExists: true


### PR DESCRIPTION
## Description

This pull request changes the following:

- Adds support for rejecting tags with an unsupported prerelease version.
- Fixes issue which prevented GitHub releases from being appropriately marked as a prerelease. 
- Adds support for appropriately applying prerelease tags to artifacts when publishing to npmjs.com

### Related Issues

- Closes #2141 