### PR TITLE
update: add node id to the precheck error

### DIFF
--- a/src/Executable.js
+++ b/src/Executable.js
@@ -314,10 +314,11 @@ export default class Executable {
      * @internal
      * @param {RequestT} request
      * @param {ResponseT} response
+     * @param {AccountId} nodeId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response) {
+    _mapStatusError(request, response, nodeId) {
         throw new Error("not implemented");
     }
 
@@ -722,7 +723,11 @@ export default class Executable {
                 case ExecutionState.Finished:
                     return this._mapResponse(response, nodeAccountId, request);
                 case ExecutionState.Error:
-                    throw this._mapStatusError(request, response);
+                    throw this._mapStatusError(
+                        request,
+                        response,
+                        nodeAccountId,
+                    );
                 default:
                     throw new Error(
                         "(BUG) non-exhaustive switch statement for `ExecutionState`",

--- a/src/PrecheckStatusError.js
+++ b/src/PrecheckStatusError.js
@@ -24,6 +24,7 @@ import StatusError from "./StatusError.js";
  * @typedef {import("./Status.js").default} Status
  * @typedef {import("./transaction/TransactionId.js").default} TransactionId
  * @typedef {import("./contract/ContractFunctionResult.js").default} ContractFunctionResult
+ * @typedef {import("./account/AccountId.js").default} AccountId
  */
 
 /**
@@ -31,6 +32,7 @@ import StatusError from "./StatusError.js";
  * @property {string} name
  * @property {string} status
  * @property {string} transactionId
+ * @property {?string | null} nodeId
  * @property {string} message
  * @property {?ContractFunctionResult} contractFunctionResult
  */
@@ -40,12 +42,13 @@ export default class PrecheckStatusError extends StatusError {
      * @param {object} props
      * @param {Status} props.status
      * @param {TransactionId} props.transactionId
+     * @param {AccountId} props.nodeId
      * @param {?ContractFunctionResult} props.contractFunctionResult
      */
     constructor(props) {
         super(
             props,
-            `transaction ${props.transactionId.toString()} failed precheck with status ${props.status.toString()}`,
+            `transaction ${props.transactionId.toString()} failed precheck with status ${props.status.toString()} against node account id ${props.nodeId.toString()}`,
         );
 
         /**
@@ -53,6 +56,12 @@ export default class PrecheckStatusError extends StatusError {
          * @readonly
          */
         this.contractFunctionResult = props.contractFunctionResult;
+
+        /**
+         * @type {AccountId}
+         * @readonly
+         */
+        this.nodeId = props.nodeId;
     }
 
     /**
@@ -63,6 +72,7 @@ export default class PrecheckStatusError extends StatusError {
             name: this.name,
             status: this.status.toString(),
             transactionId: this.transactionId.toString(),
+            nodeId: this.nodeId.toString(),
             message: this.message,
             contractFunctionResult: this.contractFunctionResult,
         };

--- a/src/Status.js
+++ b/src/Status.js
@@ -677,6 +677,8 @@ export default class Status {
                 return "EMPTY_TOKEN_REFERENCE_LIST";
             case Status.UpdateNodeAccountNotAllowed:
                 return "UPDATE_NODE_ACCOUNT_NOT_ALLOWED";
+            case Status.TokenHasNoMetadataOrSupplyKey:
+                return "TOKEN_HAS_NO_METADATA_OR_SUPPLY_KEY";
             default:
                 return `UNKNOWN (${this._code})`;
         }
@@ -1325,6 +1327,8 @@ export default class Status {
                 return Status.EmptyTokenReferenceList;
             case 359:
                 return Status.UpdateNodeAccountNotAllowed;
+            case 360:
+                return Status.TokenHasNoMetadataOrSupplyKey;
             default:
                 throw new Error(
                     `(BUG) Status.fromCode() does not handle code: ${code}`,
@@ -2973,3 +2977,8 @@ Status.EmptyTokenReferenceList = new Status(358);
  * The node account is not allowed to be updated
  */
 Status.UpdateNodeAccountNotAllowed = new Status(359);
+
+/*
+ * The token has no metadata or supply key
+ */
+Status.TokenHasNoMetadataOrSupplyKey = new Status(360);

--- a/src/contract/ContractCallQuery.js
+++ b/src/contract/ContractCallQuery.js
@@ -243,9 +243,10 @@ export default class ContractCallQuery extends Query {
      * @internal
      * @param {HashgraphProto.proto.IQuery} request
      * @param {HashgraphProto.proto.IResponse} response
+     * @param {AccountId} nodeId
      * @returns {Error}
      */
-    _mapStatusError(request, response) {
+    _mapStatusError(request, response, nodeId) {
         const { nodeTransactionPrecheckCode } =
             this._mapResponseHeader(response);
 
@@ -262,6 +263,7 @@ export default class ContractCallQuery extends Query {
             (response.contractCallLocal);
         if (!call.functionResult) {
             return new PrecheckStatusError({
+                nodeId,
                 status,
                 transactionId: this._getTransactionId(),
                 contractFunctionResult: null,
@@ -271,6 +273,7 @@ export default class ContractCallQuery extends Query {
         const contractFunctionResult = this._mapResponseSync(response);
 
         return new PrecheckStatusError({
+            nodeId,
             status,
             transactionId: this._getTransactionId(),
             contractFunctionResult,

--- a/src/query/CostQuery.js
+++ b/src/query/CostQuery.js
@@ -153,11 +153,12 @@ export default class CostQuery extends Executable {
      * @internal
      * @param {HashgraphProto.proto.IQuery} request
      * @param {HashgraphProto.proto.IResponse} response
+     * @param {AccountId} nodeId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response) {
-        return this._query._mapStatusError(request, response);
+    _mapStatusError(request, response, nodeId) {
+        return this._query._mapStatusError(request, response, nodeId);
     }
 
     /**

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -506,10 +506,11 @@ export default class Query extends Executable {
      * @internal
      * @param {HashgraphProto.proto.IQuery} request
      * @param {HashgraphProto.proto.IResponse} response
+     * @param {AccountId} nodeId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response) {
+    _mapStatusError(request, response, nodeId) {
         const { nodeTransactionPrecheckCode } =
             this._mapResponseHeader(response);
 
@@ -520,6 +521,7 @@ export default class Query extends Executable {
         );
 
         return new PrecheckStatusError({
+            nodeId,
             status,
             transactionId: this._getTransactionId(),
             contractFunctionResult: null,

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -1231,7 +1231,7 @@ export default class Transaction extends Executable {
     }
 
     /**
-     * Before we proceed exeuction, we need to do a couple checks
+     * Before we proceed execution, we need to do a couple checks
      *
      * @override
      * @protected
@@ -1513,10 +1513,11 @@ export default class Transaction extends Executable {
      * @internal
      * @param {HashgraphProto.proto.ITransaction} request
      * @param {HashgraphProto.proto.ITransactionResponse} response
+     * @param {AccountId} nodeId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response) {
+    _mapStatusError(request, response, nodeId) {
         const { nodeTransactionPrecheckCode } = response;
 
         const status = Status._fromCode(
@@ -1532,6 +1533,7 @@ export default class Transaction extends Executable {
         }
 
         return new PrecheckStatusError({
+            nodeId,
             status,
             transactionId: this._getTransactionId(),
             contractFunctionResult: null,

--- a/src/transaction/TransactionReceiptQuery.js
+++ b/src/transaction/TransactionReceiptQuery.js
@@ -282,7 +282,7 @@ export default class TransactionReceiptQuery extends Query {
      * @override
      * @internal
      * @param {HashgraphProto.proto.IQuery} request
-     * @param {HashgraphProto.proto.IResponse} response\
+     * @param {HashgraphProto.proto.IResponse} response
      * @param {AccountId} nodeId
      * @returns {Error}
      */

--- a/src/transaction/TransactionReceiptQuery.js
+++ b/src/transaction/TransactionReceiptQuery.js
@@ -282,11 +282,12 @@ export default class TransactionReceiptQuery extends Query {
      * @override
      * @internal
      * @param {HashgraphProto.proto.IQuery} request
-     * @param {HashgraphProto.proto.IResponse} response
+     * @param {HashgraphProto.proto.IResponse} response\
+     * @param {AccountId} nodeId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response) {
+    _mapStatusError(request, response, nodeId) {
         const { nodeTransactionPrecheckCode } =
             this._mapResponseHeader(response);
 
@@ -303,6 +304,7 @@ export default class TransactionReceiptQuery extends Query {
 
             default:
                 return new PrecheckStatusError({
+                    nodeId,
                     status,
                     transactionId: this._getTransactionId(),
                     contractFunctionResult: null,

--- a/src/transaction/TransactionRecordQuery.js
+++ b/src/transaction/TransactionRecordQuery.js
@@ -282,10 +282,11 @@ export default class TransactionRecordQuery extends Query {
      * @internal
      * @param {HashgraphProto.proto.IQuery} request
      * @param {HashgraphProto.proto.IResponse} response
+     * @param {AccountId} nodeId
      * @returns {Error}
      */
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapStatusError(request, response) {
+    _mapStatusError(request, response, nodeId) {
         const { nodeTransactionPrecheckCode } =
             this._mapResponseHeader(response);
 
@@ -312,6 +313,7 @@ export default class TransactionRecordQuery extends Query {
 
             default:
                 return new PrecheckStatusError({
+                    nodeId,
                     status,
                     transactionId: this._getTransactionId(),
                     contractFunctionResult: null,

--- a/test/unit/AccountInfoMocking.js
+++ b/test/unit/AccountInfoMocking.js
@@ -399,7 +399,7 @@ describe("AccountInfoMocking", function () {
         } catch (error) {
             if (
                 error.message !==
-                "transaction 0.0.1854@1651168054.029348185 failed precheck with status TRANSACTION_EXPIRED"
+                "transaction 0.0.1854@1651168054.029348185 failed precheck with status TRANSACTION_EXPIRED against node account id 0.0.3"
             ) {
                 throw error;
             }


### PR DESCRIPTION
**Description**:

Node account id which against the transaction has been executed is added to the `PrecheckStatusError`.

Fixes #2413 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
