### PR TITLE
chore: remove grpc proxy for accoundId 0.0.5

### DIFF
--- a/src/constants/ClientConstants.js
+++ b/src/constants/ClientConstants.js
@@ -5,7 +5,6 @@ import AccountId from "../account/AccountId.js";
 export const MAINNET = {
     "node00.swirldslabs.com:443": new AccountId(3),
     "node01-00-grpc.swirlds.com:443": new AccountId(4),
-    "node02.swirldslabs.com:443": new AccountId(5),
     "node03.swirldslabs.com:443": new AccountId(6),
     "node04.swirldslabs.com:443": new AccountId(7),
     "node05.swirldslabs.com:443": new AccountId(8),


### PR DESCRIPTION
**Description**:
This PR removes the grpc proxy endpoint for node with account id 0.0.5 as it has been removed from the addressbook by the council member.

Fixes #3255
