### PR TITLE
refactor: use generic Client<Channel, MirrorChannel> in topic/TopicId

### DIFF
--- a/src/topic/TopicId.js
+++ b/src/topic/TopicId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**


### PR DESCRIPTION
**Description**:
<!--
Fix typing warning in src/topic/TopicId.js by replacing the wildcard Client<*, *> typedef with explicit generic channel types.

Remove wildcard Client typedef

Add Channel and MirrorChannel typedef imports

Update Client typedef to use Client<Channel, MirrorChannel> generics

This is a typing-only change and introduces no runtime behavior changes.
-->

**Related issue(s)**:

Fixes #3823

**Notes for reviewer**:
Local lint and unit test suites were executed. Repository test failures were observed even after reverting the file change, suggesting the failures are unrelated to this typing-only contribution.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
