### PR TITLE
chore(ci): Set the dual publish defaults to true

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-medium
     env:
       # Set the default to 'true' when the dual-publishing period is active
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'true' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled == 'true' || github.event_name == 'push' }}
     outputs:
       # Project tag
       tag: ${{ steps.tag.outputs.name }}
@@ -318,7 +318,7 @@ jobs:
     runs-on: hiero-client-sdk-linux-large
     env:
       # Set the default to 'true' when the dual-publishing period is active
-      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled || 'true' }}
+      DUAL_PUBLISH_ENABLED: ${{ inputs.dual-publish-enabled == 'true' || github.event_name == 'push' }}
       DRY_RUN_ENABLED: ${{ inputs.dry-run-enabled || 'false'}}
     needs:
       - validate-release


### PR DESCRIPTION
## Description

Sets `DUAL_PUBLISH_ENABLED` to `true` by default.

### Related Issue(s)

closes #3271

### Testing

- [x] [Dry-Run-Enabled](https://github.com/hiero-ledger/hiero-sdk-js/actions/runs/16751290012) :white_check_mark: