### PR TITLE
(fix) TopicMessageQuery#unsubscribe() attempts to re-subscribe

### DIFF
--- a/src/topic/SubscriptionHandle.js
+++ b/src/topic/SubscriptionHandle.js
@@ -22,6 +22,9 @@ export default class SubscriptionHandle {
     constructor() {
         /** @type {{(): void} | null} */
         this._call = null;
+
+        /** @type {boolean} */
+        this._unsubscribed = false;
     }
 
     /**
@@ -34,6 +37,7 @@ export default class SubscriptionHandle {
 
     unsubscribe() {
         if (this._call != null) {
+            this._unsubscribed = true;
             this._call();
         }
     }

--- a/src/topic/TopicMessageQuery.js
+++ b/src/topic/TopicMessageQuery.js
@@ -438,6 +438,10 @@ export default class TopicMessageQuery extends Query {
                     const message =
                         error instanceof Error ? error.message : error.details;
 
+                    if (this._handle?._unsubscribed) {
+                        return;
+                    }
+
                     if (
                         this._attempt < this._maxAttempts &&
                         this._retryHandler(error)


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

This PR modifies ... in order to support ...
* Add config property
* Change column name
* Remove ...
-->
The `unsubscribe` method invokes the _call function, which cancels the current active subscription but doesn’t necessarily stop retry attempts, as retries are managed separately in `TopicMessageQuery`. I have added a check to prevent retries after unsubscribing in the `error` callback

https://github.com/user-attachments/assets/6f933119-58ef-416d-8561-51d9fbd5c247



**Related issue(s)**:

Fixes #2222 

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
