### PR TITLE
feat: Add method to `NodeClient` for Initialization with `MirrorNetwork` only

### DIFF
--- a/examples/initialize-client-with-mirror-node-adress-book.js
+++ b/examples/initialize-client-with-mirror-node-adress-book.js
@@ -1,0 +1,50 @@
+import {
+    AccountCreateTransaction,
+    Client,
+    PrivateKey,
+    Hbar,
+} from "@hashgraph/sdk";
+
+import dotenv from "dotenv";
+
+/**
+ * @description Initialize a client with only mirror node network address and create account with it
+ */
+
+async function main() {
+    // Ensure required environment variables are available
+    dotenv.config();
+
+    // Ensure that they are testnet variables
+    if (
+        !process.env.OPERATOR_KEY ||
+        !process.env.OPERATOR_ID ||
+        !process.env.HEDERA_NETWORK
+    ) {
+        throw new Error("Please set required keys in .env file.");
+    }
+
+    const accountKey = PrivateKey.generate();
+
+    const client = (
+        await Client.forMirrorNetwork("testnet.mirrornode.hedera.com:443")
+    ).setOperator(process.env.OPERATOR_ID, process.env.OPERATOR_KEY);
+
+    try {
+        let transaction = new AccountCreateTransaction()
+            .setInitialBalance(new Hbar(10)) // 10 h
+            .setKey(accountKey)
+            .freezeWith(client);
+
+        transaction = await transaction.sign(accountKey);
+
+        const response = await transaction.execute(client);
+
+        const receipt = await response.getReceipt(client);
+
+        console.log(`account id = ${receipt.accountId.toString()}`);
+    } catch (error) {
+        console.log(error);
+    }
+}
+void main();

--- a/examples/initialize-client-with-mirror-node-adress-book.js
+++ b/examples/initialize-client-with-mirror-node-adress-book.js
@@ -3,6 +3,7 @@ import {
     Client,
     PrivateKey,
     Hbar,
+    AccountId,
 } from "@hashgraph/sdk";
 
 import dotenv from "dotenv";
@@ -24,15 +25,20 @@ async function main() {
         throw new Error("Please set required keys in .env file.");
     }
 
+    const operatorId = AccountId.fromString(process.env.OPERATOR_ID);
+    const operatorKey = PrivateKey.fromStringED25519(process.env.OPERATOR_KEY);
+
     const accountKey = PrivateKey.generate();
 
+    // Initialize the client with the testnet mirror node. This will also get the address book from the mirror node and
+    // use it to populate the Client's consensus network.
     const client = (
         await Client.forMirrorNetwork("testnet.mirrornode.hedera.com:443")
-    ).setOperator(process.env.OPERATOR_ID, process.env.OPERATOR_KEY);
+    ).setOperator(operatorId, operatorKey);
 
     try {
         let transaction = new AccountCreateTransaction()
-            .setInitialBalance(new Hbar(10)) // 10 h
+            .setInitialBalance(new Hbar(1))
             .setKey(accountKey)
             .freezeWith(client);
 

--- a/examples/initialize-client-with-mirror-node-adress-book.js
+++ b/examples/initialize-client-with-mirror-node-adress-book.js
@@ -52,5 +52,7 @@ async function main() {
     } catch (error) {
         console.log(error);
     }
+
+    client.close();
 }
 void main();

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -30,8 +30,8 @@ import * as mainnet from "./addressbooks/mainnet.js";
 import * as testnet from "./addressbooks/testnet.js";
 import * as previewnet from "./addressbooks/previewnet.js";
 import * as hex from "../encoding/hex.js";
-import AddressBookQuery from "../../src/network/AddressBookQuery.js";
-import FileId from "../../src/file/FileId.js";
+import AddressBookQuery from "../network/AddressBookQuery.js";
+import FileId from "../file/FileId.js";
 
 const readFileAsync = util.promisify(fs.readFile);
 

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -192,13 +192,13 @@ export default class NodeClient extends Client {
     }
 
     /**
-     * @param {string} network
+     * @param {string[] | string} mirrorNetwork
      * @returns {Promise<NodeClient>}
      */
