### PR TITLE
fix: React Native's BIP32 implementation should use array instead of Buffer

### DIFF
--- a/packages/cryptography/src/primitive/bip32.native.js
+++ b/packages/cryptography/src/primitive/bip32.native.js
@@ -60,7 +60,10 @@ export async function derive(parentKey, chainCode, index) {
             .getPrivate()
             .add(secp256k1.keyFromPrivate(IL).getPrivate())
             .mod(N);
-        const hexZeroPadded = hex.hexZeroPadded(ki.toBuffer(), 32);
+        const hexZeroPadded = hex.hexZeroPadded(
+            Uint8Array.from(ki.toArray()),
+            32,
+        );
         // const ki = Buffer.from(ecc.privateAdd(this.privateKey!, IL)!);
 
         // In case ki == 0, proceed with the next value for i


### PR DESCRIPTION
**Description**:
We should use Arrays instead of Buffers whenever possible because of React Native's inability to deal with Buffers BIP32. This PR changes `packages/cryptography/src/primitive/Bip32.native.js`. There is no need to change `packages/cryptography/src/primitive/BIP32.js` as it is used in different environment. And the web version of this file already uses the correct functions. 

**Related issue(s)**:
#2458 

Fixes #
#2458

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
