### PR TITLE
fix: better condition for install:submodules task

### DIFF
--- a/packages/proto/Taskfile.yml
+++ b/packages/proto/Taskfile.yml
@@ -26,7 +26,7 @@ tasks:
             # using tag --remote in order to always apply the newest proto changes
             - git submodule update --init --remote
         status:
-            - test -d src/proto
+            - test -e src/proto/.git
 
     install:
         deps:


### PR DESCRIPTION
**Description**:
This update the condition for running the `proto:install:submodules` task to reliably determine when it should be run.

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
