### PR TITLE
chore(release): v2.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v2.56.0
+
+## What's Changed
+* feat: Custom web proxies usage and documentation @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2729
+* feat: bump node version by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2647
+* feat: HIP 423 Long Term Scheduled Transactions by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2708
+* feat: Enhance gRPC TLS by Dynamic Certificate Retrieval by @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2718
+* fix: check for successful node execution by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2730
+* chore(deps-dev): bump rollup in /packages/cryptography by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2544
+* chore(deps): bump nanoid in /examples/simple_rest_signature_provider by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2714
+* chore(deps): bump nanoid from 3.3.7 to 3.3.8 by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2716
+* chore(deps): bump nanoid from 3.3.6 to 3.3.8 in /examples/react-native-example by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2715
+* chore(deps): bump renovatebot/github-action from 41.0.5 to 41.0.6 by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2709
+
 ## v2.55.1
 
 ## What's Changed

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@ethersproject/rlp": "^5.7.0",
         "@grpc/grpc-js": "1.8.2",
         "@hashgraph/cryptography": "1.4.8-beta.10",
-        "@hashgraph/proto": "2.16.0-beta.3",
+        "@hashgraph/proto": "2.16.0-beta.4",
         "axios": "^1.6.4",
         "bignumber.js": "^9.1.1",
         "bn.js": "^5.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@hashgraph/sdk",
-    "version": "2.55.1",
+    "version": "2.56.0",
     "description": "Hedera™ Hashgraph SDK",
     "types": "./lib/index.d.ts",
     "main": "./lib/index.cjs",

--- a/src/channel/NodeChannel.js
+++ b/src/channel/NodeChannel.js
@@ -76,10 +76,9 @@ export default class NodeChannel extends Channel {
 
     /**
      * Retrieve the server's certificate dynamically.
-     * @param {string} address
      * @returns {Promise<string>}
      */
-    async _retrieveCertificate(address) {
+    async _retrieveCertificate() {
         return new Promise((resolve, reject) => {
             const socket = tls.connect(
                 {
@@ -131,9 +130,7 @@ export default class NodeChannel extends Channel {
 
         // If the port is 50212, use TLS
         if (this.nodePort === "50212") {
-            const certificate = Buffer.from(
-                await this._retrieveCertificate(this.address),
-            );
+            const certificate = Buffer.from(await this._retrieveCertificate());
 
             security = credentials.createSsl(certificate);
         } else {


### PR DESCRIPTION
## What's Changed
* feat: Custom web proxies usage and documentation @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2729
* feat: bump node version by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2647
* feat: HIP 423 Long Term Scheduled Transactions by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2708
* feat: Enhance gRPC TLS by Dynamic Certificate Retrieval by @ivaylogarnev-limechain in https://github.com/hashgraph/hedera-sdk-js/pull/2718
* fix: check for successful node execution by @ivaylonikolov7 in https://github.com/hashgraph/hedera-sdk-js/pull/2730
* chore(deps-dev): bump rollup in /packages/cryptography by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2544
* chore(deps): bump nanoid in /examples/simple_rest_signature_provider by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2714
* chore(deps): bump nanoid from 3.3.7 to 3.3.8 by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2716
* chore(deps): bump nanoid from 3.3.6 to 3.3.8 in /examples/react-native-example by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2715
* chore(deps): bump renovatebot/github-action from 41.0.5 to 41.0.6 by @dependabot in https://github.com/hashgraph/hedera-sdk-js/pull/2709