### PR TITLE
fix: typo on PrivateKey.fromBytes warning

### DIFF
--- a/packages/cryptography/src/PrivateKey.js
+++ b/packages/cryptography/src/PrivateKey.js
@@ -138,7 +138,7 @@ export default class PrivateKey extends Key {
 
         if (data.length == 32) {
             console.warn(
-                "WARNING: Consider using fromStringECDSA() or fromStringED2551() on a HEX-encoded string and fromStringDer() on a HEX-encoded string with DER prefix instead.",
+                "WARNING: Consider using fromStringECDSA() or fromStringED25519() on a HEX-encoded string and fromStringDer() on a HEX-encoded string with DER prefix instead.",
             );
         }
 


### PR DESCRIPTION
**Description**:
Fixes a typo on PrivateKey.fromBytes warning

**Related issue(s)**:

Fixes #

**Notes for reviewer**:

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
