### PR TITLE
fix: replace relative links with absolute URLs in good first issue template.

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
@@ -166,11 +166,11 @@ body:
         - [ ] Sign each commit using `-s -S`
         - [ ] Push your branch and open a pull request
 
-        Read [Workflow Guide](manual/training/workflow.md) for step-by-step workflow guidance.  
-        Read [README.md](README.md) for setup instructions.
+        Read [Workflow Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/workflow.md) for step-by-step workflow guidance.  
+        Read [README.md](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/README.md) for setup instructions.
 
         ❗ Pull requests **cannot be merged** without signed commits (use `-s -S`).  
-        See the [Signing Guide](manual/training/signing.md).
+        See the [Signing Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/signing.md).
     validations:
       required: true
 


### PR DESCRIPTION
…mplate

**Description**:
Replace relative links with absolute GitHub URLs in the good first issue template.

* Replace relative link for Workflow Guide with absolute URL
* Replace relative link for README with absolute URL
* Replace relative link for Signing Guide with absolute URL



**Related issue(s)**:

Fixes #3833 

**Notes for reviewer**:
No functional changes — only link fixes in the issue template.
**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
