### PR TITLE
release: v2.52.0-beta.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+# v2.52.0-beta.2
+
+## What's Changed
+
+* fix: serialize deserialize FileAppend by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2532
+* fix: change FEE_SCHEDULE_FILE_PART_UPLOADED to not show as an error by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2537
+* ci: Updating the build workflow to use Codecov actions instead of codecov npm package by @san-est in https://github.com/hashgraph/hedera-sdk-js/pull/2558
+
 ## v2.52.0-beta.1
 
 ## What's Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/sdk",
-    "version": "2.52.0-beta.1",
+    "version": "2.52.0-beta.2",
     "description": "Hedera™ Hashgraph SDK",
     "types": "./lib/index.d.ts",
     "main": "./lib/index.cjs",


### PR DESCRIPTION
Beta release v2.52.0-beta.2

## What's Changed

* fix: serialize deserialize FileAppend by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2532
* fix: change FEE_SCHEDULE_FILE_PART_UPLOADED to not show as an error by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2537
* ci: Updating the build workflow to use Codecov actions instead of codecov npm package by @san-est in https://github.com/hashgraph/hedera-sdk-js/pull/2558
