### PR TITLE
fix: repair broken links in good first issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
@@ -166,11 +166,11 @@ body:
         - [ ] Sign each commit using `-s -S`
         - [ ] Push your branch and open a pull request
 
-        Read [Workflow Guide](manual/training/workflow.md) for step-by-step workflow guidance.  
-        Read [README.md](README.md) for setup instructions.
+        Read [Workflow Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/workflow.md) for step-by-step workflow guidance.  
+        Read [README.md](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/README.md) for setup instructions.
 
         ❗ Pull requests **cannot be merged** without signed commits (use `-s -S`).  
-        See the [Signing Guide](manual/training/signing.md).
+        See the [Signing Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/signing.md).
     validations:
       required: true
 


### PR DESCRIPTION
## Summary
- replace relative workflow/signing/readme links in `.github/ISSUE_TEMPLATE/02_good_first_issue.yml`
- switch to absolute GitHub `blob/main/...` URLs so links resolve from issue forms

## Testing
- `grep -n "manual/training/\|\[README.md\]" .github/ISSUE_TEMPLATE/02_good_first_issue.yml`
- verified all three links now point to full `https://github.com/hiero-ledger/hiero-sdk-js/blob/main/...` URLs

## Related
Closes #3833