### PR TITLE
fix: mirror network factory method issues

### DIFF
--- a/src/client/WebClient.js
+++ b/src/client/WebClient.js
@@ -27,39 +27,10 @@ export default class WebClient extends Client {
      */
     constructor(props) {
         super(props);
+
         if (props != null) {
             if (typeof props.network === "string") {
-                switch (props.network) {
-                    case "mainnet":
-                        this.setNetwork(WebNetwork.MAINNET);
-                        this.setMirrorNetwork(WebMirrorNetwork.MAINNET);
-                        this.setLedgerId(LedgerId.MAINNET);
-                        break;
-
-                    case "testnet":
-                        this.setNetwork(WebNetwork.TESTNET);
-                        this.setLedgerId(LedgerId.TESTNET);
-                        this.setMirrorNetwork(WebMirrorNetwork.TESTNET);
-                        break;
-
-                    case "previewnet":
-                        this.setNetwork(WebNetwork.PREVIEWNET);
-                        this.setLedgerId(LedgerId.PREVIEWNET);
-                        this.setMirrorNetwork(WebMirrorNetwork.PREVIEWNET);
-                        break;
-
-                    case "local-node":
-                        this.setNetwork(WebNetwork.LOCAL_NODE);
-                        this.setLedgerId(LedgerId.LOCAL_NODE);
-                        this.setMirrorNetwork(WebMirrorNetwork.LOCAL_NODE);
-                        break;
-
-                    default:
-                        throw new Error(
-                            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-                            `unknown network: ${props.network}`,
-                        );
-                }
+                this._setNetworkFromName(props.network);
             } else if (props.network != null) {
                 Client._validateNetworkConsistency(props.network);
 
@@ -73,6 +44,28 @@ export default class WebClient extends Client {
                 this._realm = realm;
 
                 this.setNetwork(props.network);
+            }
+
+            if (typeof props.mirrorNetwork === "string") {
+                switch (props.mirrorNetwork) {
+                    case "mainnet":
+                        this.setMirrorNetwork(WebMirrorNetwork.MAINNET);
+                        break;
+
+                    case "testnet":
+                        this.setMirrorNetwork(WebMirrorNetwork.TESTNET);
+                        break;
+
+                    case "previewnet":
+                        this.setMirrorNetwork(WebMirrorNetwork.PREVIEWNET);
+                        break;
+
+                    default:
+                        this.setMirrorNetwork([props.mirrorNetwork]);
+                        break;
+                }
+            } else if (props.mirrorNetwork != null) {
+                this.setMirrorNetwork(props.mirrorNetwork);
             }
         }
     }
@@ -292,6 +285,46 @@ export default class WebClient extends Client {
             this._mirrorNetwork.setNetwork(mirrorNetwork);
         }
 
+        return this;
+    }
+
+    /**
+     * @private
+     * @param {string} name
+     * @returns {this}
+     */
+    _setNetworkFromName(name) {
+        switch (name) {
+            case "mainnet":
+                this.setNetwork(WebNetwork.MAINNET);
+                this.setMirrorNetwork(WebMirrorNetwork.MAINNET);
+                this.setLedgerId(LedgerId.MAINNET);
+                break;
+
+            case "testnet":
+                this.setNetwork(WebNetwork.TESTNET);
+                this.setMirrorNetwork(WebMirrorNetwork.TESTNET);
+                this.setLedgerId(LedgerId.TESTNET);
+                break;
+
+            case "previewnet":
+                this.setNetwork(WebNetwork.PREVIEWNET);
+                this.setMirrorNetwork(WebMirrorNetwork.PREVIEWNET);
+                this.setLedgerId(LedgerId.PREVIEWNET);
+                break;
+
+            case "local-node":
+                this.setNetwork(WebNetwork.LOCAL_NODE);
+                this.setMirrorNetwork(WebMirrorNetwork.LOCAL_NODE);
+                this.setLedgerId(LedgerId.LOCAL_NODE);
+                break;
+
+            default:
+                throw new Error(
+                    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+                    `unknown network: ${name}`,
+                );
+        }
         return this;
     }
 

--- a/src/network/AddressBookQuery.js
+++ b/src/network/AddressBookQuery.js
@@ -163,13 +163,6 @@ export default class AddressBookQuery extends Query {
      * @returns {Promise<NodeAddressBook>}
      */
     execute(client, requestTimeout) {
-        // Extra validation when initializing the client with only a mirror network
-        if (client._network._network.size === 0 && !client._timer) {
-            throw new Error(
-                "The client's network update period is required. Please set it using the setNetworkUpdatePeriod method.",
-            );
-        }
-
         return new Promise((resolve, reject) => {
             this._makeServerStreamRequest(
                 client,

--- a/src/network/AddressBookQueryWeb.js
+++ b/src/network/AddressBookQueryWeb.js
@@ -201,13 +201,6 @@ export default class AddressBookQueryWeb extends Query {
      * @returns {Promise<NodeAddressBook>}
      */
     execute(client, requestTimeout) {
-        // Extra validation when initializing the client with only a mirror network
-        if (client._network._network.size === 0 && !client._timer) {
-            throw new Error(
-                "The client's network update period is required. Please set it using the setNetworkUpdatePeriod method.",
-            );
-        }
-
         return new Promise((resolve, reject) => {
             void this._makeFetchRequest(
                 client,
@@ -298,7 +291,7 @@ export default class AddressBookQueryWeb extends Query {
                             certHash: node.node_cert_hash,
                             publicKey: node.public_key,
                             description: node.description,
-                            stake: node.stake.toString(),
+                            stake: node.stake?.toString(),
                         }),
                     );
 


### PR DESCRIPTION
**Description**:
This PR Fixes the following issues with the WebClient forMirrorNetwork factory method and the AddressBookQuery.
1. Mirror network was not set in the client state in web environment when using WebClient.forMirrorNetwork
2. AddressBookQuery could not be performed with empty network state in the Client class
3. A property of the node model was not marked as optional

Fixes: https://github.com/hiero-ledger/hiero-sdk-js/issues/3511