### PR TITLE
ci: Update NPM_TOKEN to use the org level NPM_TOKEN instead of the repo level NPM_HL_TOKEN

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -464,7 +464,7 @@ jobs:
       - name: Publish Proto Release (@hiero-ledger/proto)
         if: ${{ needs.validate-release.outputs.hiero-proto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           task -v publish -- ${{ steps.proto-publish.outputs.args }}
         working-directory: packages/proto
@@ -472,7 +472,7 @@ jobs:
       - name: Publish Cryptography Release (@hiero-ledger/cryptography)
         if: ${{ needs.validate-release.outputs.hiero-crypto-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           task -v publish -- ${{ steps.crypto-publish.outputs.args }}
         working-directory: packages/cryptography
@@ -480,7 +480,7 @@ jobs:
       - name: Publish SDK Release (@hiero-ledger/sdk)
         if: ${{ needs.validate-release.outputs.hiero-sdk-publish-required == 'true' && env.DUAL_PUBLISH_ENABLED == 'true' }}
         env:
-          NPM_TOKEN: ${{ secrets.NPM_HL_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           task -v publish -- ${{ steps.sdk-publish.outputs.args }}
 


### PR DESCRIPTION
## Description

This pull request makes a small update to the release publishing workflow configuration. The change updates the environment variable used for the NPM authentication token to use `NPM_TOKEN` instead of `NPM_HL_TOKEN` for all publish steps.

## Related Issue(s)

Closes #3495