### PR TITLE
fix: ECDSA and ED25519 public key mismatch when you get it from mnemonic

### DIFF
--- a/packages/cryptography/src/EcdsaPrivateKey.js
+++ b/packages/cryptography/src/EcdsaPrivateKey.js
@@ -168,13 +168,10 @@ export default class EcdsaPrivateKey {
      */
     toBytesDer() {
         const bytes = new Uint8Array(derPrefixBytes.length + 32);
-
+        const privateKey = this._keyPair.privateKey.subarray(0, 32);
+        const leadingZeroes = 32 - privateKey.length;
         bytes.set(derPrefixBytes, 0);
-        bytes.set(
-            this._keyPair.privateKey.subarray(0, 32),
-            derPrefixBytes.length,
-        );
-
+        bytes.set(privateKey, derPrefixBytes.length + leadingZeroes);
         return bytes;
     }
 

--- a/packages/cryptography/src/EcdsaPrivateKey.js
+++ b/packages/cryptography/src/EcdsaPrivateKey.js
@@ -170,8 +170,9 @@ export default class EcdsaPrivateKey {
         const bytes = new Uint8Array(derPrefixBytes.length + 32);
         const privateKey = this._keyPair.privateKey.subarray(0, 32);
         const leadingZeroes = 32 - privateKey.length;
+        const privateKeyOffset = derPrefixBytes.length + leadingZeroes;
         bytes.set(derPrefixBytes, 0);
-        bytes.set(privateKey, derPrefixBytes.length + leadingZeroes);
+        bytes.set(privateKey, privateKeyOffset);
         return bytes;
     }
 

--- a/packages/cryptography/src/Ed25519PrivateKey.js
+++ b/packages/cryptography/src/Ed25519PrivateKey.js
@@ -206,12 +206,11 @@ export default class Ed25519PrivateKey {
      */
     toBytesDer() {
         const bytes = new Uint8Array(derPrefixBytes.length + 32);
+        const privateKey = this._keyPair.secretKey.subarray(0, 32);
+        const leadingZeroes = 32 - privateKey.length;
 
         bytes.set(derPrefixBytes, 0);
-        bytes.set(
-            this._keyPair.secretKey.subarray(0, 32),
-            derPrefixBytes.length,
-        );
+        bytes.set(privateKey, derPrefixBytes.length + leadingZeroes);
 
         return bytes;
     }

--- a/packages/cryptography/src/Ed25519PrivateKey.js
+++ b/packages/cryptography/src/Ed25519PrivateKey.js
@@ -208,9 +208,10 @@ export default class Ed25519PrivateKey {
         const bytes = new Uint8Array(derPrefixBytes.length + 32);
         const privateKey = this._keyPair.secretKey.subarray(0, 32);
         const leadingZeroes = 32 - privateKey.length;
+        const privateKeyOffset = derPrefixBytes.length + leadingZeroes;
 
         bytes.set(derPrefixBytes, 0);
-        bytes.set(privateKey, derPrefixBytes.length + leadingZeroes);
+        bytes.set(privateKey, privateKeyOffset);
 
         return bytes;
     }

--- a/test/integration/TokenRejectIntegrationTest.js
+++ b/test/integration/TokenRejectIntegrationTest.js
@@ -24,6 +24,7 @@ describe("TokenRejectIntegrationTest", function () {
 
     describe("Fungible Tokens", function () {
         beforeEach(async function () {
+            this.timeout(120000);
             env = await IntegrationTestEnv.new();
 
             // create token
@@ -868,6 +869,7 @@ describe("TokenRejectIntegrationTest", function () {
 
     describe("Other", function () {
         beforeEach(async function () {
+            this.timeout(120000);
             env = await IntegrationTestEnv.new();
 
             // create token

--- a/test/unit/EcdsaPrivateKey.js
+++ b/test/unit/EcdsaPrivateKey.js
@@ -392,7 +392,7 @@ describe("EcdsaPrivateKey", function () {
                 await mnemonic.toStandardECDSAsecp256k1PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromStringECDSA(
+            const privateKeyFromString = PrivateKey.fromStringECDSA(
                 privateKeyFromMnemonic.toStringDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;
@@ -419,7 +419,7 @@ describe("EcdsaPrivateKey", function () {
                 await mnemonic.toStandardECDSAsecp256k1PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromBytesECDSA(
+            const privateKeyFromString = PrivateKey.fromBytesECDSA(
                 privateKeyFromMnemonic.toBytesDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;
@@ -446,7 +446,7 @@ describe("EcdsaPrivateKey", function () {
                 await mnemonic.toStandardECDSAsecp256k1PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromStringECDSA(
+            const privateKeyFromString = PrivateKey.fromStringECDSA(
                 privateKeyFromMnemonic.toStringDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;
@@ -473,7 +473,7 @@ describe("EcdsaPrivateKey", function () {
                 await mnemonic.toStandardECDSAsecp256k1PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromBytesECDSA(
+            const privateKeyFromString = PrivateKey.fromBytesECDSA(
                 privateKeyFromMnemonic.toBytesDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;

--- a/test/unit/EcdsaPrivateKey.js
+++ b/test/unit/EcdsaPrivateKey.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { PrivateKey } from "../../src/index.js";
+import { Mnemonic, PrivateKey } from "../../src/index.js";
 import * as hex from "../../src/encoding/hex.js";
 import * as bip32 from "../../packages/cryptography/src/primitive/bip32.js";
 
@@ -15,6 +15,7 @@ const DER_PRIVATE_KEY_BYTES = new Uint8Array([
 ]);
 const DER_PUBLIC_KEY =
     "302d300706052b8104000a032200033697a2b3f9f0b9f4831b39986f7f3885636a3e8622a0bc3814a4a56f7ecdc4f1";
+const STRESS_TEST_ITERATION_COUNT = 100;
 
 describe("EcdsaPrivateKey", function () {
     it("generate should return object", function () {
@@ -381,5 +382,113 @@ describe("EcdsaPrivateKey", function () {
         const privateKey = PrivateKey.generateECDSA();
 
         expect(privateKey.type).to.be.string("secp256k1");
+    });
+
+    it("should produce consistent public key from 12 word mnemonic and fromStringECDSA", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate12();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardECDSAsecp256k1PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromStringECDSA(
+                privateKeyFromMnemonic.toStringDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
+    });
+
+    it("should produce consistent public key from 12 word mnemonic and fromBytesECDSA", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate12();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardECDSAsecp256k1PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromBytesECDSA(
+                privateKeyFromMnemonic.toBytesDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
+    });
+
+    it("should produce consistent public key from 24 word mnemonic and fromStringECDSA", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardECDSAsecp256k1PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromStringECDSA(
+                privateKeyFromMnemonic.toStringDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
+    });
+
+    it("should produce consistent public key from 24 word mnemonic and fromBytesECDSA", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardECDSAsecp256k1PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromBytesECDSA(
+                privateKeyFromMnemonic.toBytesDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
     });
 });

--- a/test/unit/EcdsaPrivateKey.js
+++ b/test/unit/EcdsaPrivateKey.js
@@ -15,7 +15,7 @@ const DER_PRIVATE_KEY_BYTES = new Uint8Array([
 ]);
 const DER_PUBLIC_KEY =
     "302d300706052b8104000a032200033697a2b3f9f0b9f4831b39986f7f3885636a3e8622a0bc3814a4a56f7ecdc4f1";
-const STRESS_TEST_ITERATION_COUNT = 100;
+const STRESS_TEST_ITERATION_COUNT = 1000;
 
 describe("EcdsaPrivateKey", function () {
     it("generate should return object", function () {

--- a/test/unit/Ed25519PrivateKey.js
+++ b/test/unit/Ed25519PrivateKey.js
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 
-import { PrivateKey } from "../../src/index.js";
+import { Mnemonic, PrivateKey } from "../../src/index.js";
 import * as hex from "../../src/encoding/hex.js";
 
 const RAW_KEY =
@@ -14,6 +14,8 @@ const DER_PRIVATE_KEY_BYTES = new Uint8Array([
 ]);
 const DER_PUBLIC_KEY =
     "302a300506032b65700321004a6892f034d2d1c9b1a76acca8e34884055172f4210a0c02e3c7d55084f224d1";
+
+const STRESS_TEST_ITERATION_COUNT = 100;
 
 describe("Ed25519PrivateKey", function () {
     it("generate should return  object", function () {
@@ -298,5 +300,113 @@ describe("Ed25519PrivateKey", function () {
         const privateKey = PrivateKey.generateED25519();
 
         expect(privateKey.type).to.be.string("ED25519");
+    });
+
+    it("should produce consistent public key from 12 word mnemonic and fromStringED25519", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate12();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardEd25519PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromStringED25519(
+                privateKeyFromMnemonic.toStringDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
+    });
+
+    it("should produce consistent public key from 12 word mnemonic and fromBytesED25519", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate12();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardEd25519PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromBytesED25519(
+                privateKeyFromMnemonic.toBytesDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
+    });
+
+    it("should produce consistent public key from 24 word mnemonic and fromStringED5519", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardEd25519PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromStringED25519(
+                privateKeyFromMnemonic.toStringDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
+    });
+
+    it("should produce consistent public key from 24 word mnemonic and fromBytesED25519", async function () {
+        this.timeout(120000);
+        for (let i = 0; i < STRESS_TEST_ITERATION_COUNT; i++) {
+            const mnemonic = await Mnemonic.generate();
+            const privateKeyFromMnemonic =
+                await mnemonic.toStandardEd25519PrivateKey();
+            const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
+
+            const privateKeyFromString = await PrivateKey.fromBytesED25519(
+                privateKeyFromMnemonic.toBytesDer(),
+            );
+            const publicKeyFromString = privateKeyFromString.publicKey;
+
+            if (
+                publicKeyFromMnemonic.toStringDer() !==
+                publicKeyFromString.toStringDer()
+            ) {
+                console.log(
+                    "Public key from mnemonic: ",
+                    publicKeyFromMnemonic,
+                );
+                console.log("Public key from string: ", publicKeyFromString);
+                throw new Error("Public key mismatch");
+            }
+        }
     });
 });

--- a/test/unit/Ed25519PrivateKey.js
+++ b/test/unit/Ed25519PrivateKey.js
@@ -15,7 +15,7 @@ const DER_PRIVATE_KEY_BYTES = new Uint8Array([
 const DER_PUBLIC_KEY =
     "302a300506032b65700321004a6892f034d2d1c9b1a76acca8e34884055172f4210a0c02e3c7d55084f224d1";
 
-const STRESS_TEST_ITERATION_COUNT = 100;
+const STRESS_TEST_ITERATION_COUNT = 1000;
 
 describe("Ed25519PrivateKey", function () {
     it("generate should return  object", function () {

--- a/test/unit/Ed25519PrivateKey.js
+++ b/test/unit/Ed25519PrivateKey.js
@@ -310,7 +310,7 @@ describe("Ed25519PrivateKey", function () {
                 await mnemonic.toStandardEd25519PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromStringED25519(
+            const privateKeyFromString = PrivateKey.fromStringED25519(
                 privateKeyFromMnemonic.toStringDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;
@@ -337,7 +337,7 @@ describe("Ed25519PrivateKey", function () {
                 await mnemonic.toStandardEd25519PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromBytesED25519(
+            const privateKeyFromString = PrivateKey.fromBytesED25519(
                 privateKeyFromMnemonic.toBytesDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;
@@ -364,7 +364,7 @@ describe("Ed25519PrivateKey", function () {
                 await mnemonic.toStandardEd25519PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromStringED25519(
+            const privateKeyFromString = PrivateKey.fromStringED25519(
                 privateKeyFromMnemonic.toStringDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;
@@ -391,7 +391,7 @@ describe("Ed25519PrivateKey", function () {
                 await mnemonic.toStandardEd25519PrivateKey();
             const publicKeyFromMnemonic = privateKeyFromMnemonic.publicKey;
 
-            const privateKeyFromString = await PrivateKey.fromBytesED25519(
+            const privateKeyFromString = PrivateKey.fromBytesED25519(
                 privateKeyFromMnemonic.toBytesDer(),
             );
             const publicKeyFromString = privateKeyFromString.publicKey;


### PR DESCRIPTION
**Description**: 

This PR modifies the crypto package and in particular the ECDSA and ED25519 private key classes. A user found out that a mnemonic and a key that share the same private key mismatch their public key. In order to fix it, this PR modifies the ECDSA and ED25519 so they don't add trailing zeroes. This addition only happens only when the private key is shorter than 32 bytes. Example: 3030020100300706052b8104000a04220420a5b9dedc7c7767c4a88a0ac3cc6b9171948bada579226bd550d3342db11dc800

The last 2 trailing zeroes should be added after the DER prefix  bytes (3030020100300706052b8104000a04220420) 
e.g 3030020100300706052b8104000a0422042000a5b9dedc7c7767c4a88a0ac3cc6b9171948bada579226bd550d3342db11dc8

**Fixes**

 #2419

**Notes for reviewer**:
Not sure if 100 tests are enough of a stress test but otherwise the test gets slow. For example 10000 iterations take around 15 seconds per test case. Considering there is 4 of these per file, thats gonna take 2 minute in total which in my opiion is a lot. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
