### PR TITLE
fix: race condition in node backoff strategy

### DIFF
--- a/src/Executable.js
+++ b/src/Executable.js
@@ -767,7 +767,9 @@ export default class Executable {
                         );
                     }
 
-                    client._network.increaseBackoff(node);
+                    if (node.isHealthy()) {
+                        client._network.increaseBackoff(node);
+                    }
                     continue;
                 }
 


### PR DESCRIPTION
**Description**:
Fixes a race condition in node health handling where concurrent failures could repeatedly increase backoff and mark a node unhealthy for an excessive duration. The backoff is now only increased when the node is healthy, preventing runaway backoff under high concurrency.
**Fixes**:
https://github.com/hiero-ledger/hiero-sdk-js/issues/3646