### PR TITLE
fix: do not reset receiverSignatureRequired in AccountUpdateTransaction by default

### DIFF
--- a/src/account/AccountUpdateTransaction.js
+++ b/src/account/AccountUpdateTransaction.js
@@ -80,9 +80,9 @@ export default class AccountUpdateTransaction extends Transaction {
 
         /**
          * @private
-         * @type {boolean}
+         * @type {?boolean}
          */
-        this._receiverSignatureRequired = false;
+        this._receiverSignatureRequired = null;
 
         /**
          * @private
@@ -324,7 +324,7 @@ export default class AccountUpdateTransaction extends Transaction {
     }
 
     /**
-     * @returns {boolean}
+     * @returns {?boolean}
      */
     get receiverSignatureRequired() {
         return this._receiverSignatureRequired;


### PR DESCRIPTION
**Description**:

Do not reset `receiverSignatureRequired` field in `AccountUpdateTransaction` without being reset intentionally.

Fixes #2449 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
