### PR TITLE
Fix broken relative links in good first issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
@@ -166,11 +166,11 @@ body:
         - [ ] Sign each commit using `-s -S`
         - [ ] Push your branch and open a pull request
 
-        Read [Workflow Guide](manual/training/workflow.md) for step-by-step workflow guidance.  
-        Read [README.md](README.md) for setup instructions.
+        Read [Workflow Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/workflow.md) for step-by-step workflow guidance.  
+        Read [README.md](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/README.md) for setup instructions.
 
         ❗ Pull requests **cannot be merged** without signed commits (use `-s -S`).  
-        See the [Signing Guide](manual/training/signing.md).
+        See the [Signing Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/signing.md).
     validations:
       required: true
 


### PR DESCRIPTION
Fixes #3833

The good first issue template used relative links that don't work when the issue is viewed on GitHub. Changed them to absolute URLs:

- Read [Workflow Guide](manual/training/workflow.md) -> https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/workflow.md
- Read [README.md](README.md) -> https://github.com/hiero-ledger/hiero-sdk-js/blob/main/README.md  
- See the [Signing Guide](manual/training/signing.md) -> https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/signing.md