### PR TITLE
fix: file append transaction id after deserialization

### DIFF
--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -492,6 +492,10 @@ export default class FileAppendTransaction extends Transaction {
      */
     _buildIncompleteTransactions() {
         const dummyAccountId = AccountId.fromString("0.0.0");
+        const accountId = this.transactionId?.accountId || dummyAccountId;
+        const validStart =
+            this.transactionId?.validStart || Timestamp.fromDate(new Date());
+
         if (this._contents == null) {
             throw new Error("contents is not set");
         }
@@ -510,7 +514,10 @@ export default class FileAppendTransaction extends Transaction {
         this._signedTransactions.clear();
 
         for (let chunk = 0; chunk < this.getRequiredChunks(); chunk++) {
-            let nextTransactionId = TransactionId.generate(dummyAccountId);
+            let nextTransactionId = TransactionId.withValidStart(
+                accountId,
+                validStart.plusNanos(this._chunkInterval * chunk),
+            );
             this._transactionIds.push(nextTransactionId);
             this._transactionIds.advance();
 

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -179,6 +179,9 @@ export default class FileAppendTransaction extends Transaction {
             contents = concat;
         }
 
+        const chunkSize = append.contents?.length || undefined;
+        const maxChunks = bodies.length || undefined;
+
         return Transaction._fromProtobufTransactions(
             new FileAppendTransaction({
                 fileId:
@@ -189,7 +192,9 @@ export default class FileAppendTransaction extends Transaction {
                               ),
                           )
                         : undefined,
-                contents: contents,
+                contents,
+                chunkSize,
+                maxChunks,
             }),
             transactions,
             signedTransactions,

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -60,6 +60,7 @@ export default class FileAppendTransaction extends Transaction {
      * @param {Uint8Array | string} [props.contents]
      * @param {number} [props.maxChunks]
      * @param {number} [props.chunkSize]
+     * @param {number} [props.chunkInterval]
      */
     constructor(props = {}) {
         super();
@@ -88,6 +89,12 @@ export default class FileAppendTransaction extends Transaction {
          */
         this._chunkSize = 4096;
 
+        /**
+         * @private
+         * @type {number}
+         */
+        this._chunkInterval = 10;
+
         this._defaultMaxTransactionFee = new Hbar(5);
 
         if (props.fileId != null) {
@@ -104,6 +111,10 @@ export default class FileAppendTransaction extends Transaction {
 
         if (props.chunkSize != null) {
             this.setChunkSize(props.chunkSize);
+        }
+
+        if (props.chunkInterval != null) {
+            this.setChunkInterval(props.chunkInterval);
         }
 
         /** @type {List<TransactionId>} */
@@ -297,6 +308,22 @@ export default class FileAppendTransaction extends Transaction {
      */
     setChunkSize(chunkSize) {
         this._chunkSize = chunkSize;
+        return this;
+    }
+
+    /**
+     * @returns {number}
+     */
+    get chunkInterval() {
+        return this._chunkInterval;
+    }
+
+    /**
+     * @param {number} chunkInterval
+     * @returns {this}
+     */
+    setChunkInterval(chunkInterval) {
+        this._chunkInterval = chunkInterval;
         return this;
     }
 

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -319,7 +319,7 @@ export default class FileAppendTransaction extends Transaction {
     }
 
     /**
-     * @param {number} chunkInterval
+     * @param {number} chunkInterval The valid start interval between chunks in nanoseconds
      * @returns {this}
      */
     setChunkInterval(chunkInterval) {
@@ -371,7 +371,7 @@ export default class FileAppendTransaction extends Transaction {
                     ).seconds,
                     /** @type {Timestamp} */ (
                         nextTransactionId.validStart
-                    ).nanos.add(1),
+                    ).nanos.add(this._chunkInterval),
                 ),
             );
         }

--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -181,6 +181,16 @@ export default class FileAppendTransaction extends Transaction {
 
         const chunkSize = append.contents?.length || undefined;
         const maxChunks = bodies.length || undefined;
+        let chunkInterval;
+        if (transactionIds.length > 1) {
+            const firstValidStart = transactionIds[0].validStart;
+            const secondValidStart = transactionIds[1].validStart;
+            if (firstValidStart && secondValidStart) {
+                chunkInterval = secondValidStart.nanos
+                    .sub(firstValidStart.nanos)
+                    .toNumber();
+            }
+        }
 
         return Transaction._fromProtobufTransactions(
             new FileAppendTransaction({
@@ -195,6 +205,7 @@ export default class FileAppendTransaction extends Transaction {
                 contents,
                 chunkSize,
                 maxChunks,
+                chunkInterval,
             }),
             transactions,
             signedTransactions,

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -407,8 +407,10 @@ describe("FileAppend", function () {
         expect(receipt.status).to.be.equal(Status.Success);
     });
 
-    it("should keep chunk size and correct maxChunks after deserialization", async function () {
+    it("should keep chunk size, chunk interval and correct max chunks after deserialization", async function () {
         const operatorKey = env.operatorKey.publicKey;
+        const chunkSize = 1024;
+        const chunkInterval = 230;
 
         let response = await new FileCreateTransaction()
             .setKeys([operatorKey])
@@ -419,7 +421,8 @@ describe("FileAppend", function () {
 
         const tx = new FileAppendTransaction()
             .setFileId(fileId)
-            .setChunkSize(1024)
+            .setChunkSize(chunkSize)
+            .setChunkInterval(chunkInterval)
             .setMaxChunks(99999)
             .setContents(newContents);
 
@@ -430,6 +433,7 @@ describe("FileAppend", function () {
         expect(txFromBytes.maxChunks).to.be.equal(
             txFromBytes.getRequiredChunks(),
         );
+        expect(txFromBytes.chunkInterval).to.be.equal(230);
 
         txFromBytes.freezeWith(env.client);
         await txFromBytes.sign(env.operatorKey);

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -365,12 +365,11 @@ describe("FileAppend", function () {
         let { fileId } = await response.getReceipt(env.client);
 
         const chunkInterval = 230;
+        const validStart = Timestamp.fromDate(new Date());
+
         const tx = new FileAppendTransaction()
             .setTransactionId(
-                TransactionId.withValidStart(
-                    env.operatorId,
-                    Timestamp.fromDate(new Date()),
-                ),
+                TransactionId.withValidStart(env.operatorId, validStart),
             )
             .setFileId(fileId)
             .setChunkInterval(chunkInterval)
@@ -383,6 +382,9 @@ describe("FileAppend", function () {
         expect(
             txFromBytes.transactionId.accountId._toProtobuf(),
         ).to.be.deep.equal(env.operatorId?._toProtobuf());
+        expect(txFromBytes.transactionId.validStart).to.be.deep.equal(
+            validStart,
+        );
 
         txFromBytes._transactionIds.list.forEach(
             (transactionId, index, array) => {

--- a/test/unit/FileAppendTransaction.js
+++ b/test/unit/FileAppendTransaction.js
@@ -88,4 +88,90 @@ describe("FileAppendTransaction", function () {
         expect(body.fileAppend.contents.length).to.be.equal(1000);
         expect(body.fileAppend.contents[0]).to.be.equal(51);
     });
+
+    it("setChunkInterval()", function () {
+        const spenderAccountId1 = new AccountId(7);
+        const fileId = new FileId(8);
+        const nodeAccountId = new AccountId(10, 11, 12);
+        const timestamp1 = new Timestamp(14, 15);
+        const chunkInterval = 200;
+
+        let transaction = new FileAppendTransaction()
+            .setTransactionId(
+                TransactionId.withValidStart(spenderAccountId1, timestamp1),
+            )
+            .setNodeAccountIds([nodeAccountId])
+            .setFileId(fileId)
+            .setChunkSize(1000)
+            .setChunkInterval(chunkInterval)
+            .setContents("1".repeat(1000) + "2".repeat(1000) + "3".repeat(1000))
+            .freeze();
+
+        const transactionId = transaction.transactionId;
+
+        expect(transaction._transactionIds.list.length).to.be.equal(3);
+        expect(transaction._nodeAccountIds.list.length).to.be.equal(1);
+
+        let body = transaction._makeTransactionBody(nodeAccountId);
+
+        expect(body.transactionID).to.deep.equal(transactionId._toProtobuf());
+
+        expect(body.memo).to.be.equal("");
+        expect(body.transactionID).to.deep.equal(
+            transaction._transactionIds.list[0]._toProtobuf(),
+        );
+        expect(body.nodeAccountID).to.deep.equal(nodeAccountId._toProtobuf());
+        expect(body.transactionValidDuration).to.deep.equal({
+            seconds: Long.fromNumber(120),
+        });
+        expect(body.fileAppend.fileID).to.deep.equal(fileId._toProtobuf());
+        expect(body.fileAppend.contents.length).to.be.equal(1000);
+        expect(body.fileAppend.contents[0]).to.be.equal(49);
+
+        transaction._transactionIds.advance();
+        body = transaction._makeTransactionBody(nodeAccountId);
+
+        expect(body.memo).to.be.equal("");
+        expect(body.transactionID).to.deep.equal(
+            transaction._transactionIds.list[1]._toProtobuf(),
+        );
+        expect(
+            transaction._transactionIds.list[1].validStart.nanos.sub(
+                transaction._transactionIds.list[0].validStart.nanos,
+            ),
+        ).to.deep.equal(Long.fromNumber(chunkInterval));
+        expect(body.nodeAccountID).to.deep.equal(nodeAccountId._toProtobuf());
+        expect(body.transactionValidDuration).to.deep.equal({
+            seconds: Long.fromNumber(120),
+        });
+        expect(body.fileAppend.fileID).to.deep.equal(fileId._toProtobuf());
+        expect(body.fileAppend.contents.length).to.be.equal(1000);
+        expect(body.fileAppend.contents[0]).to.be.equal(50);
+
+        transaction._transactionIds.advance();
+        body = transaction._makeTransactionBody(nodeAccountId);
+
+        expect(body.memo).to.be.equal("");
+        expect(body.transactionID).to.deep.equal(
+            transaction._transactionIds.list[2]._toProtobuf(),
+        );
+        expect(
+            transaction._transactionIds.list[2].validStart.nanos.sub(
+                transaction._transactionIds.list[1].validStart.nanos,
+            ),
+        ).to.deep.equal(Long.fromNumber(chunkInterval));
+        expect(body.nodeAccountID).to.deep.equal(nodeAccountId._toProtobuf());
+        expect(body.transactionValidDuration).to.deep.equal({
+            seconds: Long.fromNumber(120),
+        });
+        expect(body.fileAppend.fileID).to.deep.equal(fileId._toProtobuf());
+        expect(body.fileAppend.contents.length).to.be.equal(1000);
+        expect(body.fileAppend.contents[0]).to.be.equal(51);
+
+        expect(
+            transaction._transactionIds.list[2].validStart.nanos.sub(
+                transaction._transactionIds.list[0].validStart.nanos,
+            ),
+        ).to.deep.equal(Long.fromNumber(chunkInterval * 2));
+    });
 });


### PR DESCRIPTION
**Description**:
This pull request:
- Fixes the lost transaction ID after deserialization, if previously set
- Adds chunk interval property to bring flexibility to the interval between chunks. This is helpful if a user tries to update a file that will take longer than the transaction's `validDuration`.

**Related issue(s)**:

Fixes Partially #2167 

**Checklist**

- [X] Documented (Code comments)
- [X] Tested (unit, integration)
