### PR TITLE
ci: remove outdated step-security notes in workflows

### DIFF
--- a/.github/workflows/common_js.yml
+++ b/.github/workflows/common_js.yml
@@ -42,7 +42,6 @@ jobs:
         with:
           version: 3.35.1
 
-      # Note: After Step-Security is enabled return to step-security/action-setup version
       - name: Install PNPM
         uses: step-security/action-setup@3d419c73e38e670dbffe349ffff26dd13c164640 # v4.2.0
         with:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           node-version: 22
 
-      # Note: After Step-Security is enabled return to step-security/action-setup version
       - name: Install PNPM
         uses: step-security/action-setup@3d419c73e38e670dbffe349ffff26dd13c164640 # v4.2.0
         with:

--- a/.github/workflows/react_native.yml
+++ b/.github/workflows/react_native.yml
@@ -107,7 +107,6 @@ jobs:
         with:
           node-version: "22"
 
-      # Note: After Step-Security is enabled return to step-security/action-setup version
       - name: Install PNPM
         uses: step-security/action-setup@3d419c73e38e670dbffe349ffff26dd13c164640 # v4.2.0
         with:


### PR DESCRIPTION
Fixes #2791

### Description
Removes the redundant `# Note: After Step-Security is enabled return to step-security/action-setup version` comments throughout the workflows (`common_js.yml`, `pages.yml`, `react_native.yml`).

The actual action replacements (`pnpm/action-setup` to `step-security/action-setup` and `conventional-pr-title-action` to its step-security version) have already been securely implemented in prior pull requests. This PR just cleans up the remaining outdated comments as requested in #2791.