### PR TITLE
fix: incorrect user agent header

### DIFF
--- a/src/channel/NativeChannel.js
+++ b/src/channel/NativeChannel.js
@@ -3,7 +3,7 @@ import Channel, { encodeRequest, decodeUnaryResponse } from "./Channel.js";
 import * as base64 from "../encoding/base64.native.js";
 import HttpError from "../http/HttpError.js";
 import HttpStatus from "../http/HttpStatus.js";
-import { SDK_VERSION } from "../version.js";
+import { SDK_NAME, SDK_VERSION } from "../version.js";
 
 export default class NativeChannel extends Channel {
     /**
@@ -50,7 +50,7 @@ export default class NativeChannel extends Channel {
                         method: "POST",
                         headers: {
                             "content-type": "application/grpc-web-text",
-                            "x-user-agent": SDK_VERSION,
+                            "x-user-agent": `${SDK_NAME}/${SDK_VERSION}`,
                             "x-accept-content-transfer-encoding": "base64",
                             "x-grpc-web": "1",
                         },

--- a/src/channel/NodeChannel.js
+++ b/src/channel/NodeChannel.js
@@ -5,7 +5,7 @@ import Channel from "./Channel.js";
 import GrpcServicesError from "../grpc/GrpcServiceError.js";
 import GrpcStatus from "../grpc/GrpcStatus.js";
 import { ALL_NETWORK_IPS } from "../constants/ClientConstants.js";
-import { SDK_VERSION } from "../version.js";
+import { SDK_NAME, SDK_VERSION } from "../version.js";
 
 /** @type {{ [key: string]: Client }} */
 const clientCache = {};
@@ -166,7 +166,10 @@ export default class NodeChannel extends Channel {
                             // Create metadata with user agent
                             const metadata = new Metadata();
 
-                            metadata.set("x-user-agent", SDK_VERSION);
+                            metadata.set(
+                                "x-user-agent",
+                                `${SDK_NAME}/${SDK_VERSION}`,
+                            );
 
                             this._client?.makeUnaryRequest(
                                 `/proto.${serviceName}/${method.name}`,

--- a/src/channel/WebChannel.js
+++ b/src/channel/WebChannel.js
@@ -4,7 +4,7 @@ import GrpcServiceError from "../grpc/GrpcServiceError.js";
 import GrpcStatus from "../grpc/GrpcStatus.js";
 import HttpError from "../http/HttpError.js";
 import HttpStatus from "../http/HttpStatus.js";
-import { SDK_VERSION } from "../version.js";
+import { SDK_NAME, SDK_VERSION } from "../version.js";
 import Channel, { encodeRequest, decodeUnaryResponse } from "./Channel.js";
 
 export default class WebChannel extends Channel {
@@ -56,7 +56,7 @@ export default class WebChannel extends Channel {
                         method: "POST",
                         headers: {
                             "content-type": "application/grpc-web+proto",
-                            "x-user-agent": SDK_VERSION,
+                            "x-user-agent": `${SDK_NAME}/${SDK_VERSION}`,
                             "x-grpc-web": "1",
                         },
                         body: encodeRequest(requestData),

--- a/src/version.js
+++ b/src/version.js
@@ -1,2 +1,3 @@
+export const SDK_NAME = "hiero-sdk-js";
 export const SDK_VERSION =
     typeof __SDK_VERSION__ !== "undefined" ? __SDK_VERSION__ : "DEV";

--- a/test/integration/GrpcMetadataIntegrationTest.js
+++ b/test/integration/GrpcMetadataIntegrationTest.js
@@ -7,7 +7,7 @@ import {
     Hbar,
 } from "../../src/exports.js";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
-import { SDK_VERSION } from "../../src/version.js";
+import { SDK_NAME, SDK_VERSION } from "../../src/version.js";
 
 describe("gRPC Metadata Integration Test", function () {
     let env;
@@ -60,7 +60,7 @@ describe("gRPC Metadata Integration Test", function () {
 
             // Verify the user agent header exists and has correct format
             expect(userAgentValue).to.not.be.undefined;
-            expect(userAgentValue[0]).to.equal(SDK_VERSION);
+            expect(userAgentValue[0]).to.equal(`${SDK_NAME}/${SDK_VERSION}`);
         } finally {
             GrpcClient.prototype.makeUnaryRequest = originalMakeUnaryRequest;
         }
@@ -118,7 +118,7 @@ describe("gRPC Metadata Integration Test", function () {
             // Verify all metadata entries have the same expected format and value
             for (const call of metadataCalls) {
                 expect(call.key).to.equal("x-user-agent");
-                expect(call.value).to.equal(SDK_VERSION);
+                expect(call.value).to.equal(`${SDK_NAME}/${SDK_VERSION}`);
             }
         } finally {
             // Restore original method

--- a/test/unit/NativeChannelUserAgent.js
+++ b/test/unit/NativeChannelUserAgent.js
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
-import { SDK_VERSION } from "../../src/version.js";
+import { SDK_NAME, SDK_VERSION } from "../../src/version.js";
 import NativeChannel from "../../src/channel/NativeChannel.js";
 
 // Mock the client constants if needed
@@ -101,6 +101,6 @@ describe("NativeChannel", () => {
         const headers = fetchSpy.mock.calls[0][1].headers;
 
         // Verify the SDK version header
-        expect(headers["x-user-agent"]).toBe(SDK_VERSION);
+        expect(headers["x-user-agent"]).toBe(`${SDK_NAME}/${SDK_VERSION}`);
     });
 });

--- a/test/unit/WebChannelUserAgent.js
+++ b/test/unit/WebChannelUserAgent.js
@@ -1,5 +1,5 @@
 import { beforeEach, afterEach, describe, it, expect, vi } from "vitest";
-import { SDK_VERSION } from "../../src/version.js";
+import { SDK_NAME, SDK_VERSION } from "../../src/version.js";
 import WebChannel from "../../src/channel/WebChannel.js";
 
 // Mock the client constants
@@ -69,6 +69,6 @@ describe("WebChannel", () => {
         const headers = fetchSpy.mock.calls[0][1].headers;
 
         // Verify the SDK version header
-        expect(headers["x-user-agent"]).toBe(SDK_VERSION);
+        expect(headers["x-user-agent"]).toBe(`${SDK_NAME}/${SDK_VERSION}`);
     });
 });


### PR DESCRIPTION
**Description**:
This PR fixes an issue where the X-User-Agent header was incorrectly formatted in the JavaScript SDK, causing the Control Node to classify SDK usage as unknown/unspecified. The fix ensures that the header follows the required format:
`X-User-Agent: hiero-sdk-js/<version>` (e.g., hiero-sdk-js/1.2.3)

**Related issue(s)**:
https://github.com/hiero-ledger/hiero-sdk-js/issues/3227
https://github.com/hiero-ledger/hiero-sdk-js/issues/3063

Fixes #
https://github.com/hiero-ledger/hiero-sdk-js/issues/3227


**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
