### PR TITLE
refactor: use generic Client<Channel, MirrorChannel> in entity ID classes

### DIFF
--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -11,7 +11,9 @@ import * as hex from ".././encoding/hex.js";
 import { isLongZeroAddress } from "../util.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -11,7 +11,9 @@ import { isLongZeroAddress } from "../util.js";
 import EvmAddress from "../EvmAddress.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -7,7 +7,9 @@ import EvmAddress from "../EvmAddress.js";
 import * as util from "../util.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/schedule/ScheduleId.js
+++ b/src/schedule/ScheduleId.js
@@ -5,7 +5,9 @@ import * as HieroProto from "@hiero-ledger/proto";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/token/TokenId.js
+++ b/src/token/TokenId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**


### PR DESCRIPTION
## 🎯 Summary

Replaces wildcard `*` type annotations with specific `Channel` and `MirrorChannel` types in entity ID classes, resolving eslint `jsdoc/reject-any-type` warnings.

## 📝 Changes

- Fixed wildcard type annotations in AccountId, ContractId, FileId, ScheduleId, TokenId
- Replaces `Client<*, *>` with properly typed `Client<Channel, MirrorChannel>`
- Resolves eslint `jsdoc/reject-any-type` warnings
- Related to #3798

## ✅ Checklist

- [x] Scope limited to this issue (typing only, no runtime changes)
- [x] No SDK behavior or public API changes
- [x] Signed commit with `-s`
- [x] Fixes #3798

## 🧪 Testing

Run `task lint` to verify no eslint warnings in these files.

---

First-time contributor! Thanks for the welcoming issue. 🙏