### PR TITLE
Fix typo in MIGRATING_V1.md

### DIFF
--- a/MIGRATING_V1.md
+++ b/MIGRATING_V1.md
@@ -137,7 +137,7 @@
     * Removed `setSendRecordThreshold(number)` and `setSendRecordThreshold(Hbar)`
     * Removed `setReceiveRecordThreshold(number)` and `setReceiveRecordThreshold(Hbar)`
 
-### Removed `CryptoTransferTranscation`
+### Removed `CryptoTransferTransaction`
     * Use `TransferTransaction` instead.
 
 ### `TransferTransaction` extends [Transaction](#combined-transactionbuilder-and-transaction)


### PR DESCRIPTION
**Description**:
Typo: `CryptoTransferTranscation` -> `CryptoTransferTransaction`


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
