### PR TITLE
fix: replace wildcard type with proper generic channel types

### DIFF
--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -7,7 +7,9 @@ import EvmAddress from "../EvmAddress.js";
 import * as util from "../util.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/token/TokenId.js
+++ b/src/token/TokenId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**


### PR DESCRIPTION
## Description

Replaces loose wildcard typedefs with proper generic channel types in:
-  (closes #3820)
-  (closes #3822)

Changes:
- Adds Channel and MirrorChannel typedefs
- Updates Client typedef to use proper generics instead of wildcard 

This is a typing-only improvement with no runtime or behavior changes.

## Related Issues

Closes #3820
Closes #3822