### PR TITLE
fix: replace wildcard types in ScheduleInfoQuery.js

### DIFF
--- a/src/schedule/ScheduleInfoQuery.js
+++ b/src/schedule/ScheduleInfoQuery.js
@@ -19,7 +19,8 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 
@@ -87,7 +88,7 @@ export default class ScheduleInfoQuery extends Query {
 
     /**
      * @override
-     * @param {import("../client/Client.js").default<Channel, *>} client
+     * @param {import("../client/Client.js").default<Channel, MirrorChannel>} client
      * @returns {Promise<Hbar>}
      */
     async getCost(client) {


### PR DESCRIPTION
## Summary

Replaces wildcard types in ScheduleInfoQuery.js.

Fixes #3799