### PR TITLE
fix: correct spelling in README migration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 > [!NOTE]  
 > The project has been transfered from the https://github.com/hashgraph org and therefore the namespace is at several locations still based on `hashgraph` and `hedera`.
-> We are working activly on migration the namespace fully to hiero.
+> We are working actively on migrating the namespace fully to hiero.
 
 ## Install
 


### PR DESCRIPTION
Fixes #3750

- Fixed 'activly' → 'actively'  
- Fixed 'on migration' → 'on migrating'

Before:
> We are working activly on migration the namespace fully to hiero.

After:
> We are working actively on migrating the namespace fully to hiero.