### PR TITLE
fix: inability to create and execute freeze transaction

### DIFF
--- a/src/exports.js
+++ b/src/exports.js
@@ -174,6 +174,7 @@ export { default as Logger } from "./logger/Logger.js";
 export { default as LogLevel } from "./logger/LogLevel.js";
 export { EntityIdHelper };
 export { default as Long } from "long";
+export { default as FreezeType } from "./FreezeType.js";
 
 export { default as StatusError } from "./StatusError.js";
 export { default as PrecheckStatusError } from "./PrecheckStatusError.js";

--- a/src/system/FreezeTransaction.js
+++ b/src/system/FreezeTransaction.js
@@ -382,6 +382,17 @@ export default class FreezeTransaction extends Transaction {
         );
         return `FreezeTransaction:${timestamp.toString()}`;
     }
+
+    /**
+     * @override
+     * @internal
+     * @param {Channel} channel
+     * @param {HashgraphProto.proto.ITransaction} request
+     * @returns {Promise<HashgraphProto.proto.ITransactionResponse>}
+     */
+    _execute(channel, request) {
+        return channel.freeze.freeze(request);
+    }
 }
 
 // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/test/integration/FreezeTransactionIntegrationTest.js
+++ b/test/integration/FreezeTransactionIntegrationTest.js
@@ -1,0 +1,49 @@
+import {
+    Timestamp,
+    FreezeTransaction,
+    FreezeType,
+    // TransactionResponse,
+    // TransactionReceipt,
+    Status,
+} from "../../src/exports.js";
+import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
+
+describe("FreezeTransaction", function () {
+    let client;
+
+    before(async function () {
+        const env = await IntegrationTestEnv.new();
+        client = env.client;
+    });
+
+    it("should be executable but not supported", async function () {
+        this.timeout(120000);
+        const seconds = Math.round(Date.now() / 1000);
+        const validStart = new Timestamp(seconds, 0);
+
+        const transaction = new FreezeTransaction()
+            .setStartTimestamp(validStart)
+            .setFreezeType(new FreezeType(1))
+            .freezeWith(client);
+        expect(transaction.startTimestamp).to.be.equal(validStart);
+        expect(transaction.freezeType).to.be.instanceof(FreezeType);
+
+        try {
+            await transaction.execute(client);
+        } catch (error) {
+            expect(error.status).to.be.equal(Status.NotSupported);
+        }
+
+        // At the moment the API is not supported that's why the following lines are commented out.
+        // Once supported the try/catch block above should be removed.
+        // The status from execution of the transaction is code 13 which means NOT_SUPPORTED.
+
+        // const response = await transaction.execute(client)
+        // expect(response).to.be.instanceof(TransactionResponse)
+        // const receipt = await response.getReceipt(client)
+        // expect(receipt).to.be.instanceof(TransactionReceipt)
+        // expect(receipt.status.toString).to.be.instanceof(Status.Success)
+
+        client.close();
+    });
+});

--- a/test/unit/FreezeTransaction.js
+++ b/test/unit/FreezeTransaction.js
@@ -1,0 +1,22 @@
+import { expect } from "chai";
+
+import { FreezeTransaction, Timestamp, FreezeType } from "../../src/index.js";
+
+describe("FreezeTransaction", function () {
+    it("create transaction and set ", function () {
+        const seconds = Math.round(Date.now() / 1000);
+        const validStart = new Timestamp(seconds, 0);
+        const freezeType = new FreezeType(1);
+
+        const transaction = new FreezeTransaction()
+            .setStartTimestamp(validStart)
+            .setFreezeType(freezeType);
+
+        expect(transaction).to.be.instanceof(FreezeTransaction);
+        expect(transaction.startTimestamp).to.be.equal(validStart);
+        expect(transaction.freezeType).to.be.instanceof(FreezeType);
+        expect(transaction.freezeType.toString()).to.be.equal(
+            freezeType.toString(),
+        );
+    });
+});


### PR DESCRIPTION
**Description**:

- `execute()` method of `FreezeTransaction` added
- `FreezeType` exported

Fixes #2135 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
