### PR TITLE
ci: update the codecov task to disable gcov

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -138,7 +138,7 @@ tasks:
         cmds:
             - npx c8 --reporter=lcov --reporter=text-summary ./node_modules/.bin/mocha --inline-diffs -r @babel/register -r chai/register-expect.js "test/unit/*.js" {{.CLI_ARGS}}
             - npx c8 report
-            - npx codecov
+            - npx codecov --disable=gcov
 
     "test:unit:browser":
         cmds:
@@ -156,7 +156,7 @@ tasks:
         cmds:
             - npx c8 --reporter=lcov --reporter=text-summary ./node_modules/.bin/mocha --exit -r @babel/register -r chai/register-expect.js "test/integration/*.js" {{.CLI_ARGS}}
             - npx c8 report
-            - npx codecov
+            - npx codecov --disable=gcov
 
     "update:proto":
         deps:


### PR DESCRIPTION
**Description**:

Disables gcov which runs by default in codecov

**Related issue(s)**:

Fixes #2252 

**Notes for reviewer**:

From the codecov community on a similar issue: [https://community.codecov.com/t/failed-to-run-gcov-command-yet-appears-to-succeed](https://community.codecov.com/t/failed-to-run-gcov-command-yet-appears-to-succeed/1677#:~:text=Any%20additional%20information,reports%20on%20Codecov.)
