### PR TITLE
feat(hook-entity-id): add string support to constructor and setAccountId

### DIFF
--- a/src/hooks/HookEntityId.js
+++ b/src/hooks/HookEntityId.js
@@ -7,7 +7,7 @@ class HookEntityId {
     /**
      *
      * @param {object} props
-     * @param {AccountId} [props.accountId]
+     * @param {AccountId | string} [props.accountId]
      */
     constructor(props = {}) {
         /**
@@ -22,11 +22,14 @@ class HookEntityId {
     }
 
     /**
-     * @param {AccountId} accountId
+     * @param {AccountId | string} accountId
      * @returns {this}
      */
     setAccountId(accountId) {
-        this._accountId = accountId;
+        this._accountId =
+            typeof accountId === "string"
+                ? AccountId.fromString(accountId)
+                : accountId;
         return this;
     }
 

--- a/test/unit/HookEntityId.js
+++ b/test/unit/HookEntityId.js
@@ -16,10 +16,17 @@ describe("HookEntityId", function () {
             expect(entityId.accountId).to.equal(accountId);
         });
 
-        it("should create an instance with accountId from string", function () {
+        it("should create an instance with accountId from AccountId.fromString()", function () {
             const accountId = AccountId.fromString("0.0.12345");
             const entityId = new HookEntityId({ accountId });
 
+            expect(entityId.accountId.toString()).to.equal("0.0.12345");
+        });
+
+        it("should create an instance with raw string accountId", function () {
+            const entityId = new HookEntityId({ accountId: "0.0.12345" });
+
+            expect(entityId.accountId).to.be.instanceOf(AccountId);
             expect(entityId.accountId.toString()).to.equal("0.0.12345");
         });
 
@@ -72,6 +79,14 @@ describe("HookEntityId", function () {
             // Set from AccountId.fromString
             const stringId = AccountId.fromString("5.10.999");
             entityId.setAccountId(stringId);
+            expect(entityId.accountId.toString()).to.equal("5.10.999");
+        });
+
+        it("should handle raw string accountId", function () {
+            const entityId = new HookEntityId();
+            entityId.setAccountId("5.10.999");
+
+            expect(entityId.accountId).to.be.instanceOf(AccountId);
             expect(entityId.accountId.toString()).to.equal("5.10.999");
         });
 


### PR DESCRIPTION
Resolves #3770 by:
- Updating setAccountId to accept AccountId | string
- Updating constructor to support strings for the accountId field
- Converting string inputs using fromString() SDK methods to maintain internal object type
- Adding comprehensive unit tests for string initializations

**Description**:
Added string support for `HookEntityId` constructor and `setAccountId` method. Added unit tests.

**Related issue(s)**:

Fixes #3770

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
