### PR TITLE
fix: update taskfile status check for submodules task

### DIFF
--- a/packages/proto/Taskfile.yml
+++ b/packages/proto/Taskfile.yml
@@ -26,7 +26,7 @@ tasks:
             # using tag --remote in order to always apply the newest proto changes
             - git submodule update --init --remote
         status:
-            - test -d packages/proto/src/proto
+            - test -d src/proto
 
     install:
         deps:


### PR DESCRIPTION
**Description**:
This PR fixes the previously broken status check for the `"install:submodules"` task that would cause the task to always execute thus resetting any updates made to the protobufs submodule version.



**Related issue(s)**:

Fixes #2434 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
