### PR TITLE
chore(ci): fix permissions preventing Github release creation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,7 @@ updates:
       schedule:
           interval: monthly
       open-pull-requests-limit: 10
+      versioning-strategy: increase
       ignore:
           # For all packages, ignore all minor & patch updates
           - dependency-name: "*"
@@ -20,6 +21,7 @@ updates:
       schedule:
           interval: monthly
       open-pull-requests-limit: 10
+      versioning-strategy: increase
       ignore:
           # For all packages, ignore all minor & patch updates
           - dependency-name: "*"
@@ -30,6 +32,7 @@ updates:
       schedule:
           interval: monthly
       open-pull-requests-limit: 10
+      versioning-strategy: increase
       ignore:
           # For all packages, ignore all minor & patch updates
           - dependency-name: "*"
@@ -40,6 +43,7 @@ updates:
       schedule:
           interval: monthly
       open-pull-requests-limit: 5
+      versioning-strategy: increase
       ignore:
           # For all packages, ignore all minor & patch updates
           - dependency-name: "*"
@@ -50,6 +54,7 @@ updates:
       schedule:
           interval: monthly
       open-pull-requests-limit: 5
+      versioning-strategy: increase
       ignore:
           # For all packages, ignore all minor & patch updates
           - dependency-name: "*"

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -20,7 +20,7 @@ defaults:
     shell: bash
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   validate-release:


### PR DESCRIPTION
## Descripton

This pull request changes the following:

* Updates the release workflow permissions to ensure the Github release can be created using the CI provided token.
* Updates `dependabot.yml` to ensure package updates are applied to both the `package.json` and `package-lock.json` files.

### Related Issues

* Closes #2141 