### PR TITLE
refactor: use generic Client<Channel, MirrorChannel> in contract/ContractId

### DIFF
--- a/src/contract/ContractByteCodeQuery.js
+++ b/src/contract/ContractByteCodeQuery.js
@@ -15,7 +15,8 @@ import ContractId from "./ContractId.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/contract/ContractCallQuery.js
+++ b/src/contract/ContractCallQuery.js
@@ -12,7 +12,8 @@ import Status from "../Status.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/contract/ContractExecuteTransaction.js
+++ b/src/contract/ContractExecuteTransaction.js
@@ -25,7 +25,8 @@ import HbarUnit from "../HbarUnit.js";
 /**
  * @typedef {import("bignumber.js").default} BigNumber
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  */

--- a/src/contract/ContractId.js
+++ b/src/contract/ContractId.js
@@ -13,7 +13,7 @@ import EvmAddress from "../EvmAddress.js";
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
- * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client 
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/contract/ContractInfoQuery.js
+++ b/src/contract/ContractInfoQuery.js
@@ -19,7 +19,8 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/contract/DelegateContractId.js
+++ b/src/contract/DelegateContractId.js
@@ -11,7 +11,9 @@ import ContractId from "./ContractId.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**


### PR DESCRIPTION
**Description**:

* replaces Client typedef widcard argument  with correct generics

**Related issue(s)**:

Fixes #3819 

**Notes for reviewer**:
The import path was incorrect in issue description (giving file not found error with `./`) so used `../` , and also performed `task lint` and `task test:unit`, observed no eslint `jsdoc/reject-any-type` warn on `src/contract/ContractId.js`

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Lint check  
- [x] Tested (unit, integration, etc.)
