### PR TITLE
chore(release): proto v2.16.0

### DIFF
--- a/packages/proto/package.json
+++ b/packages/proto/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/proto",
-    "version": "2.16.0-beta.1",
+    "version": "2.16.0",
     "description": "Protobufs for the Hedera™ Hashgraph SDK",
     "main": "lib/index.js",
     "browser": "src/index.js",


### PR DESCRIPTION
Stable @hashgraph/proto release v2.16.0

The logic for generating proto files has been revised, and the files have been updated in the corresponding directory. A new sub-repo has been introduced, pointing to the services repository, where the proto files are now maintained. The entire repository is pulled into the JavaScript SDK, and only the necessary proto files are moved into the proto/src/proto folder, while the sdk and mirror directories remain hardcoded.