### PR TITLE
fix: integer overflow isuue for defaultMaxQueryPayment field

### DIFF
--- a/src/client/Client.js
+++ b/src/client/Client.js
@@ -29,6 +29,7 @@ import LedgerId from "../LedgerId.js";
 import FileId from "../file/FileId.js";
 import CACHE from "../Cache.js";
 import Logger from "../logger/Logger.js"; // eslint-disable-line
+import { convertToNumber } from "../util.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
@@ -449,7 +450,9 @@ export default class Client {
      * @returns {Client<ChannelT, MirrorChannelT>}
      */
     setDefaultMaxQueryPayment(defaultMaxQueryPayment) {
-        if (defaultMaxQueryPayment.toTinybars().toInt() < 0) {
+        const isMaxQueryPaymentNegative =
+            convertToNumber(defaultMaxQueryPayment.toTinybars()) < 0;
+        if (isMaxQueryPaymentNegative) {
             throw new Error("defaultMaxQueryPayment must be non-negative");
         }
         this._defaultMaxQueryPayment = defaultMaxQueryPayment;

--- a/test/integration/ClientIntegrationTest.js
+++ b/test/integration/ClientIntegrationTest.js
@@ -172,6 +172,24 @@ describe("ClientIntegration", function () {
         expect(clientTestnet.isTransportSecurity()).to.be.an("boolean");
     });
 
+    it("should return the following error message `defaultMaxQueryPayment must be non-negative` when the user tries to set a negative value to the defaultMaxQueryPayment field", async function () {
+        this.timeout(120000);
+        try {
+            env.client.setDefaultMaxQueryPayment(new Hbar(1).negated());
+        } catch (error) {
+            expect(error.message).to.be.equal(
+                "defaultMaxQueryPayment must be non-negative",
+            );
+        }
+    });
+
+    it("should set defaultMaxQueryPayment field", async function () {
+        this.timeout(120000);
+        const value = new Hbar(100);
+        env.client.setDefaultMaxQueryPayment(value);
+        expect(env.client.defaultMaxQueryPayment).to.be.equal(value);
+    });
+
     after(async function () {
         await env.close();
         clientTestnet.close();


### PR DESCRIPTION
**Description**:

Handles setting larger integer numbers when are set to `defaultMaxQueryPayment` field.

Fixes #2203 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
