### PR TITLE
ci: update publishing workflow to use appropriate pre release and stable versions

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -354,7 +354,6 @@ jobs:
       - name: Publish SDK Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ !cancelled() && !failure() }}
         run: task -v publish -- ${{ steps.sdk-publish.outputs.args }}
 
       - name: Generate Github Release

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -340,19 +340,20 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/proto
-        if: ${{ steps.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
+        if: ${{ github.event.inputs.dry-run-enabled != 'true' && steps.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: task -v publish -- ${{ steps.proto-publish.outputs.args }}
 
       - name: Publish Cryptography Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/cryptography
-        if: ${{ steps.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
+        if: ${{ github.event.inputs.dry-run-enabled != 'true' && steps.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
         run: task -v publish -- ${{ steps.crypto-publish.outputs.args }}
 
       - name: Publish SDK Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
         run: task -v publish -- ${{ steps.sdk-publish.outputs.args }}
 
       - name: Generate Github Release

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -84,7 +84,7 @@ jobs:
           PROTO_PACKAGE_VERSION="$(jq -r '.version' 'packages/proto/package.json')"
           CRYPTO_PACKAGE_VERSION="$(jq -r '.version' 'packages/cryptography/package.json')"
           
-          echo "sdk-version=${SDK_PACKAGE_VERSION} >>"${GITHUB_OUTPUT}"
+          echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "proto-version=${PROTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "crypto-version=${CRYPTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
 

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -84,9 +84,11 @@ jobs:
           PROTO_PACKAGE_VERSION="$(jq -r '.version' './packages/proto/package.json')"
           CRYPTO_PACKAGE_VERSION="$(jq -r '.version' './packages/cryptography/package.json')"
           
+          set -x
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "proto-version=${PROTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "crypto-version=${CRYPTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
+          set +x
 
       - name: Proto Subpackage Publish Required
         id: proto-required

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -26,11 +26,24 @@ jobs:
   validate-release:
     name: Validate Release
     runs-on: [self-hosted, Linux, medium, ephemeral]
+
     outputs:
+      # Project tag
       tag: ${{ steps.tag.outputs.name }}
-      version: ${{ steps.tag.outputs.version }}
       prerelease: ${{ steps.tag.outputs.prerelease }}
       type: ${{ steps.tag.outputs.type }}
+
+      # main package
+      version: ${{ steps.tag.outputs.version }}
+
+      # proto sub-package
+      proto-version: ${{ steps.tag.outputs.proto-version }}
+      proto-publish-required: ${{ steps.tag.outputs.proto-publish-required }}
+
+      # crypto sub-package
+      crypto-version: ${{ steps.tag.outputs.crypto-version }}
+      crypto-publish-required: ${{ steps.tag.outputs.crypto-publish-required }}
+
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
@@ -62,7 +75,26 @@ jobs:
 
       - name: Extract NPM Package Information
         id: npm-package
-        run: echo "version=$(jq -r '.version' package.json)" >>"${GITHUB_OUTPUT}"
+        run: |
+          VERSION="$(jq -r '.version' package.json)"
+          PROTO_PACKAGE_VERSION="$(node -p "require('packages/proto/package.json').version")"
+          CRYPTO_PACKAGE_VERSION="$(node -p "require('packages/cryptography/package.json').version")"
+          
+          PROTO_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/proto/${PROTO_PACKAGE_VERSION}" >/dev/null 2>&1; then
+            PROTO_PUBLISH_REQUIRED="true"
+          fi
+          
+          CRYPTO_PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/cryptography/${CRYPTO_PACKAGE_VERSION}" >/dev/null 2>&1; then
+            CRYPTO_PUBLISH_REQUIRED="true"
+          fi
+          
+          echo "version=${VERSION} >>"${GITHUB_OUTPUT}" >>"${GITHUB_OUTPUT}"
+          echo "proto-version=${PROTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "crypto-version=${CRYPTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
+          echo "proto-publish-required=${PROTO_PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
+          echo "crypto-publish-required=${CRYPTO_PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
       - name: Extract Tag Information
         id: tag
@@ -192,40 +224,25 @@ jobs:
       - name: Install Playwright Dependencies
         run: sudo npx playwright install-deps
 
-      - name: Check Proto Subpackage Publish Status
-        id: proto
-        working-directory: packages/proto
-        run: |
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          PUBLISH_REQUIRED="false"
-          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/proto/${PACKAGE_VERSION}" >/dev/null 2>&1; then
-            PUBLISH_REQUIRED="true"
-          fi
-
-          echo "version=${PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
-          echo "publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
-
-      - name: Check Cryptography Subpackage Publish Status
-        id: cryptography
-        working-directory: packages/cryptography
-        run: |
-          PACKAGE_VERSION="$(node -p "require('./package.json').version")"
-          PUBLISH_REQUIRED="false"
-          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/cryptography/${PACKAGE_VERSION}" >/dev/null 2>&1; then
-            PUBLISH_REQUIRED="true"
-          fi
-          
-          echo "version=${PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
-          echo "publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
-
       - name: Calculate Publish Arguments
         id: publish
         run: |
           PUBLISH_ARGS="--access public --no-git-checks"
           [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
           [[ "${{ needs.validate-release.outputs.prerelease }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --tag ${{ needs.validate-release.outputs.type }}"
+          
+          CRYPTO_ARGS="--access public --no-git-checks"
+          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && CRYPTO_ARGS="${CRYPTO_ARGS} --dry-run"
+          [[ "${{ needs.validate-release.outputs.prerelease }}" == "true" ]] && CRYPTO_ARGS="${CRYPTO_ARGS} --tag ${{ needs.validate-release.outputs.type }}"
+          
+          PROTO_ARGS="--access public --no-git-checks"
+          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PROTO_ARGS="${PROTO_ARGS} --dry-run"
+          [[ "${{ needs.validate-release.outputs.prerelease }}" == "true" ]] && PROTO_ARGS="${PROTO_ARGS} --tag ${{ needs.validate-release.outputs.type }}"
 
           echo "args=${PUBLISH_ARGS}" >>"${GITHUB_OUTPUT}"
+          echo "crypto-args=${CRYPTO_ARGS}" >>"${GITHUB_OUTPUT}"
+          echo "proto-args=${PROTO_ARGS}" >>"${GITHUB_OUTPUT}"
+
           # Add the registry authentication stanza with variable substitution to the .npmrc configuration file.
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
 
@@ -233,19 +250,19 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/proto
-        if: ${{ steps.proto.outputs.publish-required == 'true' && !cancelled() && !failure() }}
+        if: ${{ steps.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
-          task -v publish -- ${{ steps.publish.outputs.args }}
+          task -v publish -- ${{ steps.publish.outputs.proto-args }}
 
       - name: Publish Cryptography Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/cryptography
-        if: ${{ steps.cryptography.outputs.publish-required == 'true' && !cancelled() && !failure() }}
+        if: ${{ steps.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
-          task -v publish -- ${{ steps.publish.outputs.args }}
+          task -v publish -- ${{ steps.publish.outputs.crypto-args }}
 
       - name: Publish SDK Release
         env:

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -159,8 +159,8 @@ jobs:
             exit 1
           fi
           
-          RELEASE_VERSION=${{ steps.npm-package.outputs.proto-version }}
-          PREREL_VERSION="$(semver get prerel "${{ steps.npm-package.outputs.proto-version }}")"
+          RELEASE_VERSION="${{ steps.npm-package.outputs.proto-version }}"
+          PREREL_VERSION="$(semver get prerel '${{ steps.npm-package.outputs.proto-version }}')"
           PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
           
           IS_PRERELEASE="false"
@@ -187,15 +187,15 @@ jobs:
       - name: Extract Crypto Subpackage Information
         id: crypto-package
         run: |
-          IS_VALID_SEMVER="$(semver validate "${{ steps.npm-package.outputs.crypto-version }}")"
+          IS_VALID_SEMVER="$(semver validate '${{ steps.npm-package.outputs.crypto-version }}')"
 
           if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
-            echo "::error title=Invalid Tag::The tag '${{ steps.npm-pacakage.outputs.crypto-version }}' is not a valid SemVer tag."
+            echo "::error title=Invalid Tag::The tag '${{ steps.npm-package.outputs.crypto-version }}' is not a valid SemVer tag."
             exit 1
           fi
 
-          RELEASE_VERSION=${{ steps.npm-package.outputs.crypto-version }}
-          PREREL_VERSION="$(semver get prerel "${{ steps.npm-pacakage.outputs.crypto-version }}")"
+          RELEASE_VERSION='${{ steps.npm-package.outputs.crypto-version }}'
+          PREREL_VERSION="$(semver get prerel '${{ steps.npm-package.outputs.crypto-version }}')"
           PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
           
           IS_PRERELEASE="false"

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -30,19 +30,23 @@ jobs:
     outputs:
       # Project tag
       tag: ${{ steps.tag.outputs.name }}
-      prerelease: ${{ steps.tag.outputs.prerelease }}
-      type: ${{ steps.tag.outputs.type }}
 
       # main package
-      version: ${{ steps.tag.outputs.version }}
+      sdk-version: ${{ steps.tag.outputs.version }}
+      sdk-prerelease: ${{ steps.tag.outputs.prerelease }}
+      sdk-type: ${{ steps.tag.outputs.type }}
 
       # proto sub-package
-      proto-version: ${{ steps.tag.outputs.proto-version }}
-      proto-publish-required: ${{ steps.tag.outputs.proto-publish-required }}
+      proto-version: ${{ steps.npm-package.outputs.proto-version }}
+      proto-prerelease: ${{ steps.proto-package.outputs.prerelease }}
+      proto-type: ${{ steps.proto-package.outputs.type }}
+      proto-publish-required: ${{ steps.proto-required.outputs.publish-required }}
 
       # crypto sub-package
-      crypto-version: ${{ steps.tag.outputs.crypto-version }}
-      crypto-publish-required: ${{ steps.tag.outputs.crypto-publish-required }}
+      crypto-version: ${{ steps.npm-package.outputs.crypto-version }}
+      crypto-prerelease: ${{ steps.crypto-package.output.prerelease }}
+      crypto-type: ${{ steps.crypto-package.output.type }}
+      crypto-publish-required: ${{ steps.crypto-required.outputs.publish-required }}
 
     steps:
       - name: Harden Runner
@@ -73,30 +77,38 @@ jobs:
         with:
           version: 1.7
 
-      - name: Extract NPM Package Information
+      - name: Extract NPM Package Versions
         id: npm-package
         run: |
-          VERSION="$(jq -r '.version' package.json)"
-          PROTO_PACKAGE_VERSION="$(node -p "require('packages/proto/package.json').version")"
-          CRYPTO_PACKAGE_VERSION="$(node -p "require('packages/cryptography/package.json').version")"
+          SDK_PACKAGE_VERSION="$(jq -r '.version' package.json)"
+          PROTO_PACKAGE_VERSION="$(jq -r '.version' 'packages/proto/package.json')"
+          CRYPTO_PACKAGE_VERSION="$(jq -r '.version' 'packages/cryptography/package.json')"
           
-          PROTO_PUBLISH_REQUIRED="false"
-          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/proto/${PROTO_PACKAGE_VERSION}" >/dev/null 2>&1; then
-            PROTO_PUBLISH_REQUIRED="true"
-          fi
-          
-          CRYPTO_PUBLISH_REQUIRED="false"
-          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/cryptography/${CRYPTO_PACKAGE_VERSION}" >/dev/null 2>&1; then
-            CRYPTO_PUBLISH_REQUIRED="true"
-          fi
-          
-          echo "version=${VERSION} >>"${GITHUB_OUTPUT}" >>"${GITHUB_OUTPUT}"
+          echo "sdk-version=${SDK_PACKAGE_VERSION} >>"${GITHUB_OUTPUT}"
           echo "proto-version=${PROTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "crypto-version=${CRYPTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
-          echo "proto-publish-required=${PROTO_PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
-          echo "crypto-publish-required=${CRYPTO_PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
 
-      - name: Extract Tag Information
+      - name: Proto Subpackage Publish Required
+        id: proto-required
+        run: |
+          PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/proto/${{ steps.npm-package.outputs.proto-version }}" >/dev/null 2>&1; then
+            PUBLISH_REQUIRED="true"
+          fi
+          
+          echo "publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
+
+      - name: Crypto Subpackage Publish Required
+        id: crypto-required
+        run: |
+          PUBLISH_REQUIRED="false"
+          if ! curl -sSLf "https://registry.npmjs.org/@hashgraph/cryptography/${{ steps.npm-package.outputs.crypto-version }}" >/dev/null 2>&1; then
+            PUBLISH_REQUIRED="true"
+          fi
+          
+          echo "publish-required=${PUBLISH_REQUIRED}" >>"${GITHUB_OUTPUT}"
+
+      - name: Extract SDK Tag Information
         id: tag
         run: |
           REF_NAME="$(git describe --exact-match --tags $(git log -n1 --pretty='%h'))"
@@ -135,11 +147,71 @@ jobs:
           echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
           echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
 
+      - name: Extract Proto Subpackage Information
+        id: proto-package
+        run: |
+          IS_VALID_SEMVER="$(semver validate "${{ steps.npm-package.outputs.proto-version }}")"
+
+          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
+            echo "::error title=Invalid Tag::The tag '${{ steps.npm-package.outputs.proto-version }}' is not a valid SemVer tag."
+            exit 1
+          fi
+          
+          PREREL_VERSION="$(semver get prerel "${{ steps.npm-package.outputs.proto-version }}")"
+          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
+          
+          IS_PRERELEASE="false"
+          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
+
+          PREREL_TYPE="unknown"
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
+              PREREL_TYPE="beta"
+            else
+              PREREL_TYPE="unknown"
+            fi
+          else
+            PREREL_TYPE="production"
+          fi
+          
+          echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
+          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
+          
+      - name: Extract Crypto Subpackage Information
+        id: crypto-package
+        run: |
+          IS_VALID_SEMVER="$(semver validate "${{ steps.npm-pacakage.outputs.crypto-version }}")"
+
+          if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
+            echo "::error title=Invalid Tag::The tag '${{ steps.npm-pacakage.outputs.crypto-version }}' is not a valid SemVer tag."
+            exit 1
+          fi
+
+          PREREL_VERSION="$(semver get prerel "${{ steps.npm-pacakage.outputs.crypto-version }}")"
+          PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
+          
+          IS_PRERELEASE="false"
+          [[ -n "${PREREL_VERSION}" ]] && IS_PRERELEASE="true"
+
+          PREREL_TYPE="unknown"
+          if [[ "${IS_PRERELEASE}" == "true" ]]; then
+            if [[ "${PREREL_VERSION_LC}" =~ "beta" ]]; then
+              PREREL_TYPE="beta"
+            else
+              PREREL_TYPE="unknown"
+            fi
+          else
+            PREREL_TYPE="production"
+          fi
+          
+          echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
+          echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
+
       - name: Validate Tag and Package Versions
         run: |
-          COMPARISON_RESULT="$(semver compare "${{ steps.npm-package.outputs.version }}" "${{ steps.tag.outputs.version }}")"
+          COMPARISON_RESULT="$(semver compare "${{ steps.npm-package.outputs.sdk-version }}" "${{ steps.tag.outputs.version }}")"
           if [[ "${COMPARISON_RESULT}" -ne 0 ]]; then
-            echo "::error title=Version Mismatch::The version in package.json (${{ steps.npm-package.outputs.version }}) does not match the version in the tag (${{ steps.tag.outputs.version }})."
+            echo "::error title=Version Mismatch::The version in package.json (${{ steps.npm-package.outputs.sdk-version }}) does not match the version in the tag (${{ steps.tag.outputs.version }})."
             exit 1
           fi
 
@@ -151,7 +223,7 @@ jobs:
           if [[ "${{ steps.tag.outputs.type }}" != "production" && "${{ steps.tag.outputs.type }}" != "beta" ]]; then
             echo "::error title=Unsupported PreRelease::The tag '${{ steps.tag.outputs.name }}' is an unsupported prerelease tag. Only 'beta' prereleases are supported."
             exit 2
-          fi
+          fi         
 
   run-safety-checks:
     name: Safety Checks
@@ -224,25 +296,43 @@ jobs:
       - name: Install Playwright Dependencies
         run: sudo npx playwright install-deps
 
-      - name: Calculate Publish Arguments
-        id: publish
+      - name: Calculate Proto Subpackage Publish Arguments
+        id: proto-publish
+        working-directory: packages/proto
+        if: ${{ steps.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: |
           PUBLISH_ARGS="--access public --no-git-checks"
           [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
-          [[ "${{ needs.validate-release.outputs.prerelease }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --tag ${{ needs.validate-release.outputs.type }}"
-          
-          CRYPTO_ARGS="--access public --no-git-checks"
-          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && CRYPTO_ARGS="${CRYPTO_ARGS} --dry-run"
-          [[ "${{ needs.validate-release.outputs.prerelease }}" == "true" ]] && CRYPTO_ARGS="${CRYPTO_ARGS} --tag ${{ needs.validate-release.outputs.type }}"
-          
-          PROTO_ARGS="--access public --no-git-checks"
-          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PROTO_ARGS="${PROTO_ARGS} --dry-run"
-          [[ "${{ needs.validate-release.outputs.prerelease }}" == "true" ]] && PROTO_ARGS="${PROTO_ARGS} --tag ${{ needs.validate-release.outputs.type }}"
+          [[ "${{ needs.validate-release.outputs.proto-prerelease }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --tag ${{ needs.validate-release.outputs.proto-type }}"
 
           echo "args=${PUBLISH_ARGS}" >>"${GITHUB_OUTPUT}"
-          echo "crypto-args=${CRYPTO_ARGS}" >>"${GITHUB_OUTPUT}"
-          echo "proto-args=${PROTO_ARGS}" >>"${GITHUB_OUTPUT}"
 
+          # Add the registry authentication stanza with variable substitution to the .npmrc configuration file.
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
+
+      - name: Calculate Crypto Subpackage Publish Arguments
+        id: crypto-publish
+        working-directory: packages/cryptography
+        if: ${{ steps.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
+        run: |
+          PUBLISH_ARGS="--access public --no-git-checks"
+          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+          [[ "${{ needs.validate-release.outputs.crypto-prerelease }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --tag ${{ needs.validate-release.outputs.crypto-type }}"
+          
+          echo "args=${PUBLISH_ARGS}" >>"${GITHUB_OUTPUT}"
+
+          # Add the registry authentication stanza with variable substitution to the .npmrc configuration file.
+          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
+
+      - name: Calculate SDK Publish Arguments
+        id: sdk-publish
+        run: |
+          PUBLISH_ARGS="--access public --no-git-checks"
+          [[ "${{ github.event.inputs.dry-run-enabled }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --dry-run"
+          [[ "${{ needs.validate-release.outputs.sdk-prerelease }}" == "true" ]] && PUBLISH_ARGS="${PUBLISH_ARGS} --tag ${{ needs.validate-release.outputs.sdk-type }}"
+          
+          echo "args=${PUBLISH_ARGS}" >>"${GITHUB_OUTPUT}"
+          
           # Add the registry authentication stanza with variable substitution to the .npmrc configuration file.
           echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
 
@@ -251,23 +341,19 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/proto
         if: ${{ steps.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
-          task -v publish -- ${{ steps.publish.outputs.proto-args }}
+        run: task -v publish -- ${{ steps.proto-publish.outputs.args }}
 
       - name: Publish Cryptography Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/cryptography
         if: ${{ steps.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
-        run: |
-          echo '//registry.npmjs.org/:_authToken=${NPM_TOKEN}' >>".npmrc"
-          task -v publish -- ${{ steps.publish.outputs.crypto-args }}
+        run: task -v publish -- ${{ steps.crypto-publish.outputs.args }}
 
       - name: Publish SDK Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: task -v publish -- ${{ steps.publish.outputs.args }}
+        run: task -v publish -- ${{ steps.sdk-publish.outputs.args }}
 
       - name: Generate Github Release
         uses: ncipollo/release-action@2c591bcc8ecdcd2db72b97d6147f871fcd833ba5 # v1.14.0

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -223,7 +223,7 @@ jobs:
           if [[ "${{ steps.tag.outputs.type }}" != "production" && "${{ steps.tag.outputs.type }}" != "beta" ]]; then
             echo "::error title=Unsupported PreRelease::The tag '${{ steps.tag.outputs.name }}' is an unsupported prerelease tag. Only 'beta' prereleases are supported."
             exit 2
-          fi         
+          fi
 
   run-safety-checks:
     name: Safety Checks

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -37,13 +37,13 @@ jobs:
       sdk-type: ${{ steps.tag.outputs.type }}
 
       # proto sub-package
-      proto-version: ${{ steps.npm-package.outputs.proto-version }}
+      proto-version: ${{ steps.proto-package.outputs.version }}
       proto-prerelease: ${{ steps.proto-package.outputs.prerelease }}
       proto-type: ${{ steps.proto-package.outputs.type }}
       proto-publish-required: ${{ steps.proto-required.outputs.publish-required }}
 
       # crypto sub-package
-      crypto-version: ${{ steps.npm-package.outputs.crypto-version }}
+      crypto-version: ${{ steps.crypto-package.outputs.version }}
       crypto-prerelease: ${{ steps.crypto-package.output.prerelease }}
       crypto-type: ${{ steps.crypto-package.output.type }}
       crypto-publish-required: ${{ steps.crypto-required.outputs.publish-required }}
@@ -159,6 +159,7 @@ jobs:
             exit 1
           fi
           
+          RELEASE_VERSION=${{ steps.npm-package.outputs.proto-version }}
           PREREL_VERSION="$(semver get prerel "${{ steps.npm-package.outputs.proto-version }}")"
           PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
           
@@ -176,19 +177,24 @@ jobs:
             PREREL_TYPE="production"
           fi
           
+          FINAL_VERSION="${RELEASE_VERSION}"
+          [[ -n "${PREREL_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PREREL_VERSION}"
+          
+          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
           echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
           
       - name: Extract Crypto Subpackage Information
         id: crypto-package
         run: |
-          IS_VALID_SEMVER="$(semver validate "${{ steps.npm-pacakage.outputs.crypto-version }}")"
+          IS_VALID_SEMVER="$(semver validate "${{ steps.npm-package.outputs.crypto-version }}")"
 
           if [[ "${IS_VALID_SEMVER}" != "valid" ]]; then
             echo "::error title=Invalid Tag::The tag '${{ steps.npm-pacakage.outputs.crypto-version }}' is not a valid SemVer tag."
             exit 1
           fi
 
+          RELEASE_VERSION=${{ steps.npm-package.outputs.crypto-version }}
           PREREL_VERSION="$(semver get prerel "${{ steps.npm-pacakage.outputs.crypto-version }}")"
           PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
           
@@ -206,6 +212,10 @@ jobs:
             PREREL_TYPE="production"
           fi
           
+          FINAL_VERSION="${RELEASE_VERSION}"
+          [[ -n "${PREREL_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PREREL_VERSION}"
+          
+          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
           echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
 

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -341,20 +341,20 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/proto
-        if: ${{ github.event.inputs.dry-run-enabled != 'true' && steps.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
+        if: ${{ steps.validate-release.outputs.proto-publish-required == 'true' && !cancelled() && !failure() }}
         run: task -v publish -- ${{ steps.proto-publish.outputs.args }}
 
       - name: Publish Cryptography Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: packages/cryptography
-        if: ${{ github.event.inputs.dry-run-enabled != 'true' && steps.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
+        if: ${{ steps.validate-release.outputs.crypto-publish-required == 'true' && !cancelled() && !failure() }}
         run: task -v publish -- ${{ steps.crypto-publish.outputs.args }}
 
       - name: Publish SDK Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        if: ${{ github.event.inputs.dry-run-enabled != 'true' && !cancelled() && !failure() }}
+        if: ${{ !cancelled() && !failure() }}
         run: task -v publish -- ${{ steps.sdk-publish.outputs.args }}
 
       - name: Generate Github Release

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -37,13 +37,13 @@ jobs:
       sdk-type: ${{ steps.tag.outputs.type }}
 
       # proto sub-package
-      proto-version: ${{ steps.proto-package.outputs.version }}
+      proto-version: ${{ steps.npm-package.outputs.proto-version }}
       proto-prerelease: ${{ steps.proto-package.outputs.prerelease }}
       proto-type: ${{ steps.proto-package.outputs.type }}
       proto-publish-required: ${{ steps.proto-required.outputs.publish-required }}
 
       # crypto sub-package
-      crypto-version: ${{ steps.crypto-package.outputs.version }}
+      crypto-version: ${{ steps.npm-package.outputs.crypto-version }}
       crypto-prerelease: ${{ steps.crypto-package.output.prerelease }}
       crypto-type: ${{ steps.crypto-package.output.type }}
       crypto-publish-required: ${{ steps.crypto-required.outputs.publish-required }}
@@ -159,7 +159,6 @@ jobs:
             exit 1
           fi
           
-          RELEASE_VERSION="${{ steps.npm-package.outputs.proto-version }}"
           PREREL_VERSION="$(semver get prerel '${{ steps.npm-package.outputs.proto-version }}')"
           PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
           
@@ -177,10 +176,6 @@ jobs:
             PREREL_TYPE="production"
           fi
           
-          FINAL_VERSION="${RELEASE_VERSION}"
-          [[ -n "${PREREL_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PREREL_VERSION}"
-          
-          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
           echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
           
@@ -194,7 +189,6 @@ jobs:
             exit 1
           fi
 
-          RELEASE_VERSION='${{ steps.npm-package.outputs.crypto-version }}'
           PREREL_VERSION="$(semver get prerel '${{ steps.npm-package.outputs.crypto-version }}')"
           PREREL_VERSION_LC="$(printf "%s" "${PREREL_VERSION}" | tr '[:upper:]' '[:lower:]')"
           
@@ -212,10 +206,6 @@ jobs:
             PREREL_TYPE="production"
           fi
           
-          FINAL_VERSION="${RELEASE_VERSION}"
-          [[ -n "${PREREL_VERSION}" ]] && FINAL_VERSION="${RELEASE_VERSION}-${PREREL_VERSION}"
-          
-          echo "version=${FINAL_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "prerelease=${IS_PRERELEASE}" >>"${GITHUB_OUTPUT}"
           echo "type=${PREREL_TYPE}" >>"${GITHUB_OUTPUT}"
 

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -84,11 +84,9 @@ jobs:
           PROTO_PACKAGE_VERSION="$(jq -r '.version' './packages/proto/package.json')"
           CRYPTO_PACKAGE_VERSION="$(jq -r '.version' './packages/cryptography/package.json')"
           
-          set -x
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "proto-version=${PROTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "crypto-version=${CRYPTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
-          set +x
 
       - name: Proto Subpackage Publish Required
         id: proto-required
@@ -258,9 +256,7 @@ jobs:
 
       - name: Compile Code
         run: |
-          set -x
           task -v build
-          set +x
 
   publish-release:
     name: Publish Release

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -269,7 +269,6 @@ jobs:
       - name: Compile Code
         run: |
           set -x
-          ls -alF | grep Taskfile
           task -v build
           set +x
 

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -267,7 +267,11 @@ jobs:
           node-version: 18
 
       - name: Compile Code
-        run: task -v build
+        run: |
+          set -x
+          ls -alF | grep Taskfile
+          task -v build
+          set +x
 
   publish-release:
     name: Publish Release

--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -81,8 +81,8 @@ jobs:
         id: npm-package
         run: |
           SDK_PACKAGE_VERSION="$(jq -r '.version' package.json)"
-          PROTO_PACKAGE_VERSION="$(jq -r '.version' 'packages/proto/package.json')"
-          CRYPTO_PACKAGE_VERSION="$(jq -r '.version' 'packages/cryptography/package.json')"
+          PROTO_PACKAGE_VERSION="$(jq -r '.version' './packages/proto/package.json')"
+          CRYPTO_PACKAGE_VERSION="$(jq -r '.version' './packages/cryptography/package.json')"
           
           echo "sdk-version=${SDK_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"
           echo "proto-version=${PROTO_PACKAGE_VERSION}" >>"${GITHUB_OUTPUT}"


### PR DESCRIPTION
**Description**:

Updates the publish_release workflow to accommodate the sdk, crypto, and proto release versions such that we can publish prerelease versions of subpackages that will not be marked as stable

**Related issue(s)**:

Fixes #2363 

