### PR TITLE
fix: add long types declaration locally so we dont have to rely on remote declaration

### DIFF
--- a/packages/proto/src/proto/services/response_code.proto
+++ b/packages/proto/src/proto/services/response_code.proto
@@ -1596,33 +1596,19 @@ enum ResponseCodeEnum {
 
     /**
      * A scheduled transaction configured to wait for expiry to execute was given
-     * an expiry time not strictly after the time at which its creation reached
-     * consensus.
-     */
-    SCHEDULE_EXPIRY_MUST_BE_FUTURE = 370;
-
-    /**
-     * A scheduled transaction configured to wait for expiry to execute was given
-     * an expiry time too far in the future after the time at which its creation
-     * reached consensus.
-     */
-    SCHEDULE_EXPIRY_TOO_LONG = 371;
-
-    /**
-     * A scheduled transaction configured to wait for expiry to execute was given
      * an expiry time at which there is already too many transactions scheduled to
      * expire; its creation must be retried with a different expiry.
      */
-    SCHEDULE_EXPIRY_IS_BUSY = 372;
+    SCHEDULE_EXPIRY_IS_BUSY = 370;
 
     /**
      * The provided gRPC certificate hash is invalid.
      */
-    INVALID_GRPC_CERTIFICATE_HASH = 373;
+    INVALID_GRPC_CERTIFICATE_HASH = 371;
 
     /**
      * A scheduled transaction configured to wait for expiry to execute was not
      * given an explicit expiration time.
      */
-    MISSING_EXPIRY_TIME = 374;
+    MISSING_EXPIRY_TIME = 372;
 }

--- a/src/FeeComponents.js
+++ b/src/FeeComponents.js
@@ -20,6 +20,9 @@
 
 import * as HashgraphProto from "@hashgraph/proto";
 
