### PR TITLE
chore: Add repository field to package.json files

### DIFF
--- a/common_js_test/package.json
+++ b/common_js_test/package.json
@@ -8,6 +8,7 @@
     },
     "author": "",
     "license": "ISC",
+    "repository": "https://github.com/hiero-ledger/hiero-sdk-js",
     "dependencies": {
         "@hiero-ledger/sdk": "2.79.0-beta.12",
         "chai": "4.3.6",

--- a/tck/package.json
+++ b/tck/package.json
@@ -10,6 +10,7 @@
     },
     "author": "",
     "license": "ISC",
+    "repository": "https://github.com/hiero-ledger/hiero-sdk-js",
     "dependencies": {
         "@hiero-ledger/sdk": "2.79.0-beta.12",
         "ansi-regex": "6.2.2",


### PR DESCRIPTION
## Description

This pull request adds repository metadata to the `package.json` files in both the `common_js_test` and `tck` packages. This helps clarify the source repository for these packages.

Metadata improvements:

* Added the `repository` field with the GitHub URL to `common_js_test/package.json`.
* Added the `repository` field with the GitHub URL to `tck/package.json`.

## Related Issue(s)

Resolves #3570 
