### PR TITLE
ci: publish to hiero-ledger namespace only

### DIFF
--- a/.github/workflows/publish_release.yaml
+++ b/.github/workflows/publish_release.yaml
@@ -501,7 +501,7 @@ jobs:
           task -v publish TARBALL="${{ needs.build-release-package.outputs.hiero-proto-pkg-name }}" -- ${{ needs.calculate-release-args.outputs.proto-publish-args }}
         working-directory: packages/proto
 
-      # Publish crypto artifact
+      # Publish cryptography artifact
       - name: Download HL Crypto Package Artifact
         if: ${{ needs.validate-release.outputs.hiero-crypto-publish-required == 'true' }}
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0


### PR DESCRIPTION
**Description**:

This update publishes only to the `hiero-ledger` namespace and removes dual publishing to the `hashgraph` namespace as well.

Packages impacted:
- proto
- cryptography
- sdk

**Related Issue(s)**:

Implements #3387
