### PR TITLE
release: v2.48.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.48.1
+
+## What's Changed
+
+* release: proto v2.15.0-beta.2 by @svetoslav-nikol0v in https://github.com/hashgraph/hedera-sdk-js/pull/2367
+* ci: update publishing workflow to use appropriate pre release and stable versions by @rbarkerSL in https://github.com/hashgraph/hedera-sdk-js/pull/2364
+* feature: custom derivation paths in Mnemonic ECDSA private key derivation by @bguiz in https://github.com/hashgraph/hedera-sdk-js/pull/2341
+
 ## v2.48.0
 
 ## What's Changed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,8 +1,8 @@
 ## Release process of JS SDK
 
 - **Create** a new release branch following the naming convention for:
-    - stable release - `release/v*.*.*`
-    - beta release - `release/v*.*.*-beta.*`
+    - stable release - `release-v*.*.*`
+    - beta release - `release-v*.*.*-beta.*`
 - **Run** the [local node](https://github.com/hashgraph/hedera-local-node)
 - **Run** `task test:integration:node`
 - **Stop** the [local node](https://github.com/hashgraph/hedera-local-node)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/sdk",
-    "version": "2.48.0",
+    "version": "2.48.1",
     "description": "Hedera™ Hashgraph SDK",
     "types": "./lib/index.d.ts",
     "main": "./lib/index.cjs",

--- a/src/Mnemonic.js
+++ b/src/Mnemonic.js
@@ -186,6 +186,7 @@ export default class Mnemonic {
         passphrase,
         derivationPathValues,
     ) {
+        // eslint-disable-next-line deprecation/deprecation
         return await this.toEcdsaPrivateKey(passphrase, derivationPathValues);
     }
 

--- a/src/Status.js
+++ b/src/Status.js
@@ -2938,13 +2938,13 @@ Status.InvalidEndpoint = new Status(351);
  */
 Status.GossipEndpointsExceededLimit = new Status(352);
 
- /**
+/**
  * The transaction attempted to use duplicate `TokenReference`.<br/>
  * This affects `TokenReject` attempting to reject same token reference more than once.
  */
 Status.TokenReferenceRepeated = new Status(353);
 
- /**
+/**
  * The account id specified as the owner in `TokenReject` is invalid or does not exist.
  */
 Status.InvalidOwnerId = new Status(354);
@@ -2970,6 +2970,6 @@ Status.InvalidIpv4Address = new Status(357);
 Status.EmptyTokenReferenceList = new Status(358);
 
 /*
-* The node account is not allowed to be updated
-*/
+ * The node account is not allowed to be updated
+ */
 Status.UpdateNodeAccountNotAllowed = new Status(359);

--- a/test/unit/Mnemonic.js
+++ b/test/unit/Mnemonic.js
@@ -506,7 +506,9 @@ describe("Mnemonic", function () {
         const result2 = await mnemonic1.calculateDerivationPathValues(DPATH_2);
 
         // NOTE that 0x80000000 == 2147483648
-        expect(result1).to.deep.equal([-2147483604, -2147483588, -2147483648, 0, 0]);
+        expect(result1).to.deep.equal([
+            -2147483604, -2147483588, -2147483648, 0, 0,
+        ]);
         expect(result2).to.deep.equal([44, 60, 0, -1, -2]);
     });
 


### PR DESCRIPTION
**Description**:

Stable version v2.48.1.

## What's Changed

* release: proto v2.15.0-beta.2 by @svetoslav-nikol0v in https://github.com/hashgraph/hedera-sdk-js/pull/2367
* ci: update publishing workflow to use appropriate pre release and stable versions by @rbarkerSL in https://github.com/hashgraph/hedera-sdk-js/pull/2364
* feature: custom derivation paths in Mnemonic ECDSA private key derivation by @bguiz in https://github.com/hashgraph/hedera-sdk-js/pull/2341

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
