### PR TITLE
docs: fix 'actively' spelling and 'migrating' phrasing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > [!NOTE]  
 > The project has been transfered from the https://github.com/hashgraph org and therefore the namespace is at several locations still based on `hashgraph` and `hedera`.
-> We are working activly on migration the namespace fully to hiero.
+> We are working actively on migrating the namespace fully to hiero.
 
 ## Install
 


### PR DESCRIPTION
## Summary

Fixes a spelling error and phrasing issue in README.md as described in #3750.

### Changes
- Fixed `activly` → `actively`
- Fixed `on migration` → `on migrating`

### Before
```
We are working activly on migration the namespace fully to hiero.
```

### After
```
We are working actively on migrating the namespace fully to hiero.
```

Closes #3750