### PR TITLE
fix: replace wildcard (*) in ScheduleInfoQuery.js with explicit types

### DIFF
--- a/src/schedule/ScheduleInfoQuery.js
+++ b/src/schedule/ScheduleInfoQuery.js
@@ -19,7 +19,7 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../client/Client.js").default<any, any>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 


### PR DESCRIPTION
This PR replaces the wildcard generic (`*`) usage in `ScheduleInfoQuery.js` with explicit types.

Using `*` in JSDoc generics reduces type clarity and may lead to weaker type checking. 
This change improves readability and aligns the file with stronger typing practices used elsewhere in the SDK.

No functional changes were introduced.