### PR TITLE
fix: do not instantiate logger inside a method

### DIFF
--- a/src/client/ManagedNetwork.js
+++ b/src/client/ManagedNetwork.js
@@ -20,7 +20,6 @@
 
 import LedgerId from "../LedgerId.js";
 import * as util from "../util.js";
-import Logger from "../logger/Logger.js"; // eslint-disable-line
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
@@ -87,14 +86,6 @@ export default class ManagedNetwork {
         this._nodeMaxReadmitPeriod = this._maxBackoff;
 
         this._earliestReadmitTime = Date.now() + this._nodeMinReadmitPeriod;
-
-        /**
-         * Logger
-         *
-         * @external
-         * @type {Logger | null}
-         */
-        this._logger = null;
     }
 
     /**
@@ -227,11 +218,6 @@ export default class ManagedNetwork {
 
             // Check if the node exists
             if (!selectedNode) {
-                if (this._logger) {
-                    this._logger.debug(
-                        `Selected an undefined node at index ${nodeIndex}`,
-                    );
-                }
                 break; // Break out of the loop if undefined node is selected
             }
 
@@ -494,17 +480,6 @@ export default class ManagedNetwork {
      */
     decreaseBackoff(node) {
         node.decreaseBackoff();
-    }
-
-    /**
-     * Set logger
-     *
-     * @param {Logger} logger
-     * @returns {this}
-     */
-    setLogger(logger) {
-        this._logger = logger;
-        return this;
     }
 
     close() {

--- a/src/client/ManagedNetwork.js
+++ b/src/client/ManagedNetwork.js
@@ -21,7 +21,6 @@
 import LedgerId from "../LedgerId.js";
 import * as util from "../util.js";
 import Logger from "../logger/Logger.js"; // eslint-disable-line
-import { LogLevel } from "../exports.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
@@ -215,8 +214,6 @@ export default class ManagedNetwork {
     _getNumberOfMostHealthyNodes(count) {
         this._removeDeadNodes();
         this._readmitNodes();
-
-        this.setLogger(new Logger(LogLevel.Debug));
 
         const nodes = [];
         // Create a shallow for safe iteration


### PR DESCRIPTION
**Description**:
This PR removes the problematic instantiation of a logger inside a method that is invoked repeatedly.

**Related issue(s)**:

Fixes #2194 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->
I couldn't run the integration tests as there were no instruction in the README. I saw errors when I ran `task test` locally: `Error: Failed to construct client for IntegrationTestEnv`

However, please let me know if anything else I should test/modify.

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
