### PR TITLE
chore: respect submodule SHA references on submodule init

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -59,6 +59,7 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || '' }}
           fetch-depth: 0
+          submodules: recursive
 
       - name: Install Semantic Version Tools
         run: |
@@ -238,6 +239,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.event.inputs.tag || '' }}
+          submodules: recursive
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
@@ -274,6 +276,7 @@ jobs:
         uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
         with:
           ref: ${{ github.event.inputs.tag || '' }}
+          submodules: recursive
 
       - name: Install Task
         uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0

--- a/packages/proto/Taskfile.yml
+++ b/packages/proto/Taskfile.yml
@@ -19,12 +19,7 @@ tasks:
 
     "install:submodules":
         cmds:
-            # TODO: How do we support this build step when we update the
-            # protobufs? Currently, this step results in reseting any protobuf
-            # updates we may have.
-            #- git submodule update --init
-            # using tag --remote in order to always apply the newest proto changes
-            - git submodule update --init --remote
+            - git submodule update --init
         status:
             - test -e src/proto/.git
 


### PR DESCRIPTION
**Description**:

This PR updates the submodules init command in the taskfile to respect the SHA reference to the submodule's upstream repo.
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
