### PR TITLE
release: v2.52.0-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.52.0-beta.1
+
+## What's Changed
+
+* feat: Add multi-signature and multi-node support for signing and adding signatures by @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2514
+* feat: Add removeSignature/clearAllSignatures methods by @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2491
+* chore(deps): bump actions/setup-node from 4.0.3 to 4.0.4 by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2538
+
 ## v2.51.0
 
 ## What's Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/sdk",
-    "version": "2.51.0",
+    "version": "2.52.0-beta.1",
     "description": "Hedera™ Hashgraph SDK",
     "types": "./lib/index.d.ts",
     "main": "./lib/index.cjs",

--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -342,7 +342,6 @@ export default class PrivateKey extends Key {
 
         transaction.addSignature(this.publicKey, signatures);
 
-
         // Return directly Uint8Array if there is only one signature
         return signatures.length === 1 ? signatures[0] : signatures;
     }


### PR DESCRIPTION
Beta release v2.52.0-beta.1

* feat: Add multi-signature and multi-node support for signing and adding signatures by @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2514
* feat: Add removeSignature/clearAllSignatures methods by @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2491
* chore(deps): bump actions/setup-node from 4.0.3 to 4.0.4 by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2538
