### PR TITLE
types: use generic Client<Channel, MirrorChannel> in TransactionResponse

### DIFF
--- a/src/transaction/TransactionResponse.js
+++ b/src/transaction/TransactionResponse.js
@@ -10,7 +10,9 @@ import * as hex from "../encoding/hex.js";
 import { wait } from "../util.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("./Transaction.js").default} Transaction
  * @typedef {import("./TransactionReceipt.js").default} TransactionReceipt
  * @typedef {import("./TransactionRecord.js").default} TransactionRecord


### PR DESCRIPTION
Fixes #3761

Replace the wildcard Client<*, *> typedef with explicitly typed Channel and MirrorChannel imports, and use Client<Channel, MirrorChannel> to match the rest of the codebase and improve type clarity.

This is a type-only change with no runtime or behavior impact.

Resolves #3761

**Description**:
<!--
One or two line summary of what this PR does and why it is needed, followed by a list
of changes in imperative, present tense for use in the commit message or changelog. Example:

Add support for ...

* Add config property
* Change column name
* Remove ...
-->

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
