### PR TITLE
Create account with threshold key 

### DIFF
--- a/examples/create-account-with-thresholdkey.js
+++ b/examples/create-account-with-thresholdkey.js
@@ -42,7 +42,7 @@ async function main() {
     const operatorKey = PrivateKey.fromStringED25519(process.env.OPERATOR_KEY);
 
     //  Create the client based on the HEDERA_NETWORK environment variable
-    let client = Client.forName(process.env.HEDERA_NETWORK);
+    const client = Client.forName(process.env.HEDERA_NETWORK);
 
     client.setOperator(operatorId, operatorKey);
     // Attach your custom logger to the SDK client

--- a/examples/create-account-with-thresholdkey.js
+++ b/examples/create-account-with-thresholdkey.js
@@ -1,0 +1,145 @@
+import {
+    Client,
+    PrivateKey,
+    AccountId,
+    Hbar,
+    AccountCreateTransaction,
+    TransferTransaction,
+    AccountBalanceQuery,
+    AccountDeleteTransaction,
+    KeyList,
+} from "@hashgraph/sdk";
+import dotenv from "dotenv";
+
+dotenv.config();
+
+async function main() {
+    if (
+        process.env.OPERATOR_ID == null ||
+        process.env.OPERATOR_KEY == null ||
+        process.env.HEDERA_NETWORK == null
+    ) {
+        throw new Error(
+            "Environment variables OPERATOR_ID, HEDERA_NETWORK, and OPERATOR_KEY are required.",
+        );
+    }
+
+    const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+    const operatorKey = PrivateKey.fromStringED25519(process.env.OPERATOR_KEY);
+
+    // Create a client for the local Hedera network
+    const client = Client.forNetwork({
+        [process.env.HEDERA_NETWORK]: new AccountId(3)
+    });
+    client.setOperator(operatorId, operatorKey);
+
+    try {
+        console.log("Create Account With Threshold Key Example Start!");
+
+        /*
+         * Step 1:
+         * Generate three new Ed25519 private, public key pairs.
+         *
+         * You do not need the private keys to create the Threshold Key List,
+         * you only need the public keys, and if you're doing things correctly,
+         * you probably shouldn't have these private keys.
+         */
+
+        // Generate 3 new Ed25519 private, public key pairs
+        const privateKeys = [];
+        const publicKeys = [];
+        for (let i = 0; i < 3; i++) {
+            const key = PrivateKey.generateED25519();
+            privateKeys.push(key);
+            publicKeys.push(key.publicKey);
+        }
+
+        console.log("Generating public keys...");
+        publicKeys.forEach((publicKey, index) => {
+            console.log(`Generated public key ${index + 1}: ${publicKey.toString()}`);
+        });
+
+        /*
+         * Step 2:
+         * Create a Key List.
+         *
+         * Require 2 of the 3 keys we generated to sign on anything modifying this account.
+         */
+        const thresholdKey = new KeyList();
+        thresholdKey.setThreshold(2);
+        publicKeys.forEach((publicKey) => thresholdKey.push(publicKey));
+
+        /*
+         * Step 3:
+         * Create a new account setting a Key List from a previous step as an account's key.
+         */
+        console.log("Creating new account...");
+        const accountCreateTxResponse = await new AccountCreateTransaction()
+            .setKey(thresholdKey)
+            .setInitialBalance(new Hbar(1))
+            .execute(client);
+
+        const accountCreateTxReceipt = await accountCreateTxResponse.getReceipt(client);
+        const newAccountId = accountCreateTxReceipt.accountId;
+        if (!newAccountId) {
+            throw new Error("Failed to retrieve new account ID");
+        }
+        console.log(`Created account with ID: ${newAccountId.toString()}`);
+
+        /*
+         * Step 4:
+         * Create a transfer transaction from a newly created account to demonstrate the signing process (threshold).
+         */
+        console.log("Transferring 1 Hbar from a newly created account...");
+        let transferTx =  new TransferTransaction()
+            .addHbarTransfer(newAccountId, new Hbar(-1)) // 1 Hbar in negative
+            .addHbarTransfer(new AccountId(3), new Hbar(1)) // 1 Hbar
+            .freezeWith(client); // Freeze with client
+
+        // Sign with 2 of the 3 keys
+        transferTx = await transferTx.sign(privateKeys[0]);
+        transferTx = await transferTx.sign(privateKeys[1]);
+
+        // Execute the transaction
+        const transferTxResponse = await transferTx.execute(client);
+
+        // Wait for the transfer to reach consensus
+        await transferTxResponse.getReceipt(client);
+
+        // Query the account balance after the transfer
+        const accountBalanceAfterTransfer = await new AccountBalanceQuery()
+            .setAccountId(newAccountId)
+            .execute(client);
+
+        console.log("New account's Hbar balance after transfer: " + accountBalanceAfterTransfer.hbars.toString());
+
+        /*
+         * Step 5:
+         * Clean up: Delete created account.
+         */
+        let accountDeleteTx =  new AccountDeleteTransaction()
+            .setTransferAccountId(operatorId)
+            .setAccountId(newAccountId)
+            .freezeWith(client);
+
+        accountDeleteTx = await accountDeleteTx.sign(privateKeys[0]);
+        accountDeleteTx = await accountDeleteTx.sign(privateKeys[1]);
+
+        const accountDeleteTxResponse = await accountDeleteTx.execute(client);
+        await accountDeleteTxResponse.getReceipt(client);
+
+        console.log("Account deleted successfully");
+
+        console.log("Create Account With Threshold Key Example Complete!");
+    } catch (error) {
+        console.error("Error occurred:", error);
+    } finally {
+        // Close the client
+        client.close();
+    }
+}
+
+main().catch((error) => {
+    console.error("Unhandled error:", error);
+    process.exit(1);
+});

--- a/examples/create-account-with-thresholdkey.js
+++ b/examples/create-account-with-thresholdkey.js
@@ -1,4 +1,3 @@
-/* eslint-disable n/no-extraneous-import */
 import {
     Client,
     PrivateKey,
@@ -9,28 +8,19 @@ import {
     AccountBalanceQuery,
     AccountDeleteTransaction,
     KeyList,
+    Logger,
+    LogLevel,
 } from "@hashgraph/sdk";
 
 import dotenv from "dotenv";
-import pino from "pino";
-import pinoPretty from "pino-pretty";
 
 dotenv.config();
 
 // Set default log level to 'silent' if SDK_LOG_LEVEL is not specified in .env
 const SDK_LOG_LEVEL = process.env.SDK_LOG_LEVEL || "SILENT";
 
-// Logger configuration based on SDK_LOG_LEVEL
-const logger = pino(
-    {
-        level: SDK_LOG_LEVEL.toUpperCase(),
-    },
-    pinoPretty({
-        colorize: true,
-        translateTime: "SYS:standard",
-        ignore: "pid,hostname",
-    }),
-);
+// Initialize Logger with the specified log level from the environment variable
+const logger = new Logger(LogLevel._fromString(SDK_LOG_LEVEL));
 
 /**
  * Step 0: Set up client connection to Hedera network
@@ -55,6 +45,8 @@ async function main() {
     let client = Client.forName(process.env.HEDERA_NETWORK);
 
     client.setOperator(operatorId, operatorKey);
+    // Attach your custom logger to the SDK client
+    client.setLogger(logger);
 
     try {
         logger.info("Create Account With Threshold Key Example Start!");
@@ -151,7 +143,7 @@ async function main() {
 
         logger.info("Account deleted successfully");
     } catch (error) {
-        logger.error("Error occurred during account creation:", error);
+        logger.error("Error occurred during account creation");
     } finally {
         client.close();
         logger.info("Create Account With Threshold Key Example Complete!");

--- a/examples/create-account-with-thresholdkey.js
+++ b/examples/create-account-with-thresholdkey.js
@@ -32,7 +32,7 @@ async function main() {
         !process.env.OPERATOR_KEY ||
         !process.env.HEDERA_NETWORK
     ) {
-        logger.error(
+        console.error(
             "Environment variables OPERATOR_ID, OPERATOR_KEY, and HEDERA_NETWORK are required.",
         );
         throw new Error("Missing required environment variables.");
@@ -49,7 +49,7 @@ async function main() {
     client.setLogger(logger);
 
     try {
-        logger.info("Create Account With Threshold Key Example Start!");
+        console.log("Create Account With Threshold Key Example Start!");
 
         /*
          * Step 1:
@@ -65,9 +65,9 @@ async function main() {
             publicKeys.push(key.publicKey);
         }
 
-        logger.info("Generating public keys...");
+        console.log("Generating public keys...");
         publicKeys.forEach((publicKey, index) => {
-            logger.info(
+            console.log(
                 `Generated public key ${index + 1}: ${publicKey.toString()}`,
             );
         });
@@ -84,7 +84,7 @@ async function main() {
          * Step 3:
          * Create a new account setting a Key List from a previous step as an account's key.
          */
-        logger.info("Creating new account...");
+        console.log("Creating new account...");
         const accountCreateTxResponse = await new AccountCreateTransaction()
             .setKey(thresholdKey)
             .setInitialBalance(new Hbar(100))
@@ -94,13 +94,13 @@ async function main() {
             await accountCreateTxResponse.getReceipt(client);
         const newAccountId = accountCreateTxReceipt.accountId;
 
-        logger.info(`Created account with ID: ${newAccountId.toString()}`);
+        console.log(`Created account with ID: ${newAccountId.toString()}`);
 
         /*
          * Step 4:
          * Create a transfer transaction from a newly created account to demonstrate the signing process (threshold).
          */
-        logger.info("Transferring 1 Hbar from a newly created account...");
+        console.log("Transferring 1 Hbar from a newly created account...");
         let transferTx = new TransferTransaction()
             .addHbarTransfer(newAccountId, new Hbar(-50))
             .addHbarTransfer(new AccountId(3), new Hbar(50))
@@ -121,7 +121,7 @@ async function main() {
             .setAccountId(newAccountId)
             .execute(client);
 
-        logger.info(
+        console.log(
             "New account's Hbar balance after transfer: " +
                 accountBalanceAfterTransfer.hbars.toString(),
         );
@@ -141,12 +141,12 @@ async function main() {
         const accountDeleteTxResponse = await accountDeleteTx.execute(client);
         await accountDeleteTxResponse.getReceipt(client);
 
-        logger.info("Account deleted successfully");
+        console.log("Account deleted successfully");
     } catch (error) {
-        logger.error("Error occurred during account creation");
+        console.error("Error occurred during account creation");
     } finally {
         client.close();
-        logger.info("Create Account With Threshold Key Example Complete!");
+        console.log("Create Account With Threshold Key Example Complete!");
     }
 }
 

--- a/examples/create-account-with-thresholdkey.js
+++ b/examples/create-account-with-thresholdkey.js
@@ -16,12 +16,6 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
-// Set default log level to 'silent' if SDK_LOG_LEVEL is not specified in .env
-const SDK_LOG_LEVEL = process.env.SDK_LOG_LEVEL || "SILENT";
-
-// Initialize Logger with the specified log level from the environment variable
-const logger = new Logger(LogLevel._fromString(SDK_LOG_LEVEL));
-
 /**
  * Step 0: Set up client connection to Hedera network
  */
@@ -45,8 +39,10 @@ async function main() {
     const client = Client.forName(process.env.HEDERA_NETWORK);
 
     client.setOperator(operatorId, operatorKey);
-    // Attach your custom logger to the SDK client
-    client.setLogger(logger);
+    
+    // Set logger
+    const infoLogger = new Logger(LogLevel.Info);
+    client.setLogger(infoLogger);
 
     try {
         console.log("Create Account With Threshold Key Example Start!");

--- a/examples/create-account-with-thresholdkey.js
+++ b/examples/create-account-with-thresholdkey.js
@@ -1,3 +1,4 @@
+/* eslint-disable n/no-extraneous-import */
 import {
     Client,
     PrivateKey,
@@ -11,11 +12,25 @@ import {
 } from "@hashgraph/sdk";
 
 import dotenv from "dotenv";
+import pino from "pino";
+import pinoPretty from "pino-pretty";
 
 dotenv.config();
 
-// Removed pino logger initialization
-const logger = console;
+// Set default log level to 'silent' if SDK_LOG_LEVEL is not specified in .env
+const SDK_LOG_LEVEL = process.env.SDK_LOG_LEVEL || "SILENT";
+
+// Logger configuration based on SDK_LOG_LEVEL
+const logger = pino(
+    {
+        level: SDK_LOG_LEVEL.toUpperCase(),
+    },
+    pinoPretty({
+        colorize: true,
+        translateTime: "SYS:standard",
+        ignore: "pid,hostname",
+    }),
+);
 
 /**
  * Step 0: Set up client connection to Hedera network
@@ -36,32 +51,9 @@ async function main() {
     const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
     const operatorKey = PrivateKey.fromStringED25519(process.env.OPERATOR_KEY);
 
-    let client;
+    //  Create the client based on the HEDERA_NETWORK environment variable
+    let client = Client.forName(process.env.HEDERA_NETWORK);
 
-    // Adjust this as needed for your local network
-    const localNetworkConfig = {
-        "127.0.0.1:50211": new AccountId(3),
-    }
-
-    switch (process.env.HEDERA_NETWORK) {
-        case "mainnet":
-            client = Client.forMainnet();
-            break;
-        case "testnet":
-            client = Client.forTestnet();
-            break;
-        case "previewnet":
-            client = Client.forPreviewnet();
-            break;
-        case "local-node":
-            client = Client.forNetwork(localNetworkConfig);
-            break;
-        default:
-            logger.error("Unsupported HEDERA_NETWORK value.");
-            throw new Error(
-                "Unsupported HEDERA_NETWORK value. Set to 'mainnet', 'testnet', 'previewnet', or 'local-node'.",
-            );
-    }
     client.setOperator(operatorId, operatorKey);
 
     try {
@@ -83,7 +75,7 @@ async function main() {
 
         logger.info("Generating public keys...");
         publicKeys.forEach((publicKey, index) => {
-            console.log(
+            logger.info(
                 `Generated public key ${index + 1}: ${publicKey.toString()}`,
             );
         });


### PR DESCRIPTION
**Description**:
This PR introduces an example for creating an account with a threshold key in the Hedera JavaScript SDK, which mirrors the existing example in the Hedera Java SDK.

**Problem**
The Hedera Java SDK already includes an example (CreateAccountThresholdKeyExample.java) that demonstrates how to create an account with a threshold key. This feature is essential for ensuring security by requiring multiple signatures to authorize transactions.

However, there is currently no such example in the Hedera JavaScript SDK. Developers using the JavaScript SDK would greatly benefit from a similar example to guide them through creating accounts with threshold keys in JavaScript, as it's a crucial security feature.

**Solution**

This PR provides a new example in the JavaScript SDK that follows the structure of the existing Java example. Key steps include:

- Generating key pairs using PrivateKey.generateED25519().
- Initializing a KeyList with a threshold and adding public keys to create the threshold key.
- Creating an account using the threshold key.
- Demonstrating a transaction that requires multiple signatures from the threshold key.
- Cleaning up by deleting the account, again requiring multi-signatures.

**Related issue(s)**:

Fixes #2511

