### PR TITLE
fix(ci): bump mirror node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,7 +112,7 @@ jobs:
         with:
           installMirrorNode: true
           hieroVersion: v0.65.0
-          mirrorNodeVersion: v0.136.1
+          mirrorNodeVersion: v0.138.0
           grpcProxyPort: 8080
 
       - name: Set Operator Account
@@ -212,7 +212,7 @@ jobs:
         with:
           installMirrorNode: true
           hieroVersion: v0.65.0
-          mirrorNodeVersion: v0.136.1
+          mirrorNodeVersion: v0.138.0
           grpcProxyPort: 8080
 
       - name: Set Operator Account


### PR DESCRIPTION
**Description**:
This bumps mirror node version in the solo action ci job, as previous version does not seem to work currently.