### PR TITLE
fix: restore codecov coverage report PR comments

### DIFF
--- a/.github/codecov.yaml
+++ b/.github/codecov.yaml
@@ -4,3 +4,7 @@ coverage:
             default:
                 target: 80%
                 threshold: 1%
+comment:
+    layout: "reach, diff, flags, files"
+    behavior: default
+    require_changes: false


### PR DESCRIPTION
**Description**:
The codecov workflow seems to have stopped posting comments with the coverage report in the PR that triggered it.
The last PR with a comment is https://github.com/hashgraph/hedera-sdk-js/pull/2684
The workflow and codecov steps seem to be working as expected, just the coverage report comment is non-functional.
This PR configures comments explicitly.

**Related issue(s)**:

Fixes #2761 

**Notes for reviewer**:
N/A

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
