### PR TITLE
fix: frontend-examples project configuration and readme

### DIFF
--- a/examples/frontend-examples/README.md
+++ b/examples/frontend-examples/README.md
@@ -1,6 +1,15 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# Frontend Examples
+
+## Environment Variables
+
+Make sure to set these environment variables:
+
+- `NEXT_PUBLIC_OPERATOR_ID`: Your Hedera account ID
+- `NEXT_PUBLIC_OPERATOR_KEY`: Your Hedera private key
 
 ## Getting Started
+
+This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
 
 First, run the development server:
 

--- a/examples/frontend-examples/next.config.mjs
+++ b/examples/frontend-examples/next.config.mjs
@@ -2,9 +2,13 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const monorepoRoot = path.resolve(__dirname, "../..");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-    outputFileTracingRoot: __dirname,
+    outputFileTracingRoot: monorepoRoot,
+    turbopack: {
+        root: monorepoRoot,
+    },
 };
 
 export default nextConfig;


### PR DESCRIPTION
**Description**:
While trying running the front-end examples I got errors because of the next.js root folder configuration and because of missing environment variables (there's a inner readme file describing those variables in the async client example, but they are not only relevant for that example). This PR fixes both issues.

**Related issue(s)**:

Fixes: N/A

**Notes for reviewer**:

N/A

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
