### PR TITLE
fix: incomplete file append transaction

### DIFF
--- a/src/file/FileAppendTransaction.js
+++ b/src/file/FileAppendTransaction.js
@@ -254,12 +254,11 @@ export default class FileAppendTransaction extends Transaction {
      */
     getRequiredChunks() {
         if (this._contents == null) {
-            return 0;
+            return 1;
         }
 
-        const result = Math.floor(
-            (this._contents.length + (this._chunkSize - 1)) / this._chunkSize,
-        );
+        const result = Math.ceil(this._contents.length / this._chunkSize);
+
         return result;
     }
 
@@ -511,10 +510,6 @@ export default class FileAppendTransaction extends Transaction {
         const accountId = this.transactionId?.accountId || dummyAccountId;
         const validStart =
             this.transactionId?.validStart || Timestamp.fromDate(new Date());
-
-        if (this._contents == null) {
-            throw new Error("contents is not set");
-        }
 
         if (this.maxChunks && this.getRequiredChunks() > this.maxChunks) {
             throw new Error(

--- a/test/integration/FileAppendIntegrationTest.js
+++ b/test/integration/FileAppendIntegrationTest.js
@@ -444,6 +444,34 @@ describe("FileAppend", function () {
         expect(receipt.status).to.be.equal(Status.Success);
     });
 
+    it("should return transaction bytes when content is empty", async function () {
+        const operatorKey = env.operatorKey.publicKey;
+        const validStart = Timestamp.fromDate(new Date());
+
+        let response = await new FileCreateTransaction()
+            .setKeys([operatorKey])
+            .setContents(Buffer.from(""))
+            .execute(env.client);
+
+        let { fileId } = await response.getReceipt(env.client);
+
+        const transaction = new FileAppendTransaction()
+            .setTransactionId(
+                TransactionId.withValidStart(env.operatorId, validStart),
+            )
+            .setFileId(fileId);
+
+        const transactionBytes = transaction.toBytes();
+
+        const deserializedTransaction =
+            FileAppendTransaction.fromBytes(transactionBytes);
+
+        expect(transactionBytes.length).to.be.greaterThan(0);
+        expect(transaction.transactionId).to.be.deep.equal(
+            deserializedTransaction.transactionId,
+        );
+    });
+
     after(async function () {
         await env.close();
     });


### PR DESCRIPTION
**Description**:
This pull request fixes the FileAppendTransaction when building an incomplete transaction and you don't want to set contents. Previously the contents were required and you couldn't create incomplete transactions without setting the content.

**Checklist**

- [X] Tested (unit, integration, etc.)
