### PR TITLE
fix: change FEE_SCHEDULE_FILE_PART_UPLOADED to not show as an error

### DIFF
--- a/src/transaction/TransactionReceiptQuery.js
+++ b/src/transaction/TransactionReceiptQuery.js
@@ -257,6 +257,8 @@ export default class TransactionReceiptQuery extends Query {
                 return [status, ExecutionState.Retry];
             case Status.Success:
                 return [status, ExecutionState.Finished];
+            case Status.FeeScheduleFilePartUploaded:
+                return [status, ExecutionState.Finished];
             default:
                 return [
                     status,

--- a/src/transaction/TransactionReceiptQuery.js
+++ b/src/transaction/TransactionReceiptQuery.js
@@ -256,7 +256,6 @@ export default class TransactionReceiptQuery extends Query {
             case Status.ReceiptNotFound:
                 return [status, ExecutionState.Retry];
             case Status.Success:
-                return [status, ExecutionState.Finished];
             case Status.FeeScheduleFilePartUploaded:
                 return [status, ExecutionState.Finished];
             default:

--- a/src/transaction/TransactionResponse.js
+++ b/src/transaction/TransactionResponse.js
@@ -80,7 +80,10 @@ export default class TransactionResponse {
     async getReceipt(client) {
         const receipt = await this.getReceiptQuery().execute(client);
 
-        if (receipt.status !== Status.Success) {
+        if (
+            receipt.status !== Status.Success &&
+            receipt.status !== Status.FeeScheduleFilePartUploaded
+        ) {
             throw new ReceiptStatusError({
                 transactionReceipt: receipt,
                 status: receipt.status,

--- a/test/integration/FileUpdateIntegrationTest.js
+++ b/test/integration/FileUpdateIntegrationTest.js
@@ -5,8 +5,10 @@ import {
     FileInfoQuery,
     Hbar,
     Status,
+    AccountId,
+    PrivateKey,
 } from "../../src/exports.js";
-import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
+import IntegrationTestEnv, { Client } from "./client/NodeIntegrationTestEnv.js";
 
 describe("FileUpdate", function () {
     let env;
@@ -92,6 +94,28 @@ describe("FileUpdate", function () {
         if (!err) {
             throw new Error("file update did not error");
         }
+    });
+
+    it("should not error when FEE_SCHEDULE_FILE_PART_UPLOADED response", async function () {
+        this.timeout(120000);
+
+        const OPERATOR_ID = AccountId.fromString("0.0.2");
+        const OPERATOR_KEY = PrivateKey.fromStringED25519(
+            "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137",
+        );
+        const FEES_FILE_ID = "0.0.111";
+
+        const client = Client.forLocalNode().setOperator(
+            OPERATOR_ID,
+            OPERATOR_KEY,
+        );
+
+        await (
+            await new FileUpdateTransaction()
+                .setFileId(FEES_FILE_ID)
+                .setContents("Hello, Hedera!")
+                .execute(client)
+        ).getReceipt(client);
     });
 
     after(async function () {

--- a/test/integration/FileUpdateIntegrationTest.js
+++ b/test/integration/FileUpdateIntegrationTest.js
@@ -104,6 +104,7 @@ describe("FileUpdate", function () {
             "302e020100300506032b65700422042091132178e72057a1d7528025956fe39b0b847f200ab59b2fdd367017f3087137",
         );
         const FEES_FILE_ID = "0.0.111";
+        const DUMMY_TEXT = "Hello, Hedera!";
 
         const client = Client.forLocalNode().setOperator(
             OPERATOR_ID,
@@ -113,7 +114,7 @@ describe("FileUpdate", function () {
         await (
             await new FileUpdateTransaction()
                 .setFileId(FEES_FILE_ID)
-                .setContents("Hello, Hedera!")
+                .setContents(DUMMY_TEXT)
                 .execute(client)
         ).getReceipt(client);
     });


### PR DESCRIPTION
**Description**:
Updates TransactionResponse to not throw ReceiptStatus error and mark the receipt as finished

**Related issue(s)**: #2501

Fixes #2501

**Checklist**
- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
