### PR TITLE
refactor(AccountInfoQuery): improve JSDoc types and remove ESLint suppressions

### DIFF
--- a/src/account/AccountInfoQuery.js
+++ b/src/account/AccountInfoQuery.js
@@ -3,8 +3,6 @@
 import Query, { QUERY_REGISTRY } from "../query/Query.js";
 import AccountId from "./AccountId.js";
 import AccountInfo from "./AccountInfo.js";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import Hbar from "../Hbar.js";
 
 /**
  * @namespace proto
@@ -19,7 +17,9 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
+ * @typedef {import("../Hbar.js").default} Hbar
  */
 
 /**
@@ -106,7 +106,7 @@ export default class AccountInfoQuery extends Query {
 
     /**
      * @override
-     * @param {import("../client/Client.js").default<Channel, *>} client
+     * @param {Client} client
      * @returns {Promise<Hbar>}
      */
     async getCost(client) {
@@ -145,7 +145,7 @@ export default class AccountInfoQuery extends Query {
 
         return Promise.resolve(
             AccountInfo._fromProtobuf(
-                /** @type {HieroProto.proto.CryptoGetInfoResponse.IAccountInfo} */ (
+                /** @type {HieroProto.proto.CryptoGetInfoResponse.IAccountInfo} */(
                     info.accountInfo
                 ),
             ),
@@ -176,7 +176,7 @@ export default class AccountInfoQuery extends Query {
     _getLogId() {
         const timestamp =
             this._paymentTransactionId != null &&
-            this._paymentTransactionId.validStart != null
+                this._paymentTransactionId.validStart != null
                 ? this._paymentTransactionId.validStart
                 : this._timestamp;
         return `AccountInfoQuery:${timestamp.toString()}`;


### PR DESCRIPTION
This PR improves JSDoc type annotations in AccountInfoQuery.js and removes associated ESLint suppressions.

Fixes #3759

### Description
- Replaced the runtime import of Hbar with a JSDoc @typedef.
- Added a MirrorChannel JSDoc @typedef.
- Updated the Client JSDoc @typedef to include <Channel, MirrorChannel> parameterization.
- Standardized the getCost method signature using the generic Client typedef.
- Removed unnecessary ESLint suppressions.