### PR TITLE
fix: exclude working link in markdown from checker

### DIFF
--- a/scripts/broken-links-check.js
+++ b/scripts/broken-links-check.js
@@ -28,7 +28,10 @@ const STATUS_DESCRIPTIONS = {
     504: "Gateway Timeout",
 };
 
-const excludedLinks = ["http://localhost:3000"];
+const excludedLinks = [
+    "http://localhost:3000",
+    "https://img.shields.io/ossf-scorecard/github.com/hiero-ledger/hiero-sdk-js?label=openssf+scorecard&style=flat",
+];
 
 // Get all .md files in the repo recursively
 async function getMarkdownFiles(path = "") {


### PR DESCRIPTION
**Description**:
There is a badge that throws 405 status when the link is actually working. Exclude it from the script that checks if all links are working

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
