### PR TITLE
fix: _fromProtobuf functions where google primitive wrappers used

### DIFF
--- a/src/account/AccountUpdateTransaction.js
+++ b/src/account/AccountUpdateTransaction.js
@@ -52,16 +52,16 @@ export default class AccountUpdateTransaction extends Transaction {
      * @param {object} props
      * @param {AccountId} [props.accountId]
      * @param {Key} [props.key]
-     * @param {boolean} [props.receiverSignatureRequired]
+     * @param {?boolean} [props.receiverSignatureRequired]
      * @param {AccountId} [props.proxyAccountId]
      * @param {Duration | Long | number} [props.autoRenewPeriod]
      * @param {Timestamp | Date} [props.expirationTime]
-     * @param {string} [props.accountMemo]
+     * @param {?string} [props.accountMemo]
      * @param {Long | number} [props.maxAutomaticTokenAssociations]
      * @param {Key} [props.aliasKey]
      * @param {AccountId | string} [props.stakedAccountId]
      * @param {Long | number} [props.stakedNodeId]
-     * @param {boolean} [props.declineStakingReward]
+     * @param {?boolean} [props.declineStakingReward]
      */
     constructor(props = {}) {
         super();
@@ -224,7 +224,10 @@ export default class AccountUpdateTransaction extends Transaction {
                         : undefined,
                 receiverSignatureRequired:
                     update.receiverSigRequiredWrapper != null
-                        ? update.receiverSigRequiredWrapper.value != null
+                        ? Object.hasOwn(
+                              update.receiverSigRequiredWrapper,
+                              "value",
+                          )
                             ? update.receiverSigRequiredWrapper.value
                             : undefined
                         : undefined,
@@ -248,13 +251,14 @@ export default class AccountUpdateTransaction extends Transaction {
                         : undefined,
                 accountMemo:
                     update.memo != null
-                        ? update.memo.value != null
+                        ? Object.hasOwn(update.memo, "value")
                             ? update.memo.value
                             : undefined
                         : undefined,
                 maxAutomaticTokenAssociations:
                     update.maxAutomaticTokenAssociations != null &&
-                    update.maxAutomaticTokenAssociations.value != null
+                    update.maxAutomaticTokenAssociations.value != null &&
+                    Object.hasOwn(update.maxAutomaticTokenAssociations, "value")
                         ? Long.fromNumber(
                               update.maxAutomaticTokenAssociations.value,
                           )
@@ -269,7 +273,7 @@ export default class AccountUpdateTransaction extends Transaction {
                         : undefined,
                 declineStakingReward:
                     update.declineReward != null
-                        ? update.declineReward.value != null
+                        ? Object.hasOwn(update.declineReward, "value")
                             ? update.declineReward.value
                             : undefined
                         : undefined,

--- a/src/contract/ContractFunctionResult.js
+++ b/src/contract/ContractFunctionResult.js
@@ -213,8 +213,8 @@ export default class ContractFunctionResult {
             ),
             signerNonce:
                 result.signerNonce != null
-                    ? result.signerNonce.value
-                        ? result.signerNonce.value
+                    ? Object.hasOwn(result.signerNonce, "value")
+                        ? result.signerNonce.value || null
                         : null
                     : null,
         });

--- a/src/contract/ContractFunctionResult.js
+++ b/src/contract/ContractFunctionResult.js
@@ -192,7 +192,9 @@ export default class ContractFunctionResult {
                 : []
             ).map((contractId) => ContractId._fromProtobuf(contractId)),
             evmAddress:
-                result.evmAddress != null && result.evmAddress.value != null
+                result.evmAddress != null &&
+                Object.hasOwn(result.evmAddress, "value") &&
+                result.evmAddress.value != null
                     ? result.evmAddress.value
                     : null,
             stateChanges: [],

--- a/src/contract/ContractUpdateTransaction.js
+++ b/src/contract/ContractUpdateTransaction.js
@@ -221,7 +221,11 @@ export default class ContractUpdateTransaction extends Transaction {
         }
 
         let contractMemo = undefined;
-        if (update.memoWrapper != null && update.memoWrapper.value != null) {
+        if (
+            update.memoWrapper != null &&
+            Object.hasOwn(update.memoWrapper, "value") &&
+            update.memoWrapper.value != null
+        ) {
             contractMemo = update.memoWrapper.value;
         }
 

--- a/src/file/FileUpdateTransaction.js
+++ b/src/file/FileUpdateTransaction.js
@@ -54,7 +54,7 @@ export default class FileUpdateTransaction extends Transaction {
      * @param {Key[] | KeyList} [props.keys]
      * @param {Timestamp | Date} [props.expirationTime]
      * @param {Uint8Array | string} [props.contents]
-     * @param {string} [props.fileMemo]
+     * @param {?string} [props.fileMemo]
      */
     constructor(props = {}) {
         super();
@@ -153,7 +153,7 @@ export default class FileUpdateTransaction extends Transaction {
                 contents: update.contents != null ? update.contents : undefined,
                 fileMemo:
                     update.memo != null
-                        ? update.memo.value != null
+                        ? Object.hasOwn(update.memo, "value")
                             ? update.memo.value
                             : undefined
                         : undefined,

--- a/src/node/NodeUpdateTransaction.js
+++ b/src/node/NodeUpdateTransaction.js
@@ -60,8 +60,8 @@ export default class NodeUpdateTransaction extends Transaction {
      * @param {?string} [props.description]
      * @param {Array<ServiceEndpoint>} [props.gossipEndpoints]
      * @param {?Array<ServiceEndpoint>} [props.serviceEndpoints]
-     * @param {Uint8Array} [props.gossipCaCertificate]
-     * @param {Uint8Array} [props.grpcCertificateHash]
+     * @param {?Uint8Array} [props.gossipCaCertificate]
+     * @param {?Uint8Array} [props.grpcCertificateHash]
      * @param {Key} [props.adminKey]
      */
     constructor(props) {
@@ -164,7 +164,7 @@ export default class NodeUpdateTransaction extends Transaction {
                         : undefined,
                 description:
                     nodeUpdate.description != null
-                        ? nodeUpdate.description.value != null
+                        ? Object.hasOwn(nodeUpdate.description, "value")
                             ? nodeUpdate.description.value
                             : undefined
                         : undefined,
@@ -182,13 +182,13 @@ export default class NodeUpdateTransaction extends Transaction {
                         : undefined,
                 gossipCaCertificate:
                     nodeUpdate.gossipCaCertificate != null
-                        ? nodeUpdate.gossipCaCertificate.value != null
+                        ? Object.hasOwn(nodeUpdate.gossipCaCertificate, "value")
                             ? nodeUpdate.gossipCaCertificate.value
                             : undefined
                         : undefined,
                 grpcCertificateHash:
                     nodeUpdate.grpcCertificateHash != null
-                        ? nodeUpdate.grpcCertificateHash.value != null
+                        ? Object.hasOwn(nodeUpdate.grpcCertificateHash, "value")
                             ? nodeUpdate.grpcCertificateHash.value
                             : undefined
                         : undefined,

--- a/src/token/TokenTransfer.js
+++ b/src/token/TokenTransfer.js
@@ -98,9 +98,9 @@ export default class TokenTransfer {
             );
             const expectedDecimals =
                 tokenTransfer.expectedDecimals != null
-                    ? /** @type {number | null } */ (
-                          tokenTransfer.expectedDecimals.value
-                      )
+                    ? Object.hasOwn(tokenTransfer.expectedDecimals, "value")
+                        ? tokenTransfer.expectedDecimals.value
+                        : null
                     : null;
 
             for (const transfer of tokenTransfer.transfers != null
@@ -114,7 +114,7 @@ export default class TokenTransfer {
                                 transfer.accountID
                             ),
                         ),
-                        expectedDecimals,
+                        expectedDecimals: expectedDecimals || null,
                         amount:
                             transfer.amount != null
                                 ? transfer.amount

--- a/src/token/TokenUpdateNftsTransaction.js
+++ b/src/token/TokenUpdateNftsTransaction.js
@@ -46,7 +46,7 @@ export default class TokenUpdateNftsTransaction extends Transaction {
      * @param {object} [props]
      * @param {TokenId | string} [props.tokenId]
      * @param {Long[]} [props.serialNumbers]
-     * @param {Uint8Array} [props.metadata]
+     * @param {?Uint8Array} [props.metadata]
      */
     constructor(props = {}) {
         super();
@@ -116,7 +116,7 @@ export default class TokenUpdateNftsTransaction extends Transaction {
                         : [],
                 metadata:
                     tokenUpdate.metadata != null
-                        ? tokenUpdate.metadata.value != null
+                        ? Object.hasOwn(tokenUpdate.metadata, "value")
                             ? tokenUpdate.metadata.value
                             : undefined
                         : undefined,

--- a/src/token/TokenUpdateTransaction.js
+++ b/src/token/TokenUpdateTransaction.js
@@ -68,7 +68,7 @@ export default class TokenUpdateTransaction extends Transaction {
      * @param {Key} [props.feeScheduleKey]
      * @param {Key} [props.pauseKey]
      * @param {Key} [props.metadataKey]
-     * @param {Uint8Array} [props.metadata]
+     * @param {?Uint8Array} [props.metadata]
      * @param {TokenKeyValidation} [props.keyVerificationMode]
      */
     constructor(props = {}) {
@@ -347,7 +347,7 @@ export default class TokenUpdateTransaction extends Transaction {
                         : undefined,
                 metadata:
                     update.metadata != null
-                        ? update.metadata.value != null
+                        ? Object.hasOwn(update.metadata, "value")
                             ? update.metadata.value
                             : undefined
                         : undefined,

--- a/src/token/TokenUpdateTransaction.js
+++ b/src/token/TokenUpdateTransaction.js
@@ -53,8 +53,8 @@ export default class TokenUpdateTransaction extends Transaction {
     /**
      * @param {object} [props]
      * @param {TokenId | string} [props.tokenId]
-     * @param {string} [props.tokenName]
-     * @param {string} [props.tokenSymbol]
+     * @param {?string} [props.tokenName]
+     * @param {?string} [props.tokenSymbol]
      * @param {AccountId | string} [props.treasuryAccountId]
      * @param {Key} [props.adminKey]
      * @param {Key} [props.kycKey]
@@ -64,7 +64,7 @@ export default class TokenUpdateTransaction extends Transaction {
      * @param {AccountId | string} [props.autoRenewAccountId]
      * @param {Timestamp | Date} [props.expirationTime]
      * @param {Duration | Long | number} [props.autoRenewPeriod]
-     * @param {string} [props.tokenMemo]
+     * @param {?string} [props.tokenMemo]
      * @param {Key} [props.feeScheduleKey]
      * @param {Key} [props.pauseKey]
      * @param {Key} [props.metadataKey]
@@ -285,8 +285,12 @@ export default class TokenUpdateTransaction extends Transaction {
                     update.token != null
                         ? TokenId._fromProtobuf(update.token)
                         : undefined,
-                tokenName: update.name != null ? update.name : undefined,
-                tokenSymbol: update.symbol != null ? update.symbol : undefined,
+                tokenName: Object.hasOwn(update, "name")
+                    ? update.name
+                    : undefined,
+                tokenSymbol: Object.hasOwn(update, "symbol")
+                    ? update.symbol
+                    : undefined,
                 treasuryAccountId:
                     update.treasury != null
                         ? AccountId._fromProtobuf(update.treasury)
@@ -325,7 +329,7 @@ export default class TokenUpdateTransaction extends Transaction {
                         : undefined,
                 tokenMemo:
                     update.memo != null
-                        ? update.memo.value != null
+                        ? Object.hasOwn(update.memo, "value")
                             ? update.memo.value
                             : undefined
                         : undefined,
@@ -763,7 +767,7 @@ export default class TokenUpdateTransaction extends Transaction {
     _makeTransactionData() {
         return {
             token: this._tokenId != null ? this._tokenId._toProtobuf() : null,
-            name: this.tokenName,
+            name: this.tokenName != null ? this.tokenName : null,
             symbol: this.tokenSymbol,
             treasury:
                 this._treasuryAccountId != null

--- a/src/topic/TopicUpdateTransaction.js
+++ b/src/topic/TopicUpdateTransaction.js
@@ -61,7 +61,7 @@ export default class TopicUpdateTransaction extends Transaction {
      * @param {Key} [props.submitKey]
      * @param {Duration | Long | number} [props.autoRenewPeriod]
      * @param {AccountId | string} [props.autoRenewAccountId]
-     * @param {string} [props.topicMemo]
+     * @param {?string} [props.topicMemo]
      * @param {Timestamp | Date} [props.expirationTime]
      */
     constructor(props = {}) {
@@ -186,7 +186,7 @@ export default class TopicUpdateTransaction extends Transaction {
                         : undefined,
                 topicMemo:
                     update.memo != null
-                        ? update.memo.value != null
+                        ? Object.hasOwn(update.memo, "value")
                             ? update.memo.value
                             : undefined
                         : undefined,

--- a/test/unit/AccountUpdateTransaction.js
+++ b/test/unit/AccountUpdateTransaction.js
@@ -1,0 +1,31 @@
+import { AccountUpdateTransaction } from "../../src/index.js";
+
+describe("AccountUpdateTransaction", function () {
+    describe("deserialization of optional parameters", function () {
+        let tx, txBytes, tx2;
+
+        before(function () {
+            tx = new AccountUpdateTransaction();
+            txBytes = tx.toBytes();
+            tx2 = AccountUpdateTransaction.fromBytes(txBytes);
+        });
+
+        it("should deserialize with accountMemo being null", function () {
+            expect(tx.accountMemo).to.be.null;
+            expect(tx2.accountMemo).to.be.null;
+        });
+
+        it("should deserialize with declineReward, receiverSignatureRequired being null", function () {
+            expect(tx.declineStakingRewards).to.be.null;
+            expect(tx2.declineStakingRewards).to.be.null;
+
+            expect(tx.receiverSignatureRequired).to.be.null;
+            expect(tx2.receiverSignatureRequired).to.be.null;
+        });
+
+        it("should deserialize with maxAutomaticTokenAssociations being null", function () {
+            expect(tx.maxAutomaticTokenAssociations).to.be.null;
+            expect(tx2.maxAutomaticTokenAssociations).to.be.null;
+        });
+    });
+});

--- a/test/unit/ContractUpdateTransaction.js
+++ b/test/unit/ContractUpdateTransaction.js
@@ -1,0 +1,13 @@
+import { ContractUpdateTransaction } from "../../src/index.js";
+
+describe("ContractUpdateTransaction", function () {
+    describe("deserialization of optional parameters", function () {
+        it("should deserialize with contractMemo being null", function () {
+            const tx = new ContractUpdateTransaction();
+            const tx2 = ContractUpdateTransaction.fromBytes(tx.toBytes());
+
+            expect(tx.contractMemo).to.be.null;
+            expect(tx2.contractMemo).to.be.null;
+        });
+    });
+});

--- a/test/unit/FileUpdateTransaction.js
+++ b/test/unit/FileUpdateTransaction.js
@@ -1,0 +1,13 @@
+import { FileUpdateTransaction } from "../../src/index.js";
+
+describe("FileUpdateTransaction", function () {
+    describe("deserialization of optional parameters", function () {
+        it("should deserialize with fileMemo being null", function () {
+            const tx = new FileUpdateTransaction();
+            const tx2 = FileUpdateTransaction.fromBytes(tx.toBytes());
+
+            expect(tx.fileMemo).to.be.null;
+            expect(tx2.fileMemo).to.be.null;
+        });
+    });
+});

--- a/test/unit/NodeUpdateTransaction.js
+++ b/test/unit/NodeUpdateTransaction.js
@@ -277,4 +277,24 @@ describe("NodeUpdateTransaction", function () {
             expect(err).to.be.true;
         });
     });
+
+    describe("deserialization of optional parameters", function () {
+        it("should deserialize with gossipCaCertificate, grpcCertificateHash being null", function () {
+            const tx = new NodeUpdateTransaction();
+            const tx2 = NodeUpdateTransaction.fromBytes(tx.toBytes());
+
+            expect(tx.gossipCaCertificate).to.be.null;
+            expect(tx.certificateHash).to.be.null;
+            expect(tx2.gossipCaCertificate).to.be.null;
+            expect(tx2.certificateHash).to.be.null;
+        });
+
+        it("should deserialize with description being null", function () {
+            const tx = new NodeUpdateTransaction();
+            const tx2 = NodeUpdateTransaction.fromBytes(tx.toBytes());
+
+            expect(tx.description).to.be.null;
+            expect(tx2.description).to.be.null;
+        });
+    });
 });

--- a/test/unit/TokenTransfer.js
+++ b/test/unit/TokenTransfer.js
@@ -1,0 +1,28 @@
+import TokenTransfer from "../../src/token/TokenTransfer.js";
+
+describe("TokenTransfer", function () {
+    describe("_fromProtobuf with optional parameters", function () {
+        it("should deserialize with expectedDecimals being null", function () {
+            const transfer = new TokenTransfer({
+                tokenId: "0.0.123",
+                accountId: "0.0.456",
+                amount: 100,
+                expectedDecimals: null,
+                isApproved: true,
+            });
+
+            const transfersProtobuf = [
+                {
+                    token: transfer.tokenId._toProtobuf(),
+                    expectedDecimals: {},
+                    transfers: [transfer._toProtobuf()],
+                },
+            ];
+
+            const [transferFromProtobuf] =
+                TokenTransfer._fromProtobuf(transfersProtobuf);
+
+            expect(transferFromProtobuf.expectedDecimals).to.be.null;
+        });
+    });
+});

--- a/test/unit/TokenUpdateNftsTransaction.js
+++ b/test/unit/TokenUpdateNftsTransaction.js
@@ -37,4 +37,12 @@ describe("TokenUpdateNftsTransaction", function () {
         expect(transaction._serialNumbers).to.eql(serials);
         expect(transaction._metadata).to.eql(metadata);
     });
+
+    it("should _metadata equal to null", async function () {
+        const tx = new TokenUpdateNftsTransaction();
+        const tx2 = TokenUpdateNftsTransaction.fromBytes(tx.toBytes());
+
+        expect(tx._metadata).to.be.null;
+        expect(tx2._metadata).to.be.null;
+    });
 });

--- a/test/unit/TokenUpdateTransaction.js
+++ b/test/unit/TokenUpdateTransaction.js
@@ -154,6 +154,7 @@ describe("TokenUpdateTransaction", function () {
         expect(tx.tokenMemo).to.be.null;
         expect(tx.feeScheduleKey).to.be.null;
         expect(tx.pauseKey).to.be.null;
+        expect(tx.metadata).to.be.null;
 
         expect(tx2.tokenId).to.be.null;
         expect(tx2.tokenName).to.be.null;
@@ -170,5 +171,6 @@ describe("TokenUpdateTransaction", function () {
         expect(tx2.tokenMemo).to.be.null;
         expect(tx2.feeScheduleKey).to.be.null;
         expect(tx2.pauseKey).to.be.null;
+        expect(tx2.metadata).to.be.null;
     });
 });

--- a/test/unit/TokenUpdateTransaction.js
+++ b/test/unit/TokenUpdateTransaction.js
@@ -137,6 +137,7 @@ describe("TokenUpdateTransaction", function () {
 
     it("all properties should be equal to their initial values", async function () {
         const tx = new TokenUpdateTransaction();
+        const tx2 = TokenUpdateTransaction.fromBytes(tx.toBytes());
 
         expect(tx.tokenId).to.be.null;
         expect(tx.tokenName).to.be.null;
@@ -153,5 +154,21 @@ describe("TokenUpdateTransaction", function () {
         expect(tx.tokenMemo).to.be.null;
         expect(tx.feeScheduleKey).to.be.null;
         expect(tx.pauseKey).to.be.null;
+
+        expect(tx2.tokenId).to.be.null;
+        expect(tx2.tokenName).to.be.null;
+        expect(tx2.tokenSymbol).to.be.null;
+        expect(tx2.treasuryAccountId).to.be.null;
+        expect(tx2.adminKey).to.be.null;
+        expect(tx2.kycKey).to.be.null;
+        expect(tx2.freezeKey).to.be.null;
+        expect(tx2.wipeKey).to.be.null;
+        expect(tx2.supplyKey).to.be.null;
+        expect(tx2.autoRenewAccountId).to.be.null;
+        expect(tx2.expirationTime).to.be.null;
+        expect(tx2.autoRenewPeriod).to.be.null;
+        expect(tx2.tokenMemo).to.be.null;
+        expect(tx2.feeScheduleKey).to.be.null;
+        expect(tx2.pauseKey).to.be.null;
     });
 });

--- a/test/unit/TopicUpdateTransaction.js
+++ b/test/unit/TopicUpdateTransaction.js
@@ -1,0 +1,13 @@
+import { TopicUpdateTransaction } from "../../src/index.js";
+
+describe("TopicUpdateTransaction", function () {
+    describe("deserialization of optional parameters", function () {
+        it("should deserialize with topicMemo being null", function () {
+            const tx = new TopicUpdateTransaction();
+            const tx2 = TopicUpdateTransaction.fromBytes(tx.toBytes());
+
+            expect(tx.topicMemo).to.be.null;
+            expect(tx2.topicMemo).to.be.null;
+        });
+    });
+});


### PR DESCRIPTION
**Description**:
This pull request updates the `_fromProtobuf` function of the following classes:
- AccountUpdateTransaction
- ContractFunctionResult
- ContractUpdateTransaction
- FileUpdateTransaction
- NodeUpdateTransaction
- TokenTransfer
- TokenUpdateNftsTransaction
- TokenUpdateTransaction
- TopicUpdateTransaction

This change is required because the protobufs for the bodies (or the data) of these classes use the [primitive wrappers](https://github.com/protocolbuffers/protobuf/blob/main/src/google/protobuf/wrappers.proto)
These wrappers are necessary when the property is nullable. Since the wrapper is a sub-message with a `value` it assumed that:
- if the sub-message is null, the value is null
- if the sub-message does not contain the value property, the value is null
- if the sub-message contains the value property, you should use that value

The problem with the current implementation is that it checks whether the wrapper's `value` is null, which is incorrect because the wrapper's `prototype` stores the property's default value.
Because the `prototype` has set the value to default one, if the protobuf, does not contain value (it is null), the instance still has the `value` property, which is not enumerable but it is accessible.

The correct check is to ensure that the instance has its own property `value` and not a derived one.

The current `_makeTransactionData` implementation hides the actual problem because it strips the value if it is not set at all, but the problem occurs when these values are explicitly set (correctly) to an object with a `value` property that can be undefined