+/**
+ * @typedef {import("./types/long").default} Long
+ */
 export default class FeeComponents {
     /**
      * @param {object} [props]

--- a/src/Status.js
+++ b/src/Status.js
@@ -697,10 +697,6 @@ export default class Status {
                 return "TOKEN_AIRDROP_WITH_FALLBACK_ROYALTY";
             case Status.InvalidTokenInPendingAirdrop:
                 return "INVALID_TOKEN_IN_PENDING_AIRDROP";
-            case Status.ScheduleExpiryMustBeFuture:
-                return "SCHEDULE_EXPIRY_IS_BUSY";
-            case Status.ScheduleExpiryTooLong:
-                return "SCHEDULE_EXPIRY_TOO_LONG";
             case Status.ScheduleExpiryIsBusy:
                 return "SCHEDULE_EXPIRY_IS_BUSY";
             case Status.InvalidGrpcCertificateHash:
@@ -1376,14 +1372,10 @@ export default class Status {
             case 369:
                 return Status.InvalidTokenInPendingAirdrop;
             case 370:
-                return Status.ScheduleExpiryMustBeFuture;
-            case 371:
-                return Status.ScheduleExpiryTooLong;
-            case 372:
                 return Status.ScheduleExpiryIsBusy;
-            case 373:
+            case 371:
                 return Status.InvalidGrpcCertificateHash;
-            case 374:
+            case 372:
                 return Status.MissingExpiryTime;
             default:
                 throw new Error(
@@ -3100,31 +3092,18 @@ Status.InvalidTokenInPendingAirdrop = new Status(369);
 
 /**
  * A scheduled transaction configured to wait for expiry to execute was given
- * an expiry time not strictly after the time at which its creation reached
- * consensus.
- */
-Status.ScheduleExpiryMustBeFuture = new Status(370);
-/**
- * A scheduled transaction configured to wait for expiry to execute was given
- * an expiry time too far in the future after the time at which its creation
- * reached consensus.
- */
-Status.ScheduleExpiryTooLong = new Status(371);
-
-/**
- * A scheduled transaction configured to wait for expiry to execute was given
  * an expiry time at which there is already too many transactions scheduled to
  * expire; its creation must be retried with a different expiry.
  */
-Status.ScheduleExpiryIsBusy = new Status(372);
+Status.ScheduleExpiryIsBusy = new Status(370);
 
 /**
  * The provided gRPC certificate hash is invalid.
  */
-Status.InvalidGrpcCertificateHash = new Status(373);
+Status.InvalidGrpcCertificateHash = new Status(371);
 
 /**
  * A scheduled transaction configured to wait for expiry to execute was not
  * given an explicit expiration time.
  */
-Status.MissingExpiryTime = new Status(374);
+Status.MissingExpiryTime = new Status(372);

--- a/src/Status.js
+++ b/src/Status.js
@@ -698,7 +698,7 @@ export default class Status {
             case Status.InvalidTokenInPendingAirdrop:
                 return "INVALID_TOKEN_IN_PENDING_AIRDROP";
             case Status.ScheduleExpiryMustBeFuture:
-                return "SCHEDULE_EXPIRY_MUST_BE_FUTURE";
+                return "SCHEDULE_EXPIRY_IS_BUSY";
             case Status.ScheduleExpiryTooLong:
                 return "SCHEDULE_EXPIRY_TOO_LONG";
             case Status.ScheduleExpiryIsBusy:

--- a/src/types/long.d.ts
+++ b/src/types/long.d.ts
@@ -1,0 +1,459 @@
+export default class Long {
+    /**
+     * Constructs a 64 bit two's-complement integer, given its low and high 32 bit values as signed integers. See the from* functions below for more convenient ways of constructing Longs.
+     */
+    constructor(low: number, high?: number, unsigned?: boolean);
+
+    /**
+     * Maximum unsigned value.
+     */
+    static MAX_UNSIGNED_VALUE: Long;
+
+    /**
+     * Maximum signed value.
+     */
+    static MAX_VALUE: Long;
+
+    /**
+     * Minimum signed value.
+     */
+    static MIN_VALUE: Long;
+
+    /**
+     * Signed negative one.
+     */
+    static NEG_ONE: Long;
+
+    /**
+     * Signed one.
+     */
+    static ONE: Long;
+
+    /**
+     * Unsigned one.
+     */
+    static UONE: Long;
+
+    /**
+     * Unsigned zero.
+     */
+    static UZERO: Long;
+
+    /**
+     * Signed zero
+     */
+    static ZERO: Long;
+
+    /**
+     * The high 32 bits as a signed value.
+     */
+    high: number;
+
+    /**
+     * The low 32 bits as a signed value.
+     */
+    low: number;
+
+    /**
+     * Whether unsigned or not.
+     */
+    unsigned: boolean;
+
+    /**
+     * Returns a Long representing the 64 bit integer that comes by concatenating the given low and high bits. Each is assumed to use 32 bits.
+     */
+    static fromBits(
+        lowBits: number,
+        highBits: number,
+        unsigned?: boolean,
+    ): Long;
+
+    /**
+     * Returns a Long representing the given 32 bit integer value.
+     */
+    static fromInt(value: number, unsigned?: boolean): Long;
+
+    /**
+     * Returns a Long representing the given value, provided that it is a finite number. Otherwise, zero is returned.
+     */
+    static fromNumber(value: number, unsigned?: boolean): Long;
+
+    /**
+     * Returns a Long representation of the given string, written using the specified radix.
+     */
+    static fromString(
+        str: string,
+        unsigned?: boolean | number,
+        radix?: number,
+    ): Long;
+
+    /**
+     * Creates a Long from its byte representation.
+     */
+    static fromBytes(bytes: number[], unsigned?: boolean, le?: boolean): Long;
+
+    /**
+     * Creates a Long from its little endian byte representation.
+     */
+    static fromBytesLE(bytes: number[], unsigned?: boolean): Long;
+
+    /**
+     * Creates a Long from its big endian byte representation.
+     */
+    static fromBytesBE(bytes: number[], unsigned?: boolean): Long;
+
+    /**
+     * Tests if the specified object is a Long.
+     */
+    static isLong(obj: any): obj is Long;
+
+    /**
+     * Converts the specified value to a Long.
+     */
+    static fromValue(
+        val:
+            | Long
+            | number
+            | string
+            | { low: number; high: number; unsigned: boolean },
+        unsigned?: boolean,
+    ): Long;
+
+    /**
+     * Returns the sum of this and the specified Long.
+     */
+    add(addend: number | Long | string): Long;
+
+    /**
+     * Returns the bitwise AND of this Long and the specified.
+     */
+    and(other: Long | number | string): Long;
+
+    /**
+     * Compares this Long's value with the specified's.
+     */
+    compare(other: Long | number | string): number;
+
+    /**
+     * Compares this Long's value with the specified's.
+     */
+    comp(other: Long | number | string): number;
+
+    /**
+     * Returns this Long divided by the specified.
+     */
+    divide(divisor: Long | number | string): Long;
+
+    /**
+     * Returns this Long divided by the specified.
+     */
+    div(divisor: Long | number | string): Long;
+
+    /**
+     * Tests if this Long's value equals the specified's.
+     */
+    equals(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value equals the specified's.
+     */
+    eq(other: Long | number | string): boolean;
+
+    /**
+     * Gets the high 32 bits as a signed integer.
+     */
+    getHighBits(): number;
+
+    /**
+     * Gets the high 32 bits as an unsigned integer.
+     */
+    getHighBitsUnsigned(): number;
+
+    /**
+     * Gets the low 32 bits as a signed integer.
+     */
+    getLowBits(): number;
+
+    /**
+     * Gets the low 32 bits as an unsigned integer.
+     */
+    getLowBitsUnsigned(): number;
+
+    /**
+     * Gets the number of bits needed to represent the absolute value of this Long.
+     */
+    getNumBitsAbs(): number;
+
+    /**
+     * Tests if this Long's value is greater than the specified's.
+     */
+    greaterThan(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is greater than the specified's.
+     */
+    gt(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is greater than or equal the specified's.
+     */
+    greaterThanOrEqual(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is greater than or equal the specified's.
+     */
+    gte(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is greater than or equal the specified's.
+     */
+    ge(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is even.
+     */
+    isEven(): boolean;
+
+    /**
+     * Tests if this Long's value is negative.
+     */
+    isNegative(): boolean;
+
+    /**
+     * Tests if this Long's value is odd.
+     */
+    isOdd(): boolean;
+
+    /**
+     * Tests if this Long's value is positive or zero.
+     */
+    isPositive(): boolean;
+
+    /**
+     * Tests if this Long's value equals zero.
+     */
+    isZero(): boolean;
+
+    /**
+     * Tests if this Long's value equals zero.
+     */
+    eqz(): boolean;
+
+    /**
+     * Tests if this Long's value is less than the specified's.
+     */
+    lessThan(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is less than the specified's.
+     */
+    lt(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is less than or equal the specified's.
+     */
+    lessThanOrEqual(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is less than or equal the specified's.
+     */
+    lte(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value is less than or equal the specified's.
+     */
+    le(other: Long | number | string): boolean;
+
+    /**
+     * Returns this Long modulo the specified.
+     */
+    modulo(other: Long | number | string): Long;
+
+    /**
+     * Returns this Long modulo the specified.
+     */
+    mod(other: Long | number | string): Long;
+
+    /**
+     * Returns this Long modulo the specified.
+     */
+    rem(other: Long | number | string): Long;
+
+    /**
+     * Returns the product of this and the specified Long.
+     */
+    multiply(multiplier: Long | number | string): Long;
+
+    /**
+     * Returns the product of this and the specified Long.
+     */
+    mul(multiplier: Long | number | string): Long;
+
+    /**
+     * Negates this Long's value.
+     */
+    negate(): Long;
+
+    /**
+     * Negates this Long's value.
+     */
+    neg(): Long;
+
+    /**
+     * Returns the bitwise NOT of this Long.
+     */
+    not(): Long;
+
+    /**
+     * Returns count leading zeros of this Long.
+     */
+    countLeadingZeros(): number;
+
+    /**
+     * Returns count leading zeros of this Long.
+     */
+    clz(): number;
+
+    /**
+     * Returns count trailing zeros of this Long.
+     */
+    countTrailingZeros(): number;
+
+    /**
+     * Returns count trailing zeros of this Long.
+     */
+    ctz(): number;
+
+    /**
+     * Tests if this Long's value differs from the specified's.
+     */
+    notEquals(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value differs from the specified's.
+     */
+    neq(other: Long | number | string): boolean;
+
+    /**
+     * Tests if this Long's value differs from the specified's.
+     */
+    ne(other: Long | number | string): boolean;
+
+    /**
+     * Returns the bitwise OR of this Long and the specified.
+     */
+    or(other: Long | number | string): Long;
+
+    /**
+     * Returns this Long with bits shifted to the left by the given amount.
+     */
+    shiftLeft(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits shifted to the left by the given amount.
+     */
+    shl(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits arithmetically shifted to the right by the given amount.
+     */
+    shiftRight(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits arithmetically shifted to the right by the given amount.
+     */
+    shr(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits logically shifted to the right by the given amount.
+     */
+    shiftRightUnsigned(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits logically shifted to the right by the given amount.
+     */
+    shru(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits logically shifted to the right by the given amount.
+     */
+    shr_u(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits rotated to the left by the given amount.
+     */
+    rotateLeft(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits rotated to the left by the given amount.
+     */
+    rotl(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits rotated to the right by the given amount.
+     */
+    rotateRight(numBits: number | Long): Long;
+
+    /**
+     * Returns this Long with bits rotated to the right by the given amount.
+     */
+    rotr(numBits: number | Long): Long;
+
+    /**
+     * Returns the difference of this and the specified Long.
+     */
+    subtract(subtrahend: number | Long | string): Long;
+
+    /**
+     * Returns the difference of this and the specified Long.
+     */
+    sub(subtrahend: number | Long | string): Long;
+
+    /**
+     * Converts the Long to a 32 bit integer, assuming it is a 32 bit integer.
+     */
+    toInt(): number;
+
+    /**
+     * Converts the Long to a the nearest floating-point representation of this value (double, 53 bit mantissa).
+     */
+    toNumber(): number;
+
+    /**
+     * Converts this Long to its byte representation.
+     */
+
+    toBytes(le?: boolean): number[];
+
+    /**
+     * Converts this Long to its little endian byte representation.
+     */
+
+    toBytesLE(): number[];
+
+    /**
+     * Converts this Long to its big endian byte representation.
+     */
+
+    toBytesBE(): number[];
+
+    /**
+     * Converts this Long to signed.
+     */
+    toSigned(): Long;
+
+    /**
+     * Converts the Long to a string written in the specified radix.
+     */
+    toString(radix?: number): string;
+
+    /**
+     * Converts this Long to unsigned.
+     */
+    toUnsigned(): Long;
+
+    /**
+     * Returns the bitwise XOR of this Long and the given one.
+     */
+    xor(other: Long | number | string): Long;
+}


### PR DESCRIPTION
**Description**:
Adds `types/long.d.ts` due to the transpiler not being able to find the default `Long` type. We already use `allowSyntheticDefaultImports` property but if I try to import only the type of `long` using `typedef {import("long")}` it will transpile the code to `typedef {import("long")}.default` inside the `.d.ts` files in the SDK. This will show an error. I try to circumvent this error by importing the `Long` class declaration locally. I think it might have something to do with the way they export the Long class. Similar issues has been raised [here](https://github.com/dcodeIO/long.js/issues/118) and [here](https://github.com/dcodeIO/long.js/issues/109).

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
