### PR TITLE
release: v2.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.48.0
+
+## What's Changed
+
+* release: proto v2.15.0-beta.2 by @svetoslav-nikol0v in https://github.com/hashgraph/hedera-sdk-js/pull/2367
+* ci: update publishing workflow to use appropriate pre release and stable versions by @rbarkerSL in https://github.com/hashgraph/hedera-sdk-js/pull/2364
+* feature: custom derivation paths in Mnemonic ECDSA private key derivation by @bguiz in https://github.com/hashgraph/hedera-sdk-js/pull/2341
+
 ## v2.47.0
 
 ## What's Changed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -12,7 +12,7 @@
 - **Merge** release branch into main
 - **Create** a new tag as running following command for:
     - stable release - `git tag -a "v*.*.*" -m "[message]"`
-    - bet release - `git tag -a "v*.*.*-beta.*" -m "[message]"`
+    - beta release - `git tag -a "v*.*.*-beta.*" -m "[message]"`
 - **Run** the following command for:
     - stable release - `git push origin v*.*.*`
     - beta release - `git push origin v*.*.*-beta.*`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/sdk",
-    "version": "2.47.0",
+    "version": "2.48.0",
     "description": "Hedera™ Hashgraph SDK",
     "types": "./lib/index.d.ts",
     "main": "./lib/index.cjs",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@ethersproject/rlp": "^5.7.0",
         "@grpc/grpc-js": "1.8.2",
         "@hashgraph/cryptography": "1.4.8-beta.5",
-        "@hashgraph/proto": "2.15.0-beta.1",
+        "@hashgraph/proto": "2.15.0-beta.2",
         "axios": "^1.6.4",
         "bignumber.js": "^9.1.1",
         "bn.js": "^5.1.1",


### PR DESCRIPTION
**Description**:

Stable release version v2.48.0

## What's Changed:
* release: proto v2.15.0-beta.2 by @svetoslav-nikol0v in https://github.com/hashgraph/hedera-sdk-js/pull/2367
* ci: update publishing workflow to use appropriate pre release and stable versions by @rbarkerSL in https://github.com/hashgraph/hedera-sdk-js/pull/2364
* feature: custom derivation paths in Mnemonic ECDSA private key derivation by @bguiz in https://github.com/hashgraph/hedera-sdk-js/pull/2341

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
