### PR TITLE
fix(deps): dependabot support for pnpm workspaces

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,51 +9,7 @@ updates:
       directory: "/"
       schedule:
           interval: monthly
-      open-pull-requests-limit: 10
-      versioning-strategy: increase
-      ignore:
-          # For all packages, ignore all minor & patch updates
-          - dependency-name: "*"
-            update-types:
-                ["version-update:semver-minor", "version-update:semver-patch"]
-    - package-ecosystem: npm
-      directory: "packages/cryptography"
-      schedule:
-          interval: monthly
-      open-pull-requests-limit: 10
-      versioning-strategy: increase
-      ignore:
-          # For all packages, ignore all minor & patch updates
-          - dependency-name: "*"
-            update-types:
-                ["version-update:semver-minor", "version-update:semver-patch"]
-    - package-ecosystem: npm
-      directory: "packages/proto"
-      schedule:
-          interval: monthly
-      open-pull-requests-limit: 10
-      versioning-strategy: increase
-      ignore:
-          # For all packages, ignore all minor & patch updates
-          - dependency-name: "*"
-            update-types:
-                ["version-update:semver-minor", "version-update:semver-patch"]
-    - package-ecosystem: npm
-      directory: "/examples"
-      schedule:
-          interval: monthly
-      open-pull-requests-limit: 5
-      versioning-strategy: increase
-      ignore:
-          # For all packages, ignore all minor & patch updates
-          - dependency-name: "*"
-            update-types:
-                ["version-update:semver-minor", "version-update:semver-patch"]
-    - package-ecosystem: npm
-      directory: "/examples/react-native-example"
-      schedule:
-          interval: monthly
-      open-pull-requests-limit: 5
+      open-pull-requests-limit: 40
       versioning-strategy: increase
       ignore:
           # For all packages, ignore all minor & patch updates


### PR DESCRIPTION
**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->
The JS SDK recently moved to using pnpm workspaces but dependabot only updates the root pnpm-lock.yaml if it's bumping the deps in the root directory, and [doesn't when bumping a subdir dependency](https://github.com/hiero-ledger/hiero-sdk-js/pull/3684).
After digging through quite a few issues dated from 2022 to 2025 I found [this PR](https://github.com/dependabot/dependabot-core/pull/11487) that outlines that the only supported (the only one that allows proper updates of the root pnpm-lock.yaml) dependabot config that works with pnpm workspaces properly is to have only the root dir listed in dependabot.yaml

Having a more granular config (like the one currently in use) doesn't update the root pnpm-lock.yaml when updating a subdir, which causes the issues we are observing.

This PR implements the only supported dependabot config for pnpm workspaces.


**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
