### PR TITLE
update: handle PLATFORM_NOT_ACTIVE error gracefully

### DIFF
--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -492,6 +492,7 @@ export default class Query extends Executable {
             case Status.Busy:
             case Status.Unknown:
             case Status.PlatformTransactionNotCreated:
+            case Status.PlatformNotActive:
                 return [status, ExecutionState.Retry];
             case Status.Ok:
                 return [status, ExecutionState.Finished];

--- a/src/transaction/TransactionReceiptQuery.js
+++ b/src/transaction/TransactionReceiptQuery.js
@@ -221,6 +221,7 @@ export default class TransactionReceiptQuery extends Query {
             case Status.Busy:
             case Status.Unknown:
             case Status.ReceiptNotFound:
+            case Status.PlatformNotActive:
                 return [status, ExecutionState.Retry];
             case Status.Ok:
                 break;

--- a/src/transaction/TransactionRecordQuery.js
+++ b/src/transaction/TransactionRecordQuery.js
@@ -212,6 +212,7 @@ export default class TransactionRecordQuery extends Query {
             case Status.Unknown:
             case Status.ReceiptNotFound:
             case Status.RecordNotFound:
+            case Status.PlatformNotActive:
                 return [status, ExecutionState.Retry];
 
             case Status.Ok:
@@ -412,7 +413,6 @@ export default class TransactionRecordQuery extends Query {
             /** @type {HashgraphProto.proto.ITransactionGetRecordResponse} */ (
                 response.transactionGetRecord
             );
-
         return Promise.resolve(TransactionRecord._fromProtobuf(record));
     }
 


### PR DESCRIPTION
**Description**:

When the SDK gets `PLATFORM_NOT_ACTIVE` error, will retry to execute the transaction until reaching the max attempts limit.

Fixes #2353 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
