### PR TITLE
fix: correct spelling in README migration note

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 > The JavaScript SDK for interacting with a Hiero based network
 
 > [!NOTE]  
-> The project has been transferred from the https://github.com/hashgraph org and therefore the namespace is at several locations still based on `hashgraph` and `hedera`.
-> We are working activly on migration the namespace fully to hiero.
+> The project has been transferred from the [https://github.com/hashgraph](https://github.com/hashgraph) org and therefore the namespace is at several locations still based on `hashgraph` and `hedera`.
+> We are working actively on migrating the namespace fully to hiero.
 
 ## Install
 


### PR DESCRIPTION
**Description**:
Fix spelling error in README migration note.

- Correct `activly` to `actively`
- Correct `on migration` to `on migrating`

**Related issue(s)**:

Fixes #3750

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
