### PR TITLE
fix: correct broken relative links in good first issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
@@ -166,11 +166,11 @@ body:
         - [ ] Sign each commit using `-s -S`
         - [ ] Push your branch and open a pull request
 
-        Read [Workflow Guide](manual/training/workflow.md) for step-by-step workflow guidance.  
-        Read [README.md](README.md) for setup instructions.
+        Read [Workflow Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/workflow.md) for step-by-step workflow guidance.  
+        Read [README.md](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/README.md) for setup instructions.
 
         ❗ Pull requests **cannot be merged** without signed commits (use `-s -S`).  
-        See the [Signing Guide](manual/training/signing.md).
+        See the [Signing Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/signing.md).
     validations:
       required: true
 


### PR DESCRIPTION
## Description

The good first issue template had relative links that don't work properly in GitHub issue descriptions. Updated them to full GitHub URLs.

## Related Issue
Closes #3833

## Changes
- Changed relative link `manual/training/workflow.md` to full GitHub URL
- Changed relative link `README.md` to full GitHub URL  
- Changed relative link `manual/training/signing.md` to full GitHub URL

## Checklist
- [x] Changes are limited to this issue
- [x] No SDK behavior or public API changes