-    static async forMirrorNetwork(network) {
+    static async forMirrorNetwork(mirrorNetwork) {
         const client = new NodeClient();
 
-        client.setMirrorNetwork(network).setNetworkUpdatePeriod(10000);
+        client.setMirrorNetwork(mirrorNetwork).setNetworkUpdatePeriod(10000);
 
         // Execute an address book query to get the network nodes
         const addressBook = await new AddressBookQuery()

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -30,7 +30,8 @@ import * as mainnet from "./addressbooks/mainnet.js";
 import * as testnet from "./addressbooks/testnet.js";
 import * as previewnet from "./addressbooks/previewnet.js";
 import * as hex from "../encoding/hex.js";
-import { AddressBookQuery, FileId } from "../../src/exports.js";
+import AddressBookQuery from "../../src/network/AddressBookQuery.js";
+import FileId from "../../src/file/FileId.js";
 
 const readFileAsync = util.promisify(fs.readFile);
 

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -198,7 +198,7 @@ export default class NodeClient extends Client {
     static async forMirrorNetwork(network) {
         const client = new NodeClient();
 
-        client.setMirrorNetwork(network).setNetworkUpdatePeriod(86400000);
+        client.setMirrorNetwork(network).setNetworkUpdatePeriod(10000);
 
         // Execute an address book query to get the network nodes
         const addressBook = await new AddressBookQuery()

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -200,7 +200,8 @@ export default class NodeClient extends Client {
 
         client
             .setMirrorNetwork(network)
-            .setNetworkUpdatePeriod(client.networkUpdatePeriod);
+            // @ts-ignore
+            ._scheduleNetworkUpdate();
 
         // Execute an address book query to get the network nodes
         const addressBook = await new AddressBookQuery()

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -198,7 +198,7 @@ export default class NodeClient extends Client {
     static async forMirrorNetwork(network) {
         const client = new NodeClient();
 
-        client.setMirrorNetwork(network).setNetworkUpdatePeriod(1000);
+        client.setMirrorNetwork(network).setNetworkUpdatePeriod(86400000);
 
         // Execute an address book query to get the network nodes
         const addressBook = await new AddressBookQuery()

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -198,7 +198,9 @@ export default class NodeClient extends Client {
     static async forMirrorNetwork(network) {
         const client = new NodeClient();
 
-        client.setMirrorNetwork(network).setNetworkUpdatePeriod(10000);
+        client
+            .setMirrorNetwork(network)
+            .setNetworkUpdatePeriod(client.networkUpdatePeriod);
 
         // Execute an address book query to get the network nodes
         const addressBook = await new AddressBookQuery()

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -198,10 +198,7 @@ export default class NodeClient extends Client {
     static async forMirrorNetwork(network) {
         const client = new NodeClient();
 
-        client
-            .setMirrorNetwork(network)
-            // @ts-ignore
-            ._scheduleNetworkUpdate();
+        client.setMirrorNetwork(network).setNetworkUpdatePeriod(10000);
 
         // Execute an address book query to get the network nodes
         const addressBook = await new AddressBookQuery()

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -30,8 +30,7 @@ import * as mainnet from "./addressbooks/mainnet.js";
 import * as testnet from "./addressbooks/testnet.js";
 import * as previewnet from "./addressbooks/previewnet.js";
 import * as hex from "../encoding/hex.js";
-import AddressBookQuery from "../../src/network/AddressBookQuery.js";
-import FileId from "../file/FileId.js";
+import { AddressBookQuery, FileId } from "../../src/exports.js";
 
 const readFileAsync = util.promisify(fs.readFile);
 

--- a/src/client/NodeClient.js
+++ b/src/client/NodeClient.js
@@ -30,6 +30,8 @@ import * as mainnet from "./addressbooks/mainnet.js";
 import * as testnet from "./addressbooks/testnet.js";
 import * as previewnet from "./addressbooks/previewnet.js";
 import * as hex from "../encoding/hex.js";
+import AddressBookQuery from "../../src/network/AddressBookQuery.js";
+import FileId from "../file/FileId.js";
 
 const readFileAsync = util.promisify(fs.readFile);
 
@@ -187,6 +189,25 @@ export default class NodeClient extends Client {
      */
     static forTestnet(props = {}) {
         return new NodeClient({ network: "testnet", ...props });
+    }
+
+    /**
+     * @param {string} network
+     * @returns {Promise<NodeClient>}
+     */
+    static async forMirrorNetwork(network) {
+        const client = new NodeClient();
+
+        client.setMirrorNetwork(network).setNetworkUpdatePeriod(1000);
+
+        // Execute an address book query to get the network nodes
+        const addressBook = await new AddressBookQuery()
+            .setFileId(FileId.ADDRESS_BOOK)
+            .execute(client);
+
+        client.setNetworkFromAddressBook(addressBook);
+
+        return client;
     }
 
     /**

--- a/src/network/AddressBookQuery.js
+++ b/src/network/AddressBookQuery.js
@@ -176,7 +176,8 @@ export default class AddressBookQuery extends Query {
      * @returns {Promise<NodeAddressBook>}
      */
     execute(client, requestTimeout) {
-        if (!client._timer) {
+        // Extra validation when initializing the client with only a mirror network
+        if (client._network._network.size === 0 && !client._timer) {
             throw new Error(
                 "The client's network update period is required. Please set it using the setNetworkUpdatePeriod method.",
             );

--- a/src/network/AddressBookQuery.js
+++ b/src/network/AddressBookQuery.js
@@ -176,6 +176,12 @@ export default class AddressBookQuery extends Query {
      * @returns {Promise<NodeAddressBook>}
      */
     execute(client, requestTimeout) {
+        if (!client._timer) {
+            throw new Error(
+                "The client's network update period is required. Please set it using the setNetworkUpdatePeriod method.",
+            );
+        }
+
         return new Promise((resolve, reject) => {
             this._makeServerStreamRequest(
                 client,

--- a/test/unit/NodeClient.js
+++ b/test/unit/NodeClient.js
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { Client, LedgerId } from "../../src/index.js";
 import AccountId from "../../src/account/AccountId.js";
 import NodeClient from "../../src/client/NodeClient.js";
+import MirrorNode from "../../src/MirrorNode.js";
 
 const ledgerId = LedgerId.LOCAL_NODE;
 
@@ -196,5 +197,39 @@ describe("Client", function () {
         expect(client.mirrorNetwork).to.deep.equal([
             "mainnet-public.mirrornode.hedera.com:443",
         ]);
+    });
+
+    describe("forMirrorNetwork method tests", function () {
+        it("should create a NodeClient with the specified mirror network", async function () {
+            const networkAddress = "testnet.mirrornode.hedera.com:443";
+
+            const client = await Client.forMirrorNetwork(networkAddress);
+
+            expect(client).to.be.instanceOf(NodeClient);
+
+            expect(client._mirrorNetwork._network.has(networkAddress)).to.be
+                .true;
+
+            const mirrorNode =
+                client._mirrorNetwork._network.get(networkAddress)[0];
+
+            expect(mirrorNode).to.be.an.instanceof(MirrorNode);
+            expect(mirrorNode._address).to.not.be.undefined;
+        });
+
+        it("should throw an error if network name is unknown", async function () {
+            try {
+                await Client.forMirrorNetwork("unknown-net");
+            } catch (error) {
+                expect(error.message).to.equal(
+                    "failed to parse address: unknown-net",
+                );
+            }
+        });
+
+        it("should set a default update period for network address book query", async function () {
+            const client = await NodeClient.forMirrorNetwork("testnet");
+            expect(client._networkUpdatePeriod).to.equal(86400000);
+        });
     });
 });

--- a/test/unit/NodeClient.js
+++ b/test/unit/NodeClient.js
@@ -229,7 +229,7 @@ describe("Client", function () {
 
         it("should set a default update period for network address book query", async function () {
             const client = await NodeClient.forMirrorNetwork("testnet");
-            expect(client._networkUpdatePeriod).to.equal(86400000);
+            expect(client._networkUpdatePeriod).to.equal(10000);
         });
     });
 });

--- a/test/unit/NodeClient.js
+++ b/test/unit/NodeClient.js
@@ -229,7 +229,9 @@ describe("Client", function () {
 
         it("should set a default update period for network address book query", async function () {
             const client = await NodeClient.forMirrorNetwork("testnet");
-            expect(client._networkUpdatePeriod).to.equal(10000);
+            expect(client._networkUpdatePeriod).to.equal(
+                client.networkUpdatePeriod,
+            );
         });
     });
 });

--- a/test/unit/NodeClient.js
+++ b/test/unit/NodeClient.js
@@ -229,9 +229,7 @@ describe("Client", function () {
 
         it("should set a default update period for network address book query", async function () {
             const client = await NodeClient.forMirrorNetwork("testnet");
-            expect(client._networkUpdatePeriod).to.equal(
-                client.networkUpdatePeriod,
-            );
+            expect(client._networkUpdatePeriod).to.equal(10000);
         });
     });
 });


### PR DESCRIPTION
**Description**:

This PR adds a new method to the NodeClient class, allowing it to be initialized with only a MirrorNetwork address. After setting the MirrorNetwork, an AddressBookQuery is executed to retrieve the full consensus node network, which is then configured in the client. An example usage is also provided for clarity.

**Related issue(s)**:
#2632 

**Checklist**

- [X] Documented (Code comments, README, etc.)
- [X] Tested (unit, integration, etc.)
