### PR TITLE
types: use generic Client<Channel, MirrorChannel> in ScheduleInfoQuery

### DIFF
--- a/src/schedule/ScheduleInfoQuery.js
+++ b/src/schedule/ScheduleInfoQuery.js
@@ -19,7 +19,8 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 
@@ -87,7 +88,7 @@ export default class ScheduleInfoQuery extends Query {
 
     /**
      * @override
-     * @param {import("../client/Client.js").default<Channel, *>} client
+     * @param {import("../client/Client.js").default<Channel, MirrorChannel>} client
      * @returns {Promise<Hbar>}
      */
     async getCost(client) {


### PR DESCRIPTION
## 🎯 Summary

Replaces wildcard `*` type annotations with specific `MirrorChannel` type in ScheduleInfoQuery.js, resolving eslint `jsdoc/reject-any-type` warnings.

## 📝 Changes

- Added `MirrorChannel` typedef import from `../channel/MirrorChannel.js`
- Updated `Client` typedef from `default<*, *>` to `default<Channel, MirrorChannel>` (line 23)
- Updated `getCost` param from `default<Channel, *>` to `default<Channel, MirrorChannel>` (line 91)

## ✅ Checklist

- [x] Scope limited to this issue
- [x] No SDK behavior or public API changes
- [x] Signed commit with `-s`
- [x] Fixes #3799

## 🧪 Testing

Run `pnpm exec eslint src/schedule/ScheduleInfoQuery.js` to verify no lint warnings.

---

First-time contributor! Thanks for the welcoming issue. 🙏