### PR TITLE
feat: pull protobuf changes from latest tag

### DIFF
--- a/packages/proto/Taskfile.yml
+++ b/packages/proto/Taskfile.yml
@@ -93,6 +93,7 @@ tasks:
             - git checkout {{.proto}}
             - git show-ref --verify -q refs/heads/{{.proto}} && git pull origin || exit 0
             - task: build
+            - echo "Sucessfully updated protobufs to {{.proto}}"
 
     publish:
         preconditions:

--- a/packages/proto/Taskfile.yml
+++ b/packages/proto/Taskfile.yml
@@ -79,8 +79,16 @@ tasks:
             - build
 
     update:
+        dir: src/proto
+        vars:
+            latest_tag:
+                sh: git tag|grep -iE "v[0-9]+\.[0-9]+\.[0-9]+.*"|sort|tail -1
+            proto: '{{.proto | default .latest_tag}}'
         cmds:
-            - cd src/proto && git pull origin main && git checkout main
+            - echo "Protobuf version set to {{.proto}}"
+            - git fetch origin
+            - git checkout {{.proto}}
+            - git show-ref --verify -q refs/heads/{{.proto}} && git pull origin || exit 0
             - task: build
 
     publish:

--- a/packages/proto/Taskfile.yml
+++ b/packages/proto/Taskfile.yml
@@ -82,7 +82,10 @@ tasks:
         dir: src/proto
         vars:
             latest_tag:
-                sh: git tag|grep -iE "v[0-9]+\.[0-9]+\.[0-9]+.*"|sort|tail -1
+                sh: git -c versionsort.suffix=-alpha 
+                        -c versionsort.suffix=-beta 
+                        -c versionsort.suffix=-rc  
+                        tag -l --sort=version:refname|tail -1
             proto: '{{.proto | default .latest_tag}}'
         cmds:
             - echo "Protobuf version set to {{.proto}}"


### PR DESCRIPTION
**Description**:

This PR updates the `proto:update` task to use the latest semantic version tag instead of main as a reference in the upstream protobufs repo.


**Related issue(s)**:

Fixes #2393

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
