### PR TITLE
fix(account): clean up AccountInfoQuery type imports

### DIFF
--- a/src/account/AccountInfoQuery.js
+++ b/src/account/AccountInfoQuery.js
@@ -3,8 +3,6 @@
 import Query, { QUERY_REGISTRY } from "../query/Query.js";
 import AccountId from "./AccountId.js";
 import AccountInfo from "./AccountInfo.js";
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import Hbar from "../Hbar.js";
 
 /**
  * @namespace proto
@@ -21,6 +19,7 @@ import Hbar from "../Hbar.js";
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
  * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
+ * @typedef {import("../Hbar.js").default} Hbar
  */
 
 /**
@@ -107,7 +106,7 @@ export default class AccountInfoQuery extends Query {
 
     /**
      * @override
-     * @param {import("../client/Client.js").default<Channel, *>} client
+     * @param {Client} client
      * @returns {Promise<Hbar>}
      */
     async getCost(client) {
@@ -134,12 +133,14 @@ export default class AccountInfoQuery extends Query {
      * @override
      * @internal
      * @param {HieroProto.proto.IResponse} response
-     * @param {AccountId} nodeAccountId
-     * @param {HieroProto.proto.IQuery} request
+     * @param {AccountId} _nodeAccountId
+     * @param {HieroProto.proto.IQuery} _request
      * @returns {Promise<AccountInfo>}
      */
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    _mapResponse(response, nodeAccountId, request) {
+    _mapResponse(response, _nodeAccountId, _request) {
+        void _nodeAccountId;
+        void _request;
+
         const info = /** @type {HieroProto.proto.ICryptoGetInfoResponse} */ (
             response.cryptoGetInfo
         );


### PR DESCRIPTION
**Description**:
Refine AccountInfoQuery type annotations to eliminate runtime-only imports and lint suppressions.
* Replace runtime type import with JSDoc typedefs
* Add MirrorChannel and full Client<Channel, MirrorChannel> typing
* Remove unused-var ESLint disables in AccountInfoQuery

**Related issue(s)**:

Fixes #3788

**Notes for reviewer**:
- task lint (repo has existing baseline warnings; none added in AccountInfoQuery)
- npx vitest --config=test/vitest-node.config.ts test/unit/AccountInfoQuery.js

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
