### PR TITLE
fix: incorrect protobuf body field used

### DIFF
--- a/src/token/TokenUpdateNftsTransaction.js
+++ b/src/token/TokenUpdateNftsTransaction.js
@@ -101,7 +101,7 @@ export default class TokenUpdateNftsTransaction extends Transaction {
         const body = bodies[0];
         const tokenUpdate =
             /** @type {HashgraphProto.proto.ITokenUpdateNftsTransactionBody} */ (
-                body.tokenUpdate
+                body.tokenUpdateNfts
             );
 
         return Transaction._fromProtobufTransactions(

--- a/test/unit/TokenUpdateNftsTransaction.js
+++ b/test/unit/TokenUpdateNftsTransaction.js
@@ -1,0 +1,40 @@
+import { TokenUpdateNftsTransaction } from "../../src/index.js";
+import TransactionId from "../../src/transaction/TransactionId.js";
+import AccountId from "../../src/account/AccountId.js";
+
+describe("TokenUpdateNftsTransaction", function () {
+    it("should create from a protobuf", function () {
+        const tokenId = "0.0.123";
+        const serials = [1, 2, 3];
+        const metadata = new Uint8Array([1, 2, 3]);
+
+        /**
+         * @type {HashgraphProto.proto.ITokenUpdateNftsTransactionBody}
+         */
+        const body = {
+            tokenUpdateNfts: {
+                token: { shardNum: 0, realmNum: 0, tokenNum: 123 },
+                serialNumbers: serials,
+                metadata: { value: metadata },
+            },
+        };
+
+        const transactions = [{ body }];
+        const signedTransactions = [{}];
+        const transactionIds = [TransactionId.generate(new AccountId(1))];
+        const nodeIds = [new AccountId(3)];
+        const bodies = [body];
+
+        const transaction = TokenUpdateNftsTransaction._fromProtobuf(
+            transactions,
+            signedTransactions,
+            transactionIds,
+            nodeIds,
+            bodies
+        );
+
+        expect(transaction._tokenId.toString()).to.eql(tokenId);
+        expect(transaction._serialNumbers).to.eql(serials);
+        expect(transaction._metadata).to.eql(metadata);
+    });
+});


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

-->

This PR fixes `_fromProtobuf` inside of `TokenUpdateNftsTransaction` to use the correct `tokenUpdateNfts` field instead of `tokenUpdate`. Upon investigating https://github.com/hashgraph/hedera-wallet-connect/issues/265, we realized this property was not being referenced properly. 

**Related issue(s)**:

Fixes https://github.com/hashgraph/hedera-wallet-connect/issues/265

**Notes for reviewer**:

You can confirm the error happens outside of this branch by running the following code: 

```
import Long from "long";
import { TokenUpdateNftsTransaction, Transaction } from "./exports.js";

const updateNftsTransaction = new TokenUpdateNftsTransaction()
    .setTokenId("0.0.123")
    .setSerialNumbers([Long.fromInt(1)])
    .setMetadata(new TextEncoder().encode("metadata"));

const parsedTx = Transaction.fromBytes(updateNftsTransaction.toBytes());

console.log("parsedTx: ", parsedTx._makeTransactionBody());
```

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
