### PR TITLE
test: add maxAutomaticTokenAssociations tests

### DIFF
--- a/test/integration/TokenAssociateIntegrationTest.js
+++ b/test/integration/TokenAssociateIntegrationTest.js
@@ -138,7 +138,8 @@ describe("TokenAssociate", function () {
 
     describe("Max Auto Associations", function () {
         let receiverKey, receiverId;
-        const TOKEN_SUPPLY = 100;
+        const TOKEN_SUPPLY = 100,
+            TRANSFER_AMOUNT = 10;
 
         beforeEach(async function () {
             receiverKey = PrivateKey.generateECDSA();
@@ -201,15 +202,19 @@ describe("TokenAssociate", function () {
                     await tokenCreateTransaction2.getReceipt(env.client);
 
                 const sendTokenToReceiverTx = await new TransferTransaction()
-                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
-                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, env.operatorId, -TRANSFER_AMOUNT)
+                    .addTokenTransfer(tokenId, receiverId, TRANSFER_AMOUNT)
                     .execute(env.client);
 
                 await sendTokenToReceiverTx.getReceipt(env.client);
 
                 const sendTokenToReceiverTx2 = await new TransferTransaction()
-                    .addTokenTransfer(tokenId2, env.operatorId, -TOKEN_SUPPLY)
-                    .addTokenTransfer(tokenId2, receiverId, TOKEN_SUPPLY)
+                    .addTokenTransfer(
+                        tokenId2,
+                        env.operatorId,
+                        -TRANSFER_AMOUNT,
+                    )
+                    .addTokenTransfer(tokenId2, receiverId, TRANSFER_AMOUNT)
                     .freezeWith(env.client)
                     .execute(env.client);
 
@@ -364,8 +369,8 @@ describe("TokenAssociate", function () {
                 ).getReceipt(env.client);
 
                 const sendTokenToReceiverTx = await new TransferTransaction()
-                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
-                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, env.operatorId, -TRANSFER_AMOUNT)
+                    .addTokenTransfer(tokenId, receiverId, TRANSFER_AMOUNT)
                     .execute(env.client);
 
                 await sendTokenToReceiverTx.getReceipt(env.client);
@@ -375,7 +380,7 @@ describe("TokenAssociate", function () {
                     .execute(env.client);
 
                 expect(tokenBalance.tokens.get(tokenId).toInt()).to.be.equal(
-                    TOKEN_SUPPLY,
+                    TRANSFER_AMOUNT,
                 );
             });
 
@@ -478,15 +483,19 @@ describe("TokenAssociate", function () {
                 ).getReceipt(env.client);
 
                 const tokenTransferResponse = await new TransferTransaction()
-                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
-                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, env.operatorId, -TRANSFER_AMOUNT)
+                    .addTokenTransfer(tokenId, receiverId, TRANSFER_AMOUNT)
                     .execute(env.client);
 
                 await tokenTransferResponse.getReceipt(env.client);
 
                 const tokenTransferResponse2 = await new TransferTransaction()
-                    .addTokenTransfer(tokenId2, env.operatorId, -TOKEN_SUPPLY)
-                    .addTokenTransfer(tokenId2, receiverId, TOKEN_SUPPLY)
+                    .addTokenTransfer(
+                        tokenId2,
+                        env.operatorId,
+                        -TRANSFER_AMOUNT,
+                    )
+                    .addTokenTransfer(tokenId2, receiverId, TRANSFER_AMOUNT)
                     .execute(env.client);
 
                 await tokenTransferResponse2.getReceipt(env.client);
@@ -503,8 +512,8 @@ describe("TokenAssociate", function () {
                         .execute(env.client)
                 ).tokens.get(tokenId2);
 
-                expect(newTokenBalance.toInt()).to.equal(TOKEN_SUPPLY);
-                expect(newTokenBalance2.toInt()).to.equal(TOKEN_SUPPLY);
+                expect(newTokenBalance.toInt()).to.equal(TRANSFER_AMOUNT);
+                expect(newTokenBalance2.toInt()).to.equal(TRANSFER_AMOUNT);
             });
 
             it("receiver should contain NFTs when transfering to account with unlimited auto associations", async function () {
@@ -628,8 +637,8 @@ describe("TokenAssociate", function () {
                 );
 
                 const tokenTransferHalfSupply = await new TransferTransaction()
-                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
-                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, env.operatorId, -TRANSFER_AMOUNT)
+                    .addTokenTransfer(tokenId, receiverId, TRANSFER_AMOUNT)
                     .execute(env.client);
 
                 await tokenTransferHalfSupply.getReceipt(env.client);
@@ -663,13 +672,13 @@ describe("TokenAssociate", function () {
 
                 expect(
                     tokenBalanceReceiver.tokens.get(tokenId).toInt(),
-                ).to.equal(TOKEN_SUPPLY);
+                ).to.equal(TRANSFER_AMOUNT);
 
                 expect(tokenBalanceSpender.tokens.get(tokenId)).to.equal(null);
 
                 expect(
                     tokenBalanceTreasury.tokens.get(tokenId).toInt(),
-                ).to.equal(0);
+                ).to.equal(TOKEN_SUPPLY - TRANSFER_AMOUNT);
             });
 
             it("receiver should have nft even if it has given allowance to spender", async function () {
@@ -806,8 +815,12 @@ describe("TokenAssociate", function () {
                 ).execute(env.client);
 
                 const tokenTransferResponse = await new TransferTransaction()
-                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
-                    .addTokenTransfer(tokenId, receiverAccountId, TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, env.operatorId, -TRANSFER_AMOUNT)
+                    .addTokenTransfer(
+                        tokenId,
+                        receiverAccountId,
+                        TRANSFER_AMOUNT,
+                    )
                     .execute(env.client);
 
                 await tokenTransferResponse.getReceipt(env.client);
@@ -820,7 +833,7 @@ describe("TokenAssociate", function () {
                     .get(tokenId)
                     .toInt();
 
-                expect(receiverBalance).to.equal(TOKEN_SUPPLY);
+                expect(receiverBalance).to.equal(TRANSFER_AMOUNT);
             });
 
             it("should revert when auto association is set to <-1", async function () {

--- a/test/integration/TokenAssociateIntegrationTest.js
+++ b/test/integration/TokenAssociateIntegrationTest.js
@@ -155,7 +155,7 @@ describe("TokenAssociate", function () {
 
         describe("Limited Auto Associations", function () {
             it("should revert FT transfer when no auto associations left", async function () {
-                this.timeout(12000);
+                this.timeout(120000);
                 // update account to have one auto association
                 const accountUpdateTx = await new AccountUpdateTransaction()
                     .setAccountId(receiverId)
@@ -325,7 +325,7 @@ describe("TokenAssociate", function () {
             });
 
             it("should contain sent balance when transfering FT to account with manual token association", async function () {
-                this.timeout(12000);
+                this.timeout(120000);
                 const tokenCreateTransaction =
                     await new TokenCreateTransaction()
                         .setTokenType(TokenType.FungibleCommon)
@@ -380,7 +380,7 @@ describe("TokenAssociate", function () {
             });
 
             it("should contain sent balance when transfering NFT to account with manual token association", async function () {
-                this.timeout(12000);
+                this.timeout(120000);
                 const tokenCreateTransaction =
                     await new TokenCreateTransaction()
                         .setTokenType(TokenType.NonFungibleUnique)
@@ -432,7 +432,7 @@ describe("TokenAssociate", function () {
 
         describe("Unlimited Auto Associations", function () {
             it("receiver should contain FTs when transfering to account with unlimited auto associations", async function () {
-                this.timeout(12000);
+                this.timeout(120000);
                 const tokenCreateResponse = await new TokenCreateTransaction()
                     .setTokenType(TokenType.FungibleCommon)
                     .setTokenName("ffff")
@@ -508,7 +508,7 @@ describe("TokenAssociate", function () {
             });
 
             it("receiver should contain NFTs when transfering to account with unlimited auto associations", async function () {
-                this.timeout(12000);
+                this.timeout(120000);
                 const tokenCreateResponse = await new TokenCreateTransaction()
                     .setTokenType(TokenType.NonFungibleUnique)
                     .setTokenName("ffff")
@@ -590,7 +590,7 @@ describe("TokenAssociate", function () {
             });
 
             it("receiver should have token balance even if it has given allowance to spender", async function () {
-                this.timeout(12000);
+                this.timeout(120000);
                 const spenderKey = PrivateKey.generateECDSA();
 
                 const unlimitedAutoAssociationTx =
@@ -673,7 +673,7 @@ describe("TokenAssociate", function () {
             });
 
             it("receiver should have nft even if it has given allowance to spender", async function () {
-                this.timeout(12000);
+                this.timeout(120000);
                 const spenderKey = PrivateKey.generateECDSA();
 
                 const unlimitedAutoAssociationReceiverTx =

--- a/test/integration/TokenAssociateIntegrationTest.js
+++ b/test/integration/TokenAssociateIntegrationTest.js
@@ -1,12 +1,19 @@
 import {
+    AccountAllowanceApproveTransaction,
     AccountBalanceQuery,
     AccountCreateTransaction,
-    AccountInfoQuery,
+    AccountUpdateTransaction,
     Hbar,
+    NftId,
+    AccountInfoQuery,
     PrivateKey,
     Status,
     TokenAssociateTransaction,
     TokenCreateTransaction,
+    TokenMintTransaction,
+    TokenType,
+    TransactionId,
+    TransferTransaction,
 } from "../../src/exports.js";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
 
@@ -14,7 +21,7 @@ describe("TokenAssociate", function () {
     let env;
 
     before(async function () {
-        env = await IntegrationTestEnv.new();
+        env = await IntegrationTestEnv.new({ balance: 1000 });
     });
 
     it("should be executable", async function () {
@@ -127,6 +134,739 @@ describe("TokenAssociate", function () {
         if (!err) {
             throw new Error("token association did not error");
         }
+    });
+
+    describe("Max Auto Associations", function () {
+        let receiverKey, receiverId;
+        const TOKEN_SUPPLY = 100;
+
+        beforeEach(async function () {
+            receiverKey = PrivateKey.generateECDSA();
+            const receiverAccountCreateTx = await new AccountCreateTransaction()
+                .setKey(receiverKey)
+                .freezeWith(env.client)
+                .sign(receiverKey);
+            receiverId = (
+                await (
+                    await receiverAccountCreateTx.execute(env.client)
+                ).getReceipt(env.client)
+            ).accountId;
+        });
+
+        describe("Limited Auto Associations", function () {
+            it("should revert FT transfer when no auto associations left", async function () {
+                this.timeout(12000);
+                // update account to have one auto association
+                const accountUpdateTx = await new AccountUpdateTransaction()
+                    .setAccountId(receiverId)
+                    .setMaxAutomaticTokenAssociations(1)
+                    .freezeWith(env.client)
+                    .sign(receiverKey);
+
+                await (
+                    await accountUpdateTx.execute(env.client)
+                ).getReceipt(env.client);
+
+                const tokenCreateTransaction =
+                    await new TokenCreateTransaction()
+                        .setTokenType(TokenType.FungibleCommon)
+                        .setTokenName("FFFFF")
+                        .setTokenSymbol("ffff")
+                        .setInitialSupply(TOKEN_SUPPLY)
+                        .setTreasuryAccountId(env.operatorId)
+                        .setAdminKey(env.operatorKey)
+                        .setFreezeKey(env.operatorKey)
+                        .setWipeKey(env.operatorKey)
+                        .setSupplyKey(env.operatorKey)
+                        .execute(env.client);
+
+                const { tokenId } = await tokenCreateTransaction.getReceipt(
+                    env.client,
+                );
+
+                const tokenCreateTransaction2 =
+                    await new TokenCreateTransaction()
+                        .setTokenType(TokenType.FungibleCommon)
+                        .setTokenName("FFFFF")
+                        .setTokenSymbol("ffff")
+                        .setInitialSupply(TOKEN_SUPPLY)
+                        .setTreasuryAccountId(env.operatorId)
+                        .setAdminKey(env.operatorKey)
+                        .setFreezeKey(env.operatorKey)
+                        .setWipeKey(env.operatorKey)
+                        .setSupplyKey(env.operatorKey)
+                        .execute(env.client);
+
+                const { tokenId: tokenId2 } =
+                    await tokenCreateTransaction2.getReceipt(env.client);
+
+                const sendTokenToReceiverTx = await new TransferTransaction()
+                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .execute(env.client);
+
+                await sendTokenToReceiverTx.getReceipt(env.client);
+
+                const sendTokenToReceiverTx2 = await new TransferTransaction()
+                    .addTokenTransfer(tokenId2, env.operatorId, -TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId2, receiverId, TOKEN_SUPPLY)
+                    .freezeWith(env.client)
+                    .execute(env.client);
+
+                let err = false;
+
+                try {
+                    await sendTokenToReceiverTx2.getReceipt(env.client);
+                } catch (error) {
+                    err = error
+                        .toString()
+                        .includes(Status.NoRemainingAutomaticAssociations);
+                }
+
+                if (!err) {
+                    throw new Error(
+                        "Token transfer did not error with NO_REMAINING_AUTOMATIC_ASSOCIATIONS",
+                    );
+                }
+            });
+
+            it("should revert NFTs transfer when no auto associations left", async function () {
+                this.timeout(120000);
+                const accountUpdateTx = await new AccountUpdateTransaction()
+                    .setAccountId(receiverId)
+                    .setMaxAutomaticTokenAssociations(1)
+                    .freezeWith(env.client)
+                    .sign(receiverKey);
+
+                await (
+                    await accountUpdateTx.execute(env.client)
+                ).getReceipt(env.client);
+
+                // create token 1
+                const tokenCreateTransaction =
+                    await new TokenCreateTransaction()
+                        .setTokenType(TokenType.NonFungibleUnique)
+                        .setTokenName("FFFFF")
+                        .setTokenSymbol("ffff")
+                        .setTreasuryAccountId(env.operatorId)
+                        .setAdminKey(env.operatorKey)
+                        .setSupplyKey(env.operatorKey)
+                        .execute(env.client);
+
+                const { tokenId } = await tokenCreateTransaction.getReceipt(
+                    env.client,
+                );
+
+                // mint a token in token 1
+                const tokenMintSignedTransaction =
+                    await new TokenMintTransaction()
+                        .setTokenId(tokenId)
+                        .setMetadata([Buffer.from("-")])
+                        .execute(env.client);
+
+                await tokenMintSignedTransaction.getReceipt(env.client);
+
+                // transfer the token to receiver
+
+                const transferTxSign = await new TransferTransaction()
+                    .addNftTransfer(tokenId, 1, env.operatorId, receiverId)
+                    .execute(env.client);
+
+                await transferTxSign.getReceipt(env.client);
+
+                // create token 2
+                const tokenCreateTransaction2 =
+                    await new TokenCreateTransaction()
+                        .setTokenType(TokenType.NonFungibleUnique)
+                        .setTokenName("FFFFF")
+                        .setTokenSymbol("ffff")
+                        .setTreasuryAccountId(env.operatorId)
+                        .setAdminKey(env.operatorKey)
+                        .setSupplyKey(env.operatorKey)
+                        .execute(env.client);
+
+                const { tokenId: tokenId2 } =
+                    await tokenCreateTransaction2.getReceipt(env.client);
+
+                // mint token 2
+                const tokenMintSignedTransaction2 =
+                    await new TokenMintTransaction()
+                        .setTokenId(tokenId2)
+                        .addMetadata(Buffer.from("-"))
+                        .execute(env.client);
+
+                await tokenMintSignedTransaction2.getReceipt(env.client);
+
+                let err = false;
+
+                try {
+                    const transferToken2Response =
+                        await new TransferTransaction()
+                            .addNftTransfer(
+                                tokenId2,
+                                1,
+                                env.operatorId,
+                                receiverId,
+                            )
+                            .execute(env.client);
+
+                    await transferToken2Response.getReceipt(env.client);
+                } catch (error) {
+                    err = error
+                        .toString()
+                        .includes(Status.NoRemainingAutomaticAssociations);
+                }
+
+                if (!err) {
+                    throw new Error(
+                        "Token transfer did not error with NO_REMAINING_AUTOMATIC_ASSOCIATIONS",
+                    );
+                }
+            });
+
+            it("should contain sent balance when transfering FT to account with manual token association", async function () {
+                this.timeout(12000);
+                const tokenCreateTransaction =
+                    await new TokenCreateTransaction()
+                        .setTokenType(TokenType.FungibleCommon)
+                        .setTokenName("FFFFF")
+                        .setTokenSymbol("ffff")
+                        .setInitialSupply(TOKEN_SUPPLY)
+                        .setTreasuryAccountId(env.operatorId)
+                        .setAdminKey(env.operatorKey)
+                        .setFreezeKey(env.operatorKey)
+                        .setWipeKey(env.operatorKey)
+                        .setSupplyKey(env.operatorKey)
+                        .execute(env.client);
+
+                const { tokenId } = await tokenCreateTransaction.getReceipt(
+                    env.client,
+                );
+
+                const tokenAssociateTransaction =
+                    await new TokenAssociateTransaction()
+                        .setAccountId(receiverId)
+                        .setTokenIds([tokenId])
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+
+                await (
+                    await tokenAssociateTransaction.execute(env.client)
+                ).getReceipt(env.client);
+
+                const tokenMintTx = await new TokenMintTransaction()
+                    .setTokenId(tokenId)
+                    .freezeWith(env.client)
+                    .sign(env.operatorKey);
+
+                await (
+                    await tokenMintTx.execute(env.client)
+                ).getReceipt(env.client);
+
+                const sendTokenToReceiverTx = await new TransferTransaction()
+                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .execute(env.client);
+
+                await sendTokenToReceiverTx.getReceipt(env.client);
+
+                const tokenBalance = await new AccountBalanceQuery()
+                    .setAccountId(receiverId)
+                    .execute(env.client);
+
+                expect(tokenBalance.tokens.get(tokenId).toInt()).to.be.equal(
+                    TOKEN_SUPPLY,
+                );
+            });
+
+            it("should contain sent balance when transfering NFT to account with manual token association", async function () {
+                this.timeout(12000);
+                const tokenCreateTransaction =
+                    await new TokenCreateTransaction()
+                        .setTokenType(TokenType.NonFungibleUnique)
+                        .setTokenName("FFFFF")
+                        .setTokenSymbol("ffff")
+                        .setTreasuryAccountId(env.operatorId)
+                        .setAdminKey(env.operatorKey)
+                        .setSupplyKey(env.operatorKey)
+                        .execute(env.client);
+
+                const { tokenId } = await tokenCreateTransaction.getReceipt(
+                    env.client,
+                );
+
+                const tokenAssociateTransaction =
+                    await new TokenAssociateTransaction()
+                        .setAccountId(receiverId)
+                        .setTokenIds([tokenId])
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+
+                await (
+                    await tokenAssociateTransaction.execute(env.client)
+                ).getReceipt(env.client);
+
+                const tokenMintTx = await new TokenMintTransaction()
+                    .setTokenId(tokenId)
+                    .setMetadata([Buffer.from("-")])
+                    .freezeWith(env.client)
+                    .sign(env.operatorKey);
+
+                await (
+                    await tokenMintTx.execute(env.client)
+                ).getReceipt(env.client);
+
+                const sendTokenToReceiverTx = await new TransferTransaction()
+                    .addNftTransfer(tokenId, 1, env.operatorId, receiverId)
+                    .execute(env.client);
+
+                await sendTokenToReceiverTx.getReceipt(env.client);
+
+                const tokenBalance = await new AccountBalanceQuery()
+                    .setAccountId(receiverId)
+                    .execute(env.client);
+
+                expect(tokenBalance.tokens.get(tokenId).toInt()).to.be.equal(1);
+            });
+        });
+
+        describe("Unlimited Auto Associations", function () {
+            it("receiver should contain FTs when transfering to account with unlimited auto associations", async function () {
+                this.timeout(12000);
+                const tokenCreateResponse = await new TokenCreateTransaction()
+                    .setTokenType(TokenType.FungibleCommon)
+                    .setTokenName("ffff")
+                    .setTokenSymbol("F")
+                    .setInitialSupply(TOKEN_SUPPLY)
+                    .setTreasuryAccountId(env.operatorId)
+                    .setAdminKey(env.operatorKey)
+                    .setFreezeKey(env.operatorKey)
+                    .setWipeKey(env.operatorKey)
+                    .setSupplyKey(env.operatorKey)
+                    .execute(env.client);
+
+                const { tokenId } = await tokenCreateResponse.getReceipt(
+                    env.client,
+                );
+
+                const tokenCreateResponse2 = await new TokenCreateTransaction()
+                    .setTokenType(TokenType.FungibleCommon)
+                    .setTokenName("ffff")
+                    .setTokenSymbol("F")
+                    .setInitialSupply(TOKEN_SUPPLY)
+                    .setTreasuryAccountId(env.operatorId)
+                    .setAdminKey(env.operatorKey)
+                    .setFreezeKey(env.operatorKey)
+                    .setWipeKey(env.operatorKey)
+                    .setSupplyKey(env.operatorKey)
+                    .execute(env.client);
+
+                const { tokenId: tokenId2 } =
+                    await tokenCreateResponse2.getReceipt(env.client);
+
+                const updateUnlimitedAutomaticAssociations =
+                    await new AccountUpdateTransaction()
+                        .setAccountId(receiverId)
+                        .setMaxAutomaticTokenAssociations(-1)
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+
+                await (
+                    await updateUnlimitedAutomaticAssociations.execute(
+                        env.client,
+                    )
+                ).getReceipt(env.client);
+
+                const tokenTransferResponse = await new TransferTransaction()
+                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .execute(env.client);
+
+                await tokenTransferResponse.getReceipt(env.client);
+
+                const tokenTransferResponse2 = await new TransferTransaction()
+                    .addTokenTransfer(tokenId2, env.operatorId, -TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId2, receiverId, TOKEN_SUPPLY)
+                    .execute(env.client);
+
+                await tokenTransferResponse2.getReceipt(env.client);
+
+                const newTokenBalance = (
+                    await new AccountBalanceQuery()
+                        .setAccountId(receiverId)
+                        .execute(env.client)
+                ).tokens.get(tokenId);
+
+                const newTokenBalance2 = (
+                    await new AccountBalanceQuery()
+                        .setAccountId(receiverId)
+                        .execute(env.client)
+                ).tokens.get(tokenId2);
+
+                expect(newTokenBalance.toInt()).to.equal(TOKEN_SUPPLY);
+                expect(newTokenBalance2.toInt()).to.equal(TOKEN_SUPPLY);
+            });
+
+            it("receiver should contain NFTs when transfering to account with unlimited auto associations", async function () {
+                this.timeout(12000);
+                const tokenCreateResponse = await new TokenCreateTransaction()
+                    .setTokenType(TokenType.NonFungibleUnique)
+                    .setTokenName("ffff")
+                    .setTokenSymbol("F")
+                    .setTreasuryAccountId(env.operatorId)
+                    .setAdminKey(env.operatorKey)
+                    .setSupplyKey(env.operatorKey)
+                    .execute(env.client);
+
+                const { tokenId } = await tokenCreateResponse.getReceipt(
+                    env.client,
+                );
+
+                const tokenCreateResponse2 = await new TokenCreateTransaction()
+                    .setTokenType(TokenType.NonFungibleUnique)
+                    .setTokenName("ffff")
+                    .setTokenSymbol("F")
+                    .setTreasuryAccountId(env.operatorId)
+                    .setAdminKey(env.operatorKey)
+                    .setSupplyKey(env.operatorKey)
+                    .execute(env.client);
+
+                const { tokenId: tokenId2 } =
+                    await tokenCreateResponse2.getReceipt(env.client);
+
+                const mintTokenTx = await new TokenMintTransaction()
+                    .setTokenId(tokenId)
+                    .setMetadata([Buffer.from("-")])
+                    .execute(env.client);
+
+                await mintTokenTx.getReceipt(env.client);
+
+                const mintTokenTx2 = await new TokenMintTransaction()
+                    .setTokenId(tokenId2)
+                    .setMetadata([Buffer.from("-")])
+                    .execute(env.client);
+
+                await mintTokenTx2.getReceipt(env.client);
+
+                const updateUnlimitedAutomaticAssociations =
+                    await new AccountUpdateTransaction()
+                        .setAccountId(receiverId)
+                        .setMaxAutomaticTokenAssociations(-1)
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+
+                await (
+                    await updateUnlimitedAutomaticAssociations.execute(
+                        env.client,
+                    )
+                ).getReceipt(env.client);
+
+                const tokenTransferResponse = await new TransferTransaction()
+                    .addNftTransfer(tokenId, 1, env.operatorId, receiverId)
+                    .execute(env.client);
+
+                await tokenTransferResponse.getReceipt(env.client);
+
+                const tokenTransferResponse2 = await new TransferTransaction()
+                    .addNftTransfer(tokenId2, 1, env.operatorId, receiverId)
+                    .execute(env.client);
+
+                await tokenTransferResponse2.getReceipt(env.client);
+
+                const newTokenBalance = (
+                    await new AccountBalanceQuery()
+                        .setAccountId(receiverId)
+                        .execute(env.client)
+                ).tokens.get(tokenId);
+
+                const newTokenBalance2 = (
+                    await new AccountBalanceQuery()
+                        .setAccountId(receiverId)
+                        .execute(env.client)
+                ).tokens.get(tokenId2);
+
+                expect(newTokenBalance.toInt()).to.equal(1);
+                expect(newTokenBalance2.toInt()).to.equal(1);
+            });
+
+            it("receiver should have token balance even if it has given allowance to spender", async function () {
+                this.timeout(12000);
+                const spenderKey = PrivateKey.generateECDSA();
+
+                const unlimitedAutoAssociationTx =
+                    await new AccountUpdateTransaction()
+                        .setAccountId(receiverId)
+                        .setMaxAutomaticTokenAssociations(-1)
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+
+                await (
+                    await unlimitedAutoAssociationTx.execute(env.client)
+                ).getReceipt(env.client);
+
+                const spenderAccountCreateTx =
+                    await new AccountCreateTransaction()
+                        .setKey(spenderKey)
+                        .setInitialBalance(new Hbar(1))
+                        .execute(env.client);
+
+                const spenderId = (
+                    await spenderAccountCreateTx.getReceipt(env.client)
+                ).accountId;
+
+                const tokenCreateResponse = await new TokenCreateTransaction()
+                    .setTokenName("ffff")
+                    .setTokenSymbol("F")
+                    .setInitialSupply(TOKEN_SUPPLY)
+                    .setTreasuryAccountId(env.operatorId)
+                    .setAdminKey(env.operatorKey)
+                    .setSupplyKey(env.operatorKey)
+                    .execute(env.client);
+
+                const { tokenId } = await tokenCreateResponse.getReceipt(
+                    env.client,
+                );
+
+                const tokenTransferHalfSupply = await new TransferTransaction()
+                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, receiverId, TOKEN_SUPPLY)
+                    .execute(env.client);
+
+                await tokenTransferHalfSupply.getReceipt(env.client);
+
+                const tokenAllowanceTx =
+                    await new AccountAllowanceApproveTransaction()
+                        .approveTokenAllowance(
+                            tokenId,
+                            receiverId,
+                            spenderId,
+                            1,
+                        )
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+
+                await (
+                    await tokenAllowanceTx.execute(env.client)
+                ).getReceipt(env.client);
+
+                const tokenBalanceReceiver = await new AccountBalanceQuery()
+                    .setAccountId(receiverId)
+                    .execute(env.client);
+
+                const tokenBalanceSpender = await new AccountBalanceQuery()
+                    .setAccountId(spenderId)
+                    .execute(env.client);
+
+                const tokenBalanceTreasury = await new AccountBalanceQuery()
+                    .setAccountId(env.operatorId)
+                    .execute(env.client);
+
+                expect(
+                    tokenBalanceReceiver.tokens.get(tokenId).toInt(),
+                ).to.equal(TOKEN_SUPPLY);
+
+                expect(tokenBalanceSpender.tokens.get(tokenId)).to.equal(null);
+
+                expect(
+                    tokenBalanceTreasury.tokens.get(tokenId).toInt(),
+                ).to.equal(0);
+            });
+
+            it("receiver should have nft even if it has given allowance to spender", async function () {
+                this.timeout(12000);
+                const spenderKey = PrivateKey.generateECDSA();
+
+                const unlimitedAutoAssociationReceiverTx =
+                    await new AccountUpdateTransaction()
+                        .setAccountId(receiverId)
+                        .setMaxAutomaticTokenAssociations(-1)
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+
+                await (
+                    await unlimitedAutoAssociationReceiverTx.execute(env.client)
+                ).getReceipt(env.client);
+
+                const spenderAccountCreateTx =
+                    await new AccountCreateTransaction()
+                        .setKey(spenderKey)
+                        .setInitialBalance(new Hbar(1))
+                        .setMaxAutomaticTokenAssociations(-1)
+                        .execute(env.client);
+
+                const spenderId = (
+                    await spenderAccountCreateTx.getReceipt(env.client)
+                ).accountId;
+
+                const tokenCreateResponse = await new TokenCreateTransaction()
+                    .setTokenName("ffff")
+                    .setTokenSymbol("F")
+                    .setTokenType(TokenType.NonFungibleUnique)
+                    .setTreasuryAccountId(env.operatorId)
+                    .setAdminKey(env.operatorKey)
+                    .setSupplyKey(env.operatorKey)
+                    .execute(env.client);
+
+                const { tokenId } = await tokenCreateResponse.getReceipt(
+                    env.client,
+                );
+
+                await (
+                    await new TokenMintTransaction()
+                        .setTokenId(tokenId)
+                        .setMetadata([Buffer.from("-")])
+                        .execute(env.client)
+                ).getReceipt(env.client);
+
+                const nftId = new NftId(tokenId, 1);
+                const nftAllowanceTx =
+                    await new AccountAllowanceApproveTransaction()
+                        .approveTokenNftAllowance(
+                            nftId,
+                            env.operatorId,
+                            spenderId,
+                        )
+                        .execute(env.client);
+
+                await nftAllowanceTx.getReceipt(env.client);
+
+                // Generate TransactionId from spender's account id in order
+                // for the transaction to be to be executed on behalf of the spender
+                const onBehalfOfTransactionId =
+                    TransactionId.generate(spenderId);
+
+                const nftTransferToReceiver = await new TransferTransaction()
+                    .addApprovedNftTransfer(nftId, env.operatorId, receiverId)
+                    .setTransactionId(onBehalfOfTransactionId)
+                    .freezeWith(env.client)
+                    .sign(spenderKey);
+
+                await (
+                    await nftTransferToReceiver.execute(env.client)
+                ).getReceipt(env.client);
+
+                const tokenBalanceReceiver = await new AccountBalanceQuery()
+                    .setAccountId(receiverId)
+                    .execute(env.client);
+
+                const tokenBalanceSpender = await new AccountBalanceQuery()
+                    .setAccountId(spenderId)
+                    .execute(env.client);
+
+                const tokenBalanceTreasury = await new AccountBalanceQuery()
+                    .setAccountId(env.operatorId)
+                    .execute(env.client);
+
+                expect(
+                    tokenBalanceReceiver.tokens.get(tokenId).toInt(),
+                ).to.equal(1);
+
+                expect(tokenBalanceSpender.tokens.get(tokenId)).to.equal(null);
+
+                expect(
+                    tokenBalanceTreasury.tokens.get(tokenId).toInt(),
+                ).to.equal(0);
+            });
+
+            it("receiver with unlimited auto associations should have FTs with decimal when sender transfers FTs", async function () {
+                const tokenCreateResponse = await new TokenCreateTransaction()
+                    .setTokenType(TokenType.FungibleCommon)
+                    .setTokenName("FFFFFFF")
+                    .setTokenSymbol("fff")
+                    .setDecimals(3)
+                    .setInitialSupply(TOKEN_SUPPLY)
+                    .setTreasuryAccountId(env.operatorId)
+                    .setAdminKey(env.operatorKey)
+                    .setFreezeKey(env.operatorKey)
+                    .setWipeKey(env.operatorKey)
+                    .setSupplyKey(env.operatorKey)
+                    .execute(env.client);
+
+                const { tokenId } = await tokenCreateResponse.getReceipt(
+                    env.client,
+                );
+
+                const receiverKey = PrivateKey.generateECDSA();
+                const receiverAccountResponse =
+                    await new AccountCreateTransaction()
+                        .setKey(receiverKey)
+                        .setMaxAutomaticTokenAssociations(-1)
+                        .setInitialBalance(new Hbar(1))
+                        .execute(env.client);
+
+                const { accountId: receiverAccountId } =
+                    await receiverAccountResponse.getReceipt(env.client);
+
+                await (
+                    await new TokenAssociateTransaction()
+                        .setAccountId(receiverAccountId)
+                        .setTokenIds([tokenId])
+                        .freezeWith(env.client)
+                        .sign(receiverKey)
+                ).execute(env.client);
+
+                const tokenTransferResponse = await new TransferTransaction()
+                    .addTokenTransfer(tokenId, env.operatorId, -TOKEN_SUPPLY)
+                    .addTokenTransfer(tokenId, receiverAccountId, TOKEN_SUPPLY)
+                    .execute(env.client);
+
+                await tokenTransferResponse.getReceipt(env.client);
+
+                const receiverBalance = (
+                    await new AccountBalanceQuery()
+                        .setAccountId(receiverAccountId)
+                        .execute(env.client)
+                ).tokens
+                    .get(tokenId)
+                    .toInt();
+
+                expect(receiverBalance).to.equal(TOKEN_SUPPLY);
+            });
+
+            it("should revert when auto association is set to <-1", async function () {
+                let err = false;
+
+                try {
+                    const accountUpdateTx = await new AccountUpdateTransaction()
+                        .setAccountId(receiverId)
+                        .setMaxAutomaticTokenAssociations(-2)
+                        .freezeWith(env.client)
+                        .sign(receiverKey);
+                    await (
+                        await accountUpdateTx.execute(env.client)
+                    ).getReceipt(env.client);
+                } catch (error) {
+                    err = error
+                        .toString()
+                        .includes(Status.InvalidMaxAutoAssociations);
+                }
+
+                if (!err) {
+                    throw new Error("Token association did not error");
+                }
+
+                try {
+                    const key = PrivateKey.generateECDSA();
+                    const accountCreateInvalidAutoAssociation =
+                        await new AccountCreateTransaction()
+                            .setKey(key)
+                            .setMaxAutomaticTokenAssociations(-2)
+                            .execute(env.client);
+
+                    await accountCreateInvalidAutoAssociation.getReceipt(
+                        env.client,
+                    );
+                } catch (error) {
+                    err = error
+                        .toString()
+                        .includes(Status.InvalidMaxAutoAssociations);
+                }
+
+                if (!err) {
+                    throw new Error("Token association did not error");
+                }
+            });
+        });
     });
 
     after(async function () {

--- a/test/integration/TokenAssociateIntegrationTest.js
+++ b/test/integration/TokenAssociateIntegrationTest.js
@@ -269,12 +269,19 @@ describe("TokenAssociate", function () {
                         .setMetadata([Buffer.from("-")])
                         .execute(env.client);
 
-                await tokenMintSignedTransaction.getReceipt(env.client);
+                const { serials } = await tokenMintSignedTransaction.getReceipt(
+                    env.client,
+                );
 
                 // transfer the token to receiver
 
                 const transferTxSign = await new TransferTransaction()
-                    .addNftTransfer(tokenId, 1, env.operatorId, receiverId)
+                    .addNftTransfer(
+                        tokenId,
+                        serials[0],
+                        env.operatorId,
+                        receiverId,
+                    )
                     .execute(env.client);
 
                 await transferTxSign.getReceipt(env.client);
@@ -300,7 +307,9 @@ describe("TokenAssociate", function () {
                         .addMetadata(Buffer.from("-"))
                         .execute(env.client);
 
-                await tokenMintSignedTransaction2.getReceipt(env.client);
+                const serials2 = (
+                    await tokenMintSignedTransaction2.getReceipt(env.client)
+                ).serials;
 
                 let err = false;
 
@@ -309,7 +318,7 @@ describe("TokenAssociate", function () {
                         await new TransferTransaction()
                             .addNftTransfer(
                                 tokenId2,
-                                1,
+                                serials2[0],
                                 env.operatorId,
                                 receiverId,
                             )
@@ -417,12 +426,17 @@ describe("TokenAssociate", function () {
                     .freezeWith(env.client)
                     .sign(env.operatorKey);
 
-                await (
+                const { serials } = await (
                     await tokenMintTx.execute(env.client)
                 ).getReceipt(env.client);
 
                 const sendTokenToReceiverTx = await new TransferTransaction()
-                    .addNftTransfer(tokenId, 1, env.operatorId, receiverId)
+                    .addNftTransfer(
+                        tokenId,
+                        serials[0],
+                        env.operatorId,
+                        receiverId,
+                    )
                     .execute(env.client);
 
                 await sendTokenToReceiverTx.getReceipt(env.client);
@@ -548,7 +562,7 @@ describe("TokenAssociate", function () {
                     .setMetadata([Buffer.from("-")])
                     .execute(env.client);
 
-                await mintTokenTx.getReceipt(env.client);
+                const { serials } = await mintTokenTx.getReceipt(env.client);
 
                 const mintTokenTx2 = await new TokenMintTransaction()
                     .setTokenId(tokenId2)
@@ -571,7 +585,12 @@ describe("TokenAssociate", function () {
                 ).getReceipt(env.client);
 
                 const tokenTransferResponse = await new TransferTransaction()
-                    .addNftTransfer(tokenId, 1, env.operatorId, receiverId)
+                    .addNftTransfer(
+                        tokenId,
+                        serials[0],
+                        env.operatorId,
+                        receiverId,
+                    )
                     .execute(env.client);
 
                 await tokenTransferResponse.getReceipt(env.client);


### PR DESCRIPTION
**Description**:

Adds integration tests for `maxAutomaticTokenAssociations` according to HIP-904 test plan. 
 
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

This PR modifies `TokenAssociateIntegrationTest.js` by adding additional tests according to this test plan: 

> LIMITED AUTO ASSOCIATIONS `[0-5000]` (some sdks don’t have tests for these flows)
> 1. Given 2 fungible tokens, a sender account with a balance of the 2 fungible tokens, and a receiver account with 1 auto associations, when token1 is transferred from the sender to the receiver account, then the receiver account contains the sent balance of the token and when token2 is transferred from the sender to the receiver account, then the transaction fails with `NO_REMAINING_AUTOMATIC_ASSOCIATIONS`
> 2. Same test as above but with NFTs
> 3. Given a fungible token, a sender account with a balance of the fungible token, a receiver account with no auto associations, and the fungible token is manually associated with the receiver account, when the token is transferred from the sender to the receiver account, then the receiver account contains the sent balance of the token
> 4. Given an NFT, a sender account with 1 minted NFT, a receiver account with no auto associations, and the NFT is manually associated with the receiver account, when the NFT is transferred from the sender to the receiver account, then the receiver account contains the NFT ***(this is same as above but with NFT)***

> ***UNLIMITED AUTO ASSOCIATIONS `-1`***
>1. Given 2 fungible tokens, a sender account with a balance of the 2 fungible tokens, and a receiver account with 1 auto associations, when token1 is transferred from the sender to the receiver account, then the receiver account contains the sent balance of the token and when token2 is transferred from the sender to the receiver account, then receiver account contains the sent balance of the token 
> 2. Same test as above but with NFTs
> 3. Given a fungible token, a holder account with a balance of the fungible token, a spender account which has an allowance of the fungible token, and a receiver account with unlimited auto associations, when the token is transferred from the spender to the receiver account, then the receiver account contains the sent balance of the token and the transferred amount is debited from the holder account
> 4. Given an NFT, a holder account with 1 minted NFT, a spender account which has an allowance of the NFT, and a receiver account with unlimited auto associations, when the NFT is transferred from the spender to the receiver account, then the receiver account contains the NFT and the NFT is debited from the holder account  ***(this is same as above but with NFT)***
> 5. Given a fungible token with `decimals`, a sender account with a balance of the fungible token, and a receiver account with unlimited auto associations, when the token is transferred from the sender to the receiver account, then the receiver account contains the sent balance of the token 
> 6. Given a a receiver account with auto associations set to < -1, the `INVALID_MAX_AUTO_ASSOCIATIONS` error should be raised for `AccountCreate` and `AccountUpdate` transactions

**Related issue(s)**:

#2332 #2333 

Fixes #

#2332 #2333 


**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
