### PR TITLE
fix: correct broken links in good first issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
+++ b/.github/ISSUE_TEMPLATE/02_good_first_issue.yml
@@ -166,11 +166,11 @@ body:
         - [ ] Sign each commit using `-s -S`
         - [ ] Push your branch and open a pull request
 
-        Read [Workflow Guide](manual/training/workflow.md) for step-by-step workflow guidance.  
-        Read [README.md](README.md) for setup instructions.
+        Read [Workflow Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/workflow.md) for step-by-step workflow guidance.  
+        Read [README.md](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/README.md) for setup instructions.
 
         ❗ Pull requests **cannot be merged** without signed commits (use `-s -S`).  
-        See the [Signing Guide](manual/training/signing.md).
+        See the [Signing Guide](https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/signing.md).
     validations:
       required: true
 


### PR DESCRIPTION
## Summary
Replace relative links with absolute GitHub URLs in the good first issue template.

## Changes
- Changed `manual/training/workflow.md` to `https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/workflow.md`
- Changed `README.md` to `https://github.com/hiero-ledger/hiero-sdk-js/blob/main/README.md`
- Changed `manual/training/signing.md` to `https://github.com/hiero-ledger/hiero-sdk-js/blob/main/manual/training/signing.md`

This fixes the broken links mentioned in issue #3833.