### PR TITLE
feat(pending-airdrop-id): add string support to constructor and setters

### DIFF
--- a/src/token/PendingAirdropId.js
+++ b/src/token/PendingAirdropId.js
@@ -19,10 +19,10 @@ export default class PendingAirdropId {
     /**
      *
      * @param {object} props
-     * @param {AccountId} [props.senderId]
-     * @param {AccountId} [props.receiverId]
-     * @param {TokenId?} [props.tokenId]
-     * @param {NftId?} [props.nftId]
+     * @param {AccountId | string} [props.senderId]
+     * @param {AccountId | string} [props.receiverId]
+     * @param {TokenId | string | null} [props.tokenId]
+     * @param {NftId | string | null} [props.nftId]
      */
     constructor(props = {}) {
         this._senderId = null;
@@ -31,15 +31,27 @@ export default class PendingAirdropId {
         this._nftId = null;
 
         if (props.receiverId) {
-            this._receiverId = props.receiverId;
+            this._receiverId =
+                typeof props.receiverId === "string"
+                    ? AccountId.fromString(props.receiverId)
+                    : props.receiverId;
         }
         if (props.senderId) {
-            this._senderId = props.senderId;
+            this._senderId =
+                typeof props.senderId === "string"
+                    ? AccountId.fromString(props.senderId)
+                    : props.senderId;
         }
         if (props.tokenId) {
-            this._tokenId = new TokenId(props.tokenId);
+            this._tokenId =
+                typeof props.tokenId === "string"
+                    ? TokenId.fromString(props.tokenId)
+                    : new TokenId(props.tokenId);
         } else if (props.nftId) {
-            this._nftId = new NftId(props.nftId?.tokenId, props.nftId?.serial);
+            this._nftId =
+                typeof props.nftId === "string"
+                    ? NftId.fromString(props.nftId)
+                    : new NftId(props.nftId?.tokenId, props.nftId?.serial);
         }
     }
 
@@ -78,40 +90,50 @@ export default class PendingAirdropId {
 
     /**
      *
-     * @param {AccountId} senderId
+     * @param {AccountId | string} senderId
      * @returns {this}
      */
     setSenderid(senderId) {
-        this._senderId = senderId;
+        this._senderId =
+            typeof senderId === "string"
+                ? AccountId.fromString(senderId)
+                : senderId;
         return this;
     }
 
     /**
-     * @param {AccountId} receiverId
+     * @param {AccountId | string} receiverId
      * @returns {this}
      */
     setReceiverId(receiverId) {
-        this._receiverId = receiverId;
+        this._receiverId =
+            typeof receiverId === "string"
+                ? AccountId.fromString(receiverId)
+                : receiverId;
         return this;
     }
 
     /**
-     * @param {TokenId} tokenId
+     * @param {TokenId | string} tokenId
      * @returns {this}
      */
     setTokenId(tokenId) {
         this._nftId = null;
-        this._tokenId = tokenId;
+        this._tokenId =
+            typeof tokenId === "string"
+                ? TokenId.fromString(tokenId)
+                : tokenId;
         return this;
     }
 
     /**
-     * @param {NftId} nftId
+     * @param {NftId | string} nftId
      * @returns {this}
      */
     setNftId(nftId) {
         this._tokenId = null;
-        this._nftId = nftId;
+        this._nftId =
+            typeof nftId === "string" ? NftId.fromString(nftId) : nftId;
         return this;
     }
 

--- a/test/unit/PendingAirdropId.js
+++ b/test/unit/PendingAirdropId.js
@@ -28,8 +28,26 @@ describe("PendingAirdropId", function () {
         expect(pendingAirdropId.receiverId).to.eql(receiverId);
     });
 
+    it("should populate PendingAirdropId from constructor with strings", function () {
+        const pendingAirdropId = new PendingAirdropId({
+            nftId: nftId.toString(),
+            senderId: senderId.toString(),
+            receiverId: receiverId.toString(),
+        });
+
+        expect(pendingAirdropId.nftId).to.eql(nftId);
+        expect(pendingAirdropId.senderId).to.eql(senderId);
+        expect(pendingAirdropId.receiverId).to.eql(receiverId);
+    });
+
     it("should set nftId", function () {
         const pendingAirdropId = new PendingAirdropId().setNftId(nftId);
+        expect(pendingAirdropId.nftId).to.eql(nftId);
+        expect(pendingAirdropId.tokenId).to.eql(null);
+    });
+
+    it("should set nftId with string", function () {
+        const pendingAirdropId = new PendingAirdropId().setNftId(nftId.toString());
         expect(pendingAirdropId.nftId).to.eql(nftId);
         expect(pendingAirdropId.tokenId).to.eql(null);
     });
@@ -40,8 +58,19 @@ describe("PendingAirdropId", function () {
         expect(pendingAirdropId.nftId).to.eql(null);
     });
 
+    it("should set tokenId with string", function () {
+        const pendingAirdropId = new PendingAirdropId().setTokenId(tokenId.toString());
+        expect(pendingAirdropId.tokenId).to.eql(tokenId);
+        expect(pendingAirdropId.nftId).to.eql(null);
+    });
+
     it("should set senderId", function () {
         const pendingAirdropId = new PendingAirdropId().setSenderid(senderId);
+        expect(pendingAirdropId.senderId).to.eql(senderId);
+    });
+
+    it("should set senderId with string", function () {
+        const pendingAirdropId = new PendingAirdropId().setSenderid(senderId.toString());
         expect(pendingAirdropId.senderId).to.eql(senderId);
     });
 
@@ -50,6 +79,21 @@ describe("PendingAirdropId", function () {
             receiverId,
         );
         expect(pendingAirdropId.receiverId).to.eql(receiverId);
+    });
+
+    it("should set receiverId with string", function () {
+        const pendingAirdropId = new PendingAirdropId().setReceiverId(
+            receiverId.toString(),
+        );
+        expect(pendingAirdropId.receiverId).to.eql(receiverId);
+    });
+
+    it("should initialize tokenId from constructor string", function () {
+        const pendingAirdropId = new PendingAirdropId({
+            tokenId: tokenId.toString(),
+        });
+        expect(pendingAirdropId.tokenId).to.eql(tokenId);
+        expect(pendingAirdropId.nftId).to.eql(null);
     });
 
     it("should not be able to call fromBytes", async function () {


### PR DESCRIPTION
Resolves #3771 by:
- Updating setTokenId, setNftId, setSenderId, and setReceiverId to accept X | string
- Updating constructor to support strings for the four ID fields
- Converting string inputs using fromString() SDK methods to maintain internal object type
- Adding comprehensive unit tests for string initializations

Fixes #3771

**Type of change: New feature**
**Tested: Yes**