### PR TITLE
test: add FileAppend unit tests for better code coverage

### DIFF
--- a/test/unit/FileAppendTransaction.js
+++ b/test/unit/FileAppendTransaction.js
@@ -17,9 +17,11 @@ describe("FileAppendTransaction", function () {
     const timestamp1 = new Timestamp(14, 15);
     const fee = new Hbar(5);
     const chunkSize = 1000;
+    const smallContent = "abcdef";
 
     it("setChunkSize()", function () {
-        const contents = "1".repeat(1000) + "2".repeat(1000) + "3".repeat(1000);
+        const bigContent =
+            "1".repeat(1000) + "2".repeat(1000) + "3".repeat(1000);
 
         let transaction = new FileAppendTransaction()
             .setTransactionId(
@@ -28,7 +30,7 @@ describe("FileAppendTransaction", function () {
             .setNodeAccountIds([nodeAccountId])
             .setFileId(fileId)
             .setChunkSize(chunkSize)
-            .setContents(contents)
+            .setContents(bigContent)
             .freeze();
 
         const transactionId = transaction.transactionId;
@@ -41,6 +43,9 @@ describe("FileAppendTransaction", function () {
 
         expect(transaction._transactionIds.list.length).to.be.equal(3);
         expect(transaction._nodeAccountIds.list.length).to.be.equal(1);
+        expect(transaction.chunkSize).to.be.equal(chunkSize);
+        expect(transaction.contents.toString()).to.be.equal(bigContent);
+        expect(transaction.fileId).to.be.deep.equal(fileId);
 
         let body = transaction._makeTransactionBody(nodeAccountId);
 
@@ -137,5 +142,81 @@ describe("FileAppendTransaction", function () {
                 transaction._transactionIds.list[0].validStart.nanos,
             ),
         ).to.deep.equal(Long.fromNumber(chunkInterval * (requiredChunks - 1)));
+    });
+
+    it("should not be able to build transaction with more chunks than maxRequiredChunks", function () {
+        let transaction = new FileAppendTransaction()
+            .setContents(smallContent)
+            .setChunkSize(1)
+            .setMaxChunks(smallContent.length - 1);
+
+        expect(() => {
+            transaction.toBytes();
+        }).to.throw(
+            `cannot build \`FileAppendTransaction\` with more than ${
+                smallContent.length - 1
+            } chunks`,
+        );
+    });
+
+    it("should not be able to build all signed transaction with more than allowed chunks", async function () {
+        const transaction = new FileAppendTransaction()
+            .setNodeAccountIds([new AccountId(3)])
+            .setTransactionId(TransactionId.generate(new AccountId(1)))
+            .setContents(smallContent)
+            .setChunkSize(1)
+            .setMaxChunks(smallContent.length - 1)
+            .freeze();
+
+        expect(() => {
+            transaction.toBytes();
+        }).to.throw(
+            `cannot build \`FileAppendTransaction\` with more than ${
+                smallContent.length - 1
+            } chunks`,
+        );
+    });
+
+    it("should be able to build all signed transaction", async function () {
+        const transaction = new FileAppendTransaction()
+            .setNodeAccountIds([new AccountId(3)])
+            .setTransactionId(TransactionId.generate(new AccountId(1)))
+            .setContents(smallContent)
+            .setChunkSize(1)
+            .freeze();
+
+        expect(transaction.isFrozen()).to.be.true;
+
+        // calling toBytes will sign all transactions
+        transaction.toBytes();
+
+        expect(transaction._transactions.length).to.equal(smallContent.length);
+        expect(transaction._signedTransactions.length).to.equal(
+            smallContent.length,
+        );
+    });
+
+    it("should set maxChunk if set in constructor", function () {
+        const maxChunks = 10;
+        const tx = new FileAppendTransaction({ maxChunks });
+        expect(tx.maxChunks).to.equal(maxChunks);
+    });
+
+    it("should set chunkSize if set in constructor", function () {
+        const chunkSize = 10;
+        const tx = new FileAppendTransaction({ chunkSize });
+        expect(tx.chunkSize).to.equal(chunkSize);
+    });
+
+    it("should not be able to set scheduled message with bigger content than chunkSize", async function () {
+        const tx = new FileAppendTransaction()
+            .setContents(smallContent)
+            .setChunkSize(1);
+
+        expect(() => {
+            tx.schedule();
+        }).to.throw(
+            `cannot schedule \`FileAppendTransaction\` with message over ${tx.chunkSize} bytes`,
+        );
     });
 });

--- a/test/unit/FileAppendTransaction.js
+++ b/test/unit/FileAppendTransaction.js
@@ -34,12 +34,6 @@ describe("FileAppendTransaction", function () {
             .freeze();
 
         const transactionId = transaction.transactionId;
-        // TOOD: fix `FileAppendTransaction.fromBytes()` it seems the transaction IDs
-        // aren't be saved?
-        //
-        // transaction = /** @type {FileAppendTransaction} */ (
-        //     Transaction.fromBytes(transaction.toBytes())
-        // ).setChunkSize(1000);
 
         expect(transaction._transactionIds.list.length).to.be.equal(3);
         expect(transaction._nodeAccountIds.list.length).to.be.equal(1);


### PR DESCRIPTION
**Description**:
Adds more unit tests for FileAppend coverage. Last PR that improves FileAppend didn't include unit tests which lowered the code coverage. This PR fixes this by adding the necessary unit tests.

Related Issues:
#2588 

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
