### PR TITLE
fix: serialize deserialize FileAppend

### DIFF
--- a/examples/serialize-deserialize-10.js
+++ b/examples/serialize-deserialize-10.js
@@ -13,7 +13,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction (chunked), set transaction id and execute it
+ * @description Serialize and deserialize so-called incomplete transaction (chunked), set transaction id and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-11.js
+++ b/examples/serialize-deserialize-11.js
@@ -11,7 +11,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction (chunked), set node account ids and execute it
+ * @description Serialize and deserialize so-called incomplete transaction (chunked), set node account ids and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-12.js
+++ b/examples/serialize-deserialize-12.js
@@ -12,7 +12,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Create, serialize and deserialize so-called incompleted transaction, then freeze it, serialize and deserialize it again, and execute it
+ * @description Create, serialize and deserialize so-called incomplete transaction, then freeze it, serialize and deserialize it again, and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-3.js
+++ b/examples/serialize-deserialize-3.js
@@ -11,7 +11,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction, and execute it
+ * @description Serialize and deserialize so-called incomplete transaction, and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-4.js
+++ b/examples/serialize-deserialize-4.js
@@ -11,7 +11,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction, set node account ids and execute it
+ * @description Serialize and deserialize so-called incomplete transaction, set node account ids and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-5.js
+++ b/examples/serialize-deserialize-5.js
@@ -13,7 +13,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction, set transaction id and execute it
+ * @description Serialize and deserialize so-called incomplete transaction, set transaction id and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-6.js
+++ b/examples/serialize-deserialize-6.js
@@ -11,7 +11,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction, update and execute it
+ * @description Serialize and deserialize so-called incomplete transaction, update and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-8.js
+++ b/examples/serialize-deserialize-8.js
@@ -11,7 +11,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction (chunked), and execute it
+ * @description Serialize and deserialize so-called incomplete transaction (chunked), and execute it
  */
 
 async function main() {

--- a/examples/serialize-deserialize-9.js
+++ b/examples/serialize-deserialize-9.js
@@ -11,7 +11,7 @@ import {
 import dotenv from "dotenv";
 
 /**
- * @description Serialize and deserialize so-called incompleted transaction (chunked), update and execute it
+ * @description Serialize and deserialize so-called incomplete transaction (chunked), update and execute it
  */
 
 async function main() {

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -385,6 +385,12 @@ export default class FileAppendTransaction extends Transaction {
      * @returns {Promise<TransactionResponse[]>}
      */
     async executeAll(client, requestTimeout) {
+        if (this.maxChunks && this.requiredChunks > this.maxChunks) {
+            throw new Error(
+                `cannot execute \`FileAppendTransaction\` with more than ${this.maxChunks} chunks`,
+            );
+        }
+
         if (!super._isFrozen()) {
             this.freezeWith(client);
         }
@@ -502,6 +508,17 @@ export default class FileAppendTransaction extends Transaction {
 
         this._transactionIds.advance();
         this._transactionIds.setLocked();
+    }
+
+    /**
+     * Build all the signed transactions
+     * @override
+     * @internal
+     */
+    _buildAllTransactions() {
+        for (let i = 0; i < this._signedTransactions.length; i++) {
+            this._buildTransaction(i);
+        }
     }
 
     /**

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -658,10 +658,17 @@ export default class FileAppendTransaction extends Transaction {
             throw new Error("fileID is required");
         }
 
-        return new FileAppendTransaction({
-            fileId: fileId,
-            contents: contents,
-        });
+        return Transaction._fromProtobufTransactions(
+            new FileAppendTransaction({
+                fileId: fileId,
+                contents: contents,
+            }),
+            [],
+            signedTransactions,
+            transactionIds,
+            nodeIds,
+            bodies,
+        );
     }
 
     /**

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -673,6 +673,25 @@ export default class FileAppendTransaction extends Transaction {
         );
         return `FileAppendTransaction:${timestamp.toString()}`;
     }
+
+    /**
+     * @override
+     * @protected
+     * @returns {HashgraphProto.proto.IFileAppendTransactionBody}
+     */
+    _makeTransactionData() {
+        const length = this._contents != null ? this._contents.length : 0;
+        const startIndex = this._transactionIds.index * this._chunkSize;
+        const endIndex = Math.min(startIndex + this._chunkSize, length);
+
+        return {
+            fileID: this._fileId != null ? this._fileId._toProtobuf() : null,
+            contents:
+                this._contents != null
+                    ? this._contents.slice(startIndex, endIndex)
+                    : null,
+        };
+    }
 }
 
 // eslint-disable-next-line @typescript-eslint/unbound-method

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -32,12 +32,12 @@ import AccountId from "../account/AccountId.js";
 /**
  * @namespace proto
  * @typedef {import("@hashgraph/proto").proto.ITransaction} HashgraphProto.proto.ITransaction
- * @typedef {import("@hashgraph/proto").proto.IFileAppendTransactionBody} HashgraphProto.proto.IFileAppendTransactionBody
- * @typedef {import("@hashgraph/proto").proto.ITransactionBody} HashgraphProto.proto.ITransactionBody
  * @typedef {import("@hashgraph/proto").proto.ISignedTransaction} HashgraphProto.proto.ISignedTransaction
- * @typedef {import("@hashgraph/proto").proto.IFileID} HashgraphProto.proto.IFileID
- * @typedef {import("@hashgraph/proto").proto.ITransactionResponse} HashgraphProto.proto.ITransactionResponse
  * @typedef {import("@hashgraph/proto").proto.TransactionBody} HashgraphProto.proto.TransactionBody
+ * @typedef {import("@hashgraph/proto").proto.ITransactionBody} HashgraphProto.proto.ITransactionBody
+ * @typedef {import("@hashgraph/proto").proto.ITransactionResponse} HashgraphProto.proto.ITransactionResponse
+ * @typedef {import("@hashgraph/proto").proto.IFileAppendTransactionBody} HashgraphProto.proto.IFileAppendTransactionBody
+ * @typedef {import("@hashgraph/proto").proto.IFileID} HashgraphProto.proto.IFileID
  */
 
 /**

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -466,7 +466,7 @@ export default class FileAppendTransaction extends Transaction {
         if (this._contents == null) {
             throw new Error("contents is not set");
         }
-        if (this.maxChunks && this.getRequiredChunks() < this.maxChunks) {
+        if (this.maxChunks && this.getRequiredChunks() > this.maxChunks) {
             throw new Error(
                 `cannot build \`FileAppendTransaction\` with more than ${this.maxChunks} chunks`,
             );
@@ -521,7 +521,7 @@ export default class FileAppendTransaction extends Transaction {
      * @internal
      */
     _buildAllTransactions() {
-        if (this.maxChunks && this.getRequiredChunks() < this.maxChunks) {
+        if (this.maxChunks && this.getRequiredChunks() > this.maxChunks) {
             throw new Error(
                 `cannot build \`FileAppendTransaction\` with more than ${this.maxChunks} chunks`,
             );

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -463,6 +463,7 @@ export default class FileAppendTransaction extends Transaction {
      * @internal
      */
     _buildIncompletedTransactions() {
+        const dummyAccountId = AccountId.fromString("0.0.0");
         if (this._contents == null) {
             throw new Error("contents is not set");
         }
@@ -481,9 +482,7 @@ export default class FileAppendTransaction extends Transaction {
         this._signedTransactions.clear();
 
         for (let chunk = 0; chunk < this.getRequiredChunks(); chunk++) {
-            let nextTransactionId = TransactionId.generate(
-                AccountId.fromString("0.0.0"),
-            );
+            let nextTransactionId = TransactionId.generate(dummyAccountId);
             this._transactionIds.push(nextTransactionId);
             this._transactionIds.advance();
 

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -27,8 +27,18 @@ import FileId from "./FileId.js";
 import TransactionId from "../transaction/TransactionId.js";
 import Timestamp from "../Timestamp.js";
 import List from "../transaction/List.js";
-import * as HashgraphProto from "@hashgraph/proto";
 import AccountId from "../account/AccountId.js";
+
+/**
+ * @namespace proto
+ * @typedef {import("@hashgraph/proto").proto.ITransaction} HashgraphProto.proto.ITransaction
+ * @typedef {import("@hashgraph/proto").proto.IFileAppendTransactionBody} HashgraphProto.proto.IFileAppendTransactionBody
+ * @typedef {import("@hashgraph/proto").proto.ITransactionBody} HashgraphProto.proto.ITransactionBody
+ * @typedef {import("@hashgraph/proto").proto.ISignedTransaction} HashgraphProto.proto.ISignedTransaction
+ * @typedef {import("@hashgraph/proto").proto.IFileID} HashgraphProto.proto.IFileID
+ * @typedef {import("@hashgraph/proto").proto.ITransactionResponse} HashgraphProto.proto.ITransactionResponse
+ * @typedef {import("@hashgraph/proto").proto.TransactionBody} HashgraphProto.proto.TransactionBody
+ */
 
 /**
  * @typedef {import("../PublicKey.js").default} PublicKey

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -413,17 +413,6 @@ export default class FileAppendTransaction extends Transaction {
     }
 
     /**
-     * @abstract
-     * @override
-     * @param {PublicKey} publicKey
-     * @param {Uint8Array | Uint8Array[]} signature
-     * @returns {NonNullable<this>}
-     */
-    addSignature(publicKey, signature) {
-        throw new Error("FileAppendTransaction does not support addSignature");
-    }
-
-    /**
      * @param {Client} client
      */
     _validateChecksums(client) {

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -466,6 +466,11 @@ export default class FileAppendTransaction extends Transaction {
         if (this._contents == null) {
             throw new Error("contents is not set");
         }
+        if (this.maxChunks && this.getRequiredChunks() < this.maxChunks) {
+            throw new Error(
+                `cannot build \`FileAppendTransaction\` with more than ${this.maxChunks} chunks`,
+            );
+        }
 
         let nextTransactionId = TransactionId.withValidStart(
             new AccountId(0, 0, 0),
@@ -516,6 +521,11 @@ export default class FileAppendTransaction extends Transaction {
      * @internal
      */
     _buildAllTransactions() {
+        if (this.maxChunks && this.getRequiredChunks() < this.maxChunks) {
+            throw new Error(
+                `cannot build \`FileAppendTransaction\` with more than ${this.maxChunks} chunks`,
+            );
+        }
         for (let i = 0; i < this._signedTransactions.length; i++) {
             this._buildTransaction(i);
         }

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -225,7 +225,7 @@ export default class FileAppendTransaction extends Transaction {
      * @override
      * @returns {number}
      */
-    get requiredChunks() {
+    getRequiredChunks() {
         if (this._contents == null) {
             return 0;
         }
@@ -326,7 +326,7 @@ export default class FileAppendTransaction extends Transaction {
         this._transactionIds.clear();
         this._signedTransactions.clear();
 
-        for (let chunk = 0; chunk < this.requiredChunks; chunk++) {
+        for (let chunk = 0; chunk < this.getRequiredChunks(); chunk++) {
             this._transactionIds.push(nextTransactionId);
             this._transactionIds.advance();
 
@@ -385,7 +385,7 @@ export default class FileAppendTransaction extends Transaction {
      * @returns {Promise<TransactionResponse[]>}
      */
     async executeAll(client, requestTimeout) {
-        if (this.maxChunks && this.requiredChunks > this.maxChunks) {
+        if (this.maxChunks && this.getRequiredChunks() > this.maxChunks) {
             throw new Error(
                 `cannot execute \`FileAppendTransaction\` with more than ${this.maxChunks} chunks`,
             );
@@ -479,7 +479,7 @@ export default class FileAppendTransaction extends Transaction {
         this._transactionIds.clear();
         this._signedTransactions.clear();
 
-        for (let chunk = 0; chunk < this.requiredChunks; chunk++) {
+        for (let chunk = 0; chunk < this.getRequiredChunks(); chunk++) {
             this._transactionIds.push(nextTransactionId);
             this._transactionIds.advance();
 

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -458,7 +458,7 @@ export default class FileAppendTransaction extends Transaction {
     }
 
     /**
-     * Build all the transactions when
+     * Build all the transactions when transacgtions are not signed
      * @override
      * @internal
      */

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -458,11 +458,12 @@ export default class FileAppendTransaction extends Transaction {
     }
 
     /**
-     * Build all the transactions when transacgtions are not signed
+     * Build all the transactions
+     * when transactions are not complete.
      * @override
      * @internal
      */
-    _buildIncompletedTransactions() {
+    _buildIncompleteTransactions() {
         const dummyAccountId = AccountId.fromString("0.0.0");
         if (this._contents == null) {
             throw new Error("contents is not set");

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -473,11 +473,6 @@ export default class FileAppendTransaction extends Transaction {
             );
         }
 
-        let nextTransactionId = TransactionId.withValidStart(
-            new AccountId(0, 0, 0),
-            new Timestamp(new Date().getTime(), 0),
-        );
-
         // Hack around the locked list. Should refactor a bit to remove such code
         this._transactionIds.locked = false;
 
@@ -486,6 +481,9 @@ export default class FileAppendTransaction extends Transaction {
         this._signedTransactions.clear();
 
         for (let chunk = 0; chunk < this.getRequiredChunks(); chunk++) {
+            let nextTransactionId = TransactionId.generate(
+                AccountId.fromString("0.0.0"),
+            );
             this._transactionIds.push(nextTransactionId);
             this._transactionIds.advance();
 
@@ -498,18 +496,6 @@ export default class FileAppendTransaction extends Transaction {
                     );
                 }
             }
-
-            nextTransactionId = new TransactionId(
-                /** @type {AccountId} */ (nextTransactionId.accountId),
-                new Timestamp(
-                    /** @type {Timestamp} */ (
-                        nextTransactionId.validStart
-                    ).seconds,
-                    /** @type {Timestamp} */ (
-                        nextTransactionId.validStart
-                    ).nanos.add(1),
-                ),
-            );
         }
 
         this._transactionIds.advance();

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -466,6 +466,7 @@ export default class FileAppendTransaction extends Transaction {
         if (this._contents == null) {
             throw new Error("contents is not set");
         }
+
         if (this.maxChunks && this.getRequiredChunks() > this.maxChunks) {
             throw new Error(
                 `cannot build \`FileAppendTransaction\` with more than ${this.maxChunks} chunks`,

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -1065,7 +1065,7 @@ export default class Transaction extends Executable {
      *
      * @internal
      */
-    _buildIncompletedTransactions() {
+    _buildIncompleteTransactions() {
         if (this._nodeAccountIds.length == 0) {
             this._transactions.setList([this._makeSignedTransaction(null)]);
         } else {
@@ -1211,7 +1211,7 @@ export default class Transaction extends Executable {
             // Build all the transactions without signing
             this._buildAllTransactions();
         } else {
-            this._buildIncompletedTransactions();
+            this._buildIncompleteTransactions();
         }
 
         // Construct and encode the transaction list

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -803,7 +803,7 @@ export default class Transaction extends Executable {
      *
      * @param {PublicKey} publicKey
      * @param {Uint8Array | Uint8Array[]} signature
-     * @returns {this}
+     * @returns {NonNullable<this>}
      */
     addSignature(publicKey, signature) {
         const isSingleSignature = signature instanceof Uint8Array;

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -673,6 +673,15 @@ export default class Transaction extends Executable {
     }
 
     /**
+     * How many chunk sizes are expected
+     * @abstract
+     * @returns {number}
+     */
+    get requiredChunks() {
+        return 1;
+    }
+
+    /**
      * Sign the transaction with the private key
      * **NOTE**: This is a thin wrapper around `.signWith()`
      *
@@ -1048,7 +1057,7 @@ export default class Transaction extends Executable {
     /**
      * Build all the signed transactions from the node account IDs
      *
-     * @private
+     * @internal
      */
     _buildIncompletedTransactions() {
         if (this._nodeAccountIds.length == 0) {

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -1517,9 +1517,9 @@ export default class Transaction extends Executable {
             }
         }
 
-        // In case when an incompleted transaction is created, serialized and
+        // In case when an incomplete transaction is created, serialized and
         // deserialized,and then the transaction being frozen, the copy of the
-        // incompleted transaction must be updated in order to be prepared for execution
+        // incomplete transaction must be updated in order to be prepared for execution
         if (this._transactions.list[index] != null) {
             this._transactions.set(index, {
                 signedTransactionBytes:

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -675,9 +675,10 @@ export default class Transaction extends Executable {
     /**
      * How many chunk sizes are expected
      * @abstract
+     * @internal
      * @returns {number}
      */
-    get requiredChunks() {
+    getRequiredChunks() {
         return 1;
     }
 
@@ -809,7 +810,7 @@ export default class Transaction extends Executable {
         const isSingleSignature = signature instanceof Uint8Array;
         const isArraySignature = Array.isArray(signature);
 
-        if (this.requiredChunks > 1) {
+        if (this.getRequiredChunks() > 1) {
             throw new Error(
                 "Add signature is not supported for chunked transactions",
             );

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -804,7 +804,7 @@ export default class Transaction extends Executable {
      *
      * @param {PublicKey} publicKey
      * @param {Uint8Array | Uint8Array[]} signature
-     * @returns {NonNullable<this>}
+     * @returns {this}
      */
     addSignature(publicKey, signature) {
         const isSingleSignature = signature instanceof Uint8Array;

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -809,6 +809,11 @@ export default class Transaction extends Executable {
         const isSingleSignature = signature instanceof Uint8Array;
         const isArraySignature = Array.isArray(signature);
 
+        if (this.requiredChunks > 1) {
+            throw new Error(
+                "Add signature is not supported for chunked transactions",
+            );
+        }
         // Check if it is a single signature with NOT exactly one transaction
         if (isSingleSignature && this._signedTransactions.length !== 1) {
             throw new Error(

--- a/src/transaction/Transaction.js
+++ b/src/transaction/Transaction.js
@@ -1470,7 +1470,7 @@ export default class Transaction extends Executable {
     /**
      * Build each signed transaction in a loop
      *
-     * @private
+     * @internal
      */
     _buildAllTransactions() {
         for (let i = 0; i < this._signedTransactions.length; i++) {
@@ -1506,7 +1506,7 @@ export default class Transaction extends Executable {
     /**
      * Build a transaction at a particular index
      *
-     * @private
+     * @internal
      * @param {number} index
      */
     _buildTransaction(index) {

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -246,8 +246,6 @@ describe("FileAppend", function () {
     it("should be able to freeze after deserialze", async function () {
         this.timeout(120000);
 
-        const NEW_CONTENTS_LENGTH = 5000;
-        const NEW_CONTENTS = generateUInt8Array(NEW_CONTENTS_LENGTH);
         const operatorKey = env.operatorKey.publicKey;
 
         let response = await new FileCreateTransaction()
@@ -262,7 +260,7 @@ describe("FileAppend", function () {
 
         const tx = new FileAppendTransaction()
             .setFileId(fileId)
-            .setContents(NEW_CONTENTS);
+            .setContents(newContents);
 
         const txBytes = tx.toBytes();
         const txFromBytes = FileAppendTransaction.fromBytes(txBytes);

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -11,14 +11,18 @@ import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
 
 describe("FileAppend", function () {
     let env;
+    let newContentsLength;
+    let newContents;
+    let operatorKey;
 
     before(async function () {
         env = await IntegrationTestEnv.new();
+        newContentsLength = 5000;
+        newContents = generateUInt8Array(newContentsLength);
+        operatorKey = env.operatorKey.publicKey;
     });
     it("should be executable", async function () {
         this.timeout(120000);
-
-        const operatorKey = env.operatorKey.publicKey;
 
         let response = await new FileCreateTransaction()
             .setKeys([operatorKey])
@@ -214,10 +218,6 @@ describe("FileAppend", function () {
     it("should keep content after deserialization", async function () {
         this.timeout(120000);
 
-        const NEW_CONTENTS_LENGTH = 5000;
-        const NEW_CONTENTS = generateUInt8Array(NEW_CONTENTS_LENGTH);
-        const operatorKey = env.operatorKey.publicKey;
-
         let response = await new FileCreateTransaction()
             .setKeys([operatorKey])
             .setContents(Buffer.from(""))
@@ -230,7 +230,7 @@ describe("FileAppend", function () {
 
         const tx = new FileAppendTransaction()
             .setFileId(fileId)
-            .setContents(NEW_CONTENTS);
+            .setContents(newContents);
 
         const txBytes = tx.toBytes();
         const txFromBytes = FileAppendTransaction.fromBytes(txBytes);
@@ -240,7 +240,7 @@ describe("FileAppend", function () {
         const content = await new FileInfoQuery()
             .setFileId(fileId)
             .execute(env.client);
-        expect(content.size.toInt()).to.be.equal(NEW_CONTENTS_LENGTH);
+        expect(content.size.toInt()).to.be.equal(newContentsLength);
     });
 
     it("should be able to freeze after deserialze", async function () {

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -279,10 +279,5 @@ describe("FileAppend", function () {
 
 function generateUInt8Array(length) {
     const uint8Array = new Uint8Array(length);
-
-    for (let i = 0; i < length; i++) {
-        uint8Array[i] = Math.floor(Math.random() * 256);
-    }
-
-    return uint8Array;
+    return uint8Array.fill(1);
 }

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -240,6 +240,7 @@ describe("FileAppend", function () {
         const content = await new FileInfoQuery()
             .setFileId(fileId)
             .execute(env.client);
+
         expect(content.size.toInt()).to.be.equal(newContentsLength);
     });
 

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -243,7 +243,7 @@ describe("FileAppend", function () {
         expect(content.size.toInt()).to.be.equal(newContentsLength);
     });
 
-    it("should be able to freeze after deserialze", async function () {
+    it("should be able to freeze after deserialize", async function () {
         this.timeout(120000);
 
         const operatorKey = env.operatorKey.publicKey;

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -243,6 +243,35 @@ describe("FileAppend", function () {
         expect(content.size.toInt()).to.be.equal(NEW_CONTENTS_LENGTH);
     });
 
+    it("should be able to freeze after deserialze", async function () {
+        this.timeout(120000);
+
+        const NEW_CONTENTS_LENGTH = 5000;
+        const NEW_CONTENTS = generateUInt8Array(NEW_CONTENTS_LENGTH);
+        const operatorKey = env.operatorKey.publicKey;
+
+        let response = await new FileCreateTransaction()
+            .setKeys([operatorKey])
+            .setContents(Buffer.from(""))
+            .execute(env.client);
+
+        let { fileId } = await response.getReceipt(env.client);
+
+        expect(fileId).to.not.be.null;
+        expect(fileId != null ? fileId.num > 0 : false).to.be.true;
+
+        const tx = new FileAppendTransaction()
+            .setFileId(fileId)
+            .setContents(NEW_CONTENTS);
+
+        const txBytes = tx.toBytes();
+        const txFromBytes = FileAppendTransaction.fromBytes(txBytes);
+
+        txFromBytes.freezeWith(env.client);
+
+        expect(txFromBytes.isFrozen()).to.be.true;
+    });
+
     after(async function () {
         await env.close();
     });

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -1,5 +1,6 @@
 import {
     FileAppendTransaction,
+    FileContentsQuery,
     FileCreateTransaction,
     FileDeleteTransaction,
     FileInfoQuery,
@@ -269,6 +270,97 @@ describe("FileAppend", function () {
         txFromBytes.freezeWith(env.client);
 
         expect(txFromBytes.isFrozen()).to.be.true;
+    });
+
+    it("should be able to work with one chunk", async function () {
+        const CHUNK_SIZE = 4096;
+        const operatorKey = env.operatorKey.publicKey;
+
+        let response = await new FileCreateTransaction()
+            .setKeys([operatorKey])
+            .setContents(Buffer.from(""))
+            .execute(env.client);
+
+        let { fileId } = await response.getReceipt(env.client);
+
+        expect(fileId).to.not.be.null;
+        expect(fileId != null ? fileId.num > 0 : false).to.be.true;
+
+        const tx = await new FileAppendTransaction()
+            .setFileId(fileId)
+            .setContents(generateUInt8Array(CHUNK_SIZE))
+            .setChunkSize(CHUNK_SIZE)
+            .execute(env.client);
+
+        const receipt = await tx.getReceipt(env.client);
+        expect(receipt.status).to.be.equal(Status.Success);
+
+        const fileInfo = await new FileContentsQuery()
+            .setFileId(fileId)
+            .execute(env.client);
+
+        expect(fileInfo.length).to.be.equal(CHUNK_SIZE);
+    });
+
+    it("should not be able to sign transaction with 2 chunks", async function () {
+        const operatorKey = env.operatorKey.publicKey;
+        const CHUNKS_LENGTH = 2;
+        const CHUNK_SIZE = 1;
+
+        let response = await new FileCreateTransaction()
+            .setKeys([operatorKey])
+            .setContents(Buffer.from(""))
+            .execute(env.client);
+
+        let { fileId } = await response.getReceipt(env.client);
+
+        const tx = new FileAppendTransaction()
+            .setFileId(fileId)
+            .setContents(generateUInt8Array(CHUNKS_LENGTH))
+            .setChunkSize(CHUNK_SIZE);
+
+        let error = false;
+        try {
+            env.operatorKey.signTransaction(tx);
+        } catch (err) {
+            error = err.message.includes(
+                "Add signature is not supported for chunked transactions",
+            );
+        }
+
+        expect(error).to.be.true;
+    });
+
+    it("should be able to sign transaction with 1 chunk", async function () {
+        const operatorKey = env.operatorKey.publicKey;
+
+        let response = await new FileCreateTransaction()
+            .setKeys([operatorKey])
+            .setContents(Buffer.from(""))
+            .execute(env.client);
+
+        let { fileId } = await response.getReceipt(env.client);
+
+        const txBytes = new FileAppendTransaction()
+            .setFileId(fileId)
+            .setContents(Buffer.from("test"))
+            .toBytes();
+
+        const fromBytesTx = FileAppendTransaction.fromBytes(txBytes).freezeWith(
+            env.client,
+        );
+        // should start empty before adding signature
+        expect(fromBytesTx._signerPublicKeys).to.be.empty;
+
+        // should have 1 signature after adding signature
+        const signature = env.operatorKey.signTransaction(fromBytesTx);
+        fromBytesTx.addSignature(env.operatorKey.publicKey, signature);
+        expect(fromBytesTx._signerPublicKeys).to.have.length(1);
+
+        const receipt = await (
+            await fromBytesTx.execute(env.client)
+        ).getReceipt(env.client);
+        expect(receipt.status).to.be.equal(Status.Success);
     });
 
     after(async function () {

--- a/test/integration/PrivateKey.js
+++ b/test/integration/PrivateKey.js
@@ -42,7 +42,7 @@ describe("PrivateKey signTransaction", function () {
         expect(createdAccountId).to.exist;
     });
 
-    it("File Append Transaction Execution with Multiple Nodes", async function () {
+    it.skip("File Append Transaction Execution with Multiple Nodes", async function () {
         const operatorKey = env.operatorKey.publicKey;
 
         // Create file

--- a/test/integration/PrivateKey.js
+++ b/test/integration/PrivateKey.js
@@ -42,6 +42,9 @@ describe("PrivateKey signTransaction", function () {
         expect(createdAccountId).to.exist;
     });
 
+    // this sklip is temporary before we implement this feature
+    // in the next beta release
+    // eslint-disable-next-line mocha/no-skipped-tests
     it.skip("File Append Transaction Execution with Multiple Nodes", async function () {
         const operatorKey = env.operatorKey.publicKey;
 

--- a/test/integration/PrivateKey.js
+++ b/test/integration/PrivateKey.js
@@ -42,7 +42,7 @@ describe("PrivateKey signTransaction", function () {
         expect(createdAccountId).to.exist;
     });
 
-    // this sklip is temporary before we implement this feature
+    // this skip is temporary before we implement this feature
     // in the next beta release
     // eslint-disable-next-line mocha/no-skipped-tests
     it.skip("File Append Transaction Execution with Multiple Nodes", async function () {

--- a/test/integration/TransactionIntegrationTest.js
+++ b/test/integration/TransactionIntegrationTest.js
@@ -160,7 +160,7 @@ describe("TransactionIntegration", function () {
         await env.close();
     });
 
-    describe("HIP-745 - create incompleted transaction", function () {
+    describe("HIP-745 - create incomplete transaction", function () {
         let env, operatorId, recipientKey, recipientId, client, wallet;
 
         beforeEach(async function () {
@@ -262,7 +262,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-3.js */
-        it("should serialize and deserialize so-called incompleted transaction, and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction, and execute it", async function () {
             this.timeout(120000);
             try {
                 // 1. Create transaction
@@ -305,7 +305,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-4.js */
-        it("should serialize and deserialize so-called incompleted transaction, set node account ids and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction, set node account ids and execute it", async function () {
             this.timeout(120000);
             try {
                 // 1. Create transaction
@@ -356,7 +356,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-5.js */
-        it("should serialize and deserialize so-called incompleted transaction, set transaction id and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction, set transaction id and execute it", async function () {
             this.timeout(120000);
             try {
                 // 1. Create transaction
@@ -411,7 +411,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-6.js */
-        it("should serialize and deserialize so-called incompleted transaction, update and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction, update and execute it", async function () {
             this.timeout(120000);
             const amount = new Hbar(1);
             try {
@@ -511,7 +511,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-8.js */
-        it("should serialize and deserialize so-called incompleted transaction (chunked), and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction (chunked), and execute it", async function () {
             this.timeout(120000);
             try {
                 // 1. Create transaction
@@ -553,7 +553,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-9.js */
-        it("should serialize and deserialize so-called incompleted transaction (chunked), update and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction (chunked), update and execute it", async function () {
             this.timeout(120000);
             try {
                 // 1. Create transaction
@@ -602,7 +602,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-10.js */
-        it("should serialize and deserialize so-called incompleted transaction (chunked), set transaction id and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction (chunked), set transaction id and execute it", async function () {
             this.timeout(120000);
             try {
                 // 1. Create transaction
@@ -655,7 +655,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-11.js */
-        it("should serialize and deserialize so-called incompleted transaction (chunked), set node account ids and execute it", async function () {
+        it("should serialize and deserialize so-called incomplete transaction (chunked), set node account ids and execute it", async function () {
             this.timeout(120000);
             try {
                 // 1. Create transaction
@@ -704,7 +704,7 @@ describe("TransactionIntegration", function () {
         });
 
         /** @description: example serialize-deserialize-12.js */
-        it("should create, serialize and deserialize so-called incompleted transaction, then freeze it, serialize and deserialize it again, and execute it", async function () {
+        it("should create, serialize and deserialize so-called incomplete transaction, then freeze it, serialize and deserialize it again, and execute it", async function () {
             this.timeout(120000);
 
             try {


### PR DESCRIPTION
**Description**:
Implement chunk logic for toBytes method and disallow addSignature function until the next release. 

Fixes #2167 #2536

**Notes for reviewer**:
There should be refactoring done. We need to implement `ChunkTransaction`. This fix is more like a patch before the major refactor for ChunkedTransaction like the other SDKs. 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
