### PR TITLE
feat: migration to ethers v6

### DIFF
--- a/examples/frontend-examples/package.json
+++ b/examples/frontend-examples/package.json
@@ -12,7 +12,7 @@
     "@base-ui-components/react": "^1.0.0-beta.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
-    "@ethersproject/rlp": "^5.8.0",
+    "ethers": "^6.16.0",
     "@hiero-ledger/cryptography": "workspace:*",
     "@hiero-ledger/sdk": "workspace:*",
     "@mui/material": "^7.1.1",

--- a/examples/frontend-examples/src/app/transaction/jumbo/page.js
+++ b/examples/frontend-examples/src/app/transaction/jumbo/page.js
@@ -23,7 +23,7 @@ import {
     Client,
     Status,
 } from "@hiero-ledger/sdk";
-import * as rlp from "@ethersproject/rlp";
+import { encodeRlp } from "ethers";
 import * as hex from "@/app/util/hex.js";
 
 const JumboPage = () => {
@@ -96,19 +96,17 @@ const JumboPage = () => {
         const accessList = [];
 
         // Encode transaction data
-        const encoded = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-            ])
-            .substring(2);
+        const encoded = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+        ]).substring(2);
 
         // Sign the transaction
         const message = hex.decode(type + encoded);
@@ -122,22 +120,20 @@ const JumboPage = () => {
         const v = new Uint8Array(recoveryId === 0 ? [] : [recoveryId]);
 
         // Create final signed transaction
-        const data = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-                v,
-                r,
-                s,
-            ])
-            .substring(2);
+        const data = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+            v,
+            r,
+            s,
+        ]).substring(2);
 
         const ethereumData = hex.decode(type + data);
 

--- a/examples/mirror-node-contract-queries-example.js
+++ b/examples/mirror-node-contract-queries-example.js
@@ -1,4 +1,4 @@
-import ABI from "@ethersproject/abi";
+import { AbiCoder } from "ethers";
 import {
     PrivateKey,
     MirrorNodeContractCallQuery,
@@ -83,7 +83,7 @@ async function main() {
     /**
      * @type {string[]}
      */
-    const decodedSimulationResult = ABI.defaultAbiCoder
+    const decodedSimulationResult = AbiCoder.defaultAbiCoder()
         .decode(["string"], simulationResult)
         .concat();
 

--- a/examples/package.json
+++ b/examples/package.json
@@ -14,7 +14,7 @@
         "node": ">=16.0.0"
     },
     "dependencies": {
-        "@ethersproject/abi": "^5.8.0",
+        "ethers": "^6.16.0",
         "@hiero-ledger/sdk": "link:..",
         "@noble/hashes": "^1.7.1",
         "axios": "^1.13.5",

--- a/package.json
+++ b/package.json
@@ -60,10 +60,7 @@
         "not ie > 0"
     ],
     "dependencies": {
-        "@ethersproject/abi": "5.8.0",
-        "@ethersproject/bignumber": "5.8.0",
-        "@ethersproject/bytes": "5.8.0",
-        "@ethersproject/rlp": "5.8.0",
+        "ethers": "6.16.0",
         "@grpc/grpc-js": "1.12.6",
         "@hiero-ledger/cryptography": "workspace:*",
         "@hiero-ledger/proto": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,18 +11,6 @@ importers:
 
   .:
     dependencies:
-      '@ethersproject/abi':
-        specifier: 5.8.0
-        version: 5.8.0
-      '@ethersproject/bignumber':
-        specifier: 5.8.0
-        version: 5.8.0
-      '@ethersproject/bytes':
-        specifier: 5.8.0
-        version: 5.8.0
-      '@ethersproject/rlp':
-        specifier: 5.8.0
-        version: 5.8.0
       '@grpc/grpc-js':
         specifier: 1.12.6
         version: 1.12.6
@@ -50,6 +38,9 @@ importers:
       debug:
         specifier: 4.4.1
         version: 4.4.1(supports-color@8.1.1)
+      ethers:
+        specifier: 6.16.0
+        version: 6.16.0
       js-base64:
         specifier: 3.7.4
         version: 3.7.4
@@ -258,9 +249,6 @@ importers:
 
   examples:
     dependencies:
-      '@ethersproject/abi':
-        specifier: ^5.8.0
-        version: 5.8.0
       '@hiero-ledger/sdk':
         specifier: link:..
         version: link:..
@@ -273,6 +261,9 @@ importers:
       dotenv:
         specifier: ^17.2.3
         version: 17.2.3
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0
     devDependencies:
       '@types/node':
         specifier: ^25.0.3
@@ -355,9 +346,6 @@ importers:
       '@emotion/styled':
         specifier: ^11.14.0
         version: 11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4)
-      '@ethersproject/rlp':
-        specifier: ^5.8.0
-        version: 5.8.0
       '@hiero-ledger/cryptography':
         specifier: workspace:*
         version: link:../../packages/cryptography
@@ -367,6 +355,9 @@ importers:
       '@mui/material':
         specifier: ^7.1.1
         version: 7.3.7(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react@19.2.4))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ethers:
+        specifier: ^6.16.0
+        version: 6.16.0
       next:
         specifier: 16.1.6
         version: 16.1.6(@babel/core@7.23.3)(@playwright/test@1.30.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -833,6 +824,9 @@ packages:
 
   '@adobe/css-tools@4.4.4':
     resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
+  '@adraffy/ens-normalize@1.10.1':
+    resolution: {integrity: sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==}
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -2525,89 +2519,105 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -3054,24 +3064,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.6':
     resolution: {integrity: sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.6':
     resolution: {integrity: sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.6':
     resolution: {integrity: sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.6':
     resolution: {integrity: sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==}
@@ -3091,9 +3105,16 @@ packages:
   '@nicolo-ribaudo/eslint-scope-5-internals@5.1.1-v1':
     resolution: {integrity: sha512-54/JRvkLIzzDWshCWfuhadfrfZVPiElY8Fcgmg1HroEly/EDSszzhBAsarCux+D/kOslTRquNzuyGSmUSTTHGg==}
 
+  '@noble/curves@1.2.0':
+    resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
+
   '@noble/curves@1.8.1':
     resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
     engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.3.2':
+    resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
+    engines: {node: '>= 16'}
 
   '@noble/hashes@1.4.0':
     resolution: {integrity: sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==}
@@ -3548,131 +3569,157 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-gnueabihf@4.59.0':
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -3893,24 +3940,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.18':
     resolution: {integrity: sha512-1px92582HkPQlaaCkdRcio71p8bc8i/ap5807tPRDK/uw953cauQBT8c5tVGkOwrHMfc2Yh6UuxaH4vtTjGvHg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.18':
     resolution: {integrity: sha512-v3gyT0ivkfBLoZGF9LyHmts0Isc8jHZyVcbzio6Wpzifg/+5ZJpDiRiUhDLkcr7f/r38SWNe7ucxmGW3j3Kb/g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.18':
     resolution: {integrity: sha512-bhJ2y2OQNlcRwwgOAGMY0xTFStt4/wyU6pvI6LSuZpRgKQwxTec0/3Scu91O8ir7qCR3AuepQKLU/kX99FouqQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.18':
     resolution: {integrity: sha512-LffYTvPjODiP6PT16oNeUQJzNVyJl1cjIebq/rWWBF+3eDst5JGEFSc5cWxyRCJ0Mxl+KyIkqRxk1XPEs9x8TA==}
@@ -4114,6 +4165,9 @@ packages:
 
   '@types/node@20.19.28':
     resolution: {integrity: sha512-VyKBr25BuFDzBFCK5sUM6ZXiWfqgCTwTAOK8qzGV/m9FCirXYDlmczJ+d5dXBAQALGCdRRdbteKYfJ84NGEusw==}
+
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/node@24.0.10':
     resolution: {integrity: sha512-ENHwaH+JIRTDIEEbDK6QSQntAYGtbvdDXnMXnZaZ6k13Du1dPMmprkEHIL7ok2Wl2aZevetwTAb5S+7yIF+enA==}
@@ -4517,41 +4571,49 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -4745,6 +4807,9 @@ packages:
   adm-zip@0.5.16:
     resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
     engines: {node: '>=12.0'}
+
+  aes-js@4.0.0-beta.5:
+    resolution: {integrity: sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -6753,6 +6818,10 @@ packages:
     resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
     engines: {node: '>= 0.6'}
 
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
+
   event-target-shim@5.0.1:
     resolution: {integrity: sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==}
     engines: {node: '>=6'}
@@ -8364,24 +8433,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -11254,6 +11327,9 @@ packages:
   tslib@1.14.1:
     resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
 
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -11410,6 +11486,9 @@ packages:
 
   underscore@1.13.7:
     resolution: {integrity: sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==}
+
+  undici-types@6.19.8:
+    resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
@@ -11922,6 +12001,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.3:
     resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
@@ -12069,6 +12160,8 @@ snapshots:
   '@acemir/cssom@0.9.31': {}
 
   '@adobe/css-tools@4.4.4': {}
+
+  '@adraffy/ens-normalize@1.10.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -15639,9 +15732,15 @@ snapshots:
     dependencies:
       eslint-scope: 5.1.1
 
+  '@noble/curves@1.2.0':
+    dependencies:
+      '@noble/hashes': 1.3.2
+
   '@noble/curves@1.8.1':
     dependencies:
       '@noble/hashes': 1.7.1
+
+  '@noble/hashes@1.3.2': {}
 
   '@noble/hashes@1.4.0': {}
 
@@ -16779,6 +16878,10 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
+
   '@types/node@24.0.10':
     dependencies:
       undici-types: 7.8.0
@@ -17697,7 +17800,7 @@ snapshots:
       magicast: 0.5.2
       obug: 2.1.1
       tinyrainbow: 3.0.3
-      vitest: 4.0.18(@types/node@24.0.10)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.0.10)(typescript@5.8.2))(terser@5.44.1)(yaml@2.8.2)
+      vitest: 4.0.18(@types/node@24.0.8)(@vitest/browser-playwright@4.0.18)(jiti@2.6.1)(jsdom@28.1.0)(lightningcss@1.30.2)(msw@2.10.2(@types/node@24.0.8)(typescript@5.7.2))(terser@5.44.1)(yaml@2.8.2)
     transitivePeerDependencies:
       - supports-color
 
@@ -17917,6 +18020,8 @@ snapshots:
       regex-parser: 2.3.1
 
   adm-zip@0.5.16: {}
+
+  aes-js@4.0.0-beta.5: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -19882,7 +19987,7 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.6
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.2(jiti@2.6.1))
       eslint-plugin-react: 7.37.5(eslint@9.39.2(jiti@2.6.1))
@@ -19932,7 +20037,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1(supports-color@8.1.1)
@@ -20007,14 +20112,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.2(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -20303,7 +20408,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.2(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.56.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.2(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -20854,6 +20959,19 @@ snapshots:
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
+
+  ethers@6.16.0:
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   event-target-shim@5.0.1: {}
 
@@ -26575,6 +26693,8 @@ snapshots:
 
   tslib@1.14.1: {}
 
+  tslib@2.7.0: {}
+
   tslib@2.8.1: {}
 
   tsutils@3.21.0(typescript@5.7.2):
@@ -26739,6 +26859,8 @@ snapshots:
   underscore@1.12.1: {}
 
   underscore@1.13.7: {}
+
+  undici-types@6.19.8: {}
 
   undici-types@6.21.0: {}
 
@@ -27436,6 +27558,8 @@ snapshots:
       async-limiter: 1.0.1
 
   ws@7.5.10: {}
+
+  ws@8.17.1: {}
 
   ws@8.18.3: {}
 

--- a/src/EntityIdHelper.js
+++ b/src/EntityIdHelper.js
@@ -7,7 +7,7 @@ import * as util from "./util.js";
 import base32 from "./base32.js";
 import * as HieroProto from "@hiero-ledger/proto";
 import PublicKey from "./PublicKey.js";
-import { arrayify } from "@ethersproject/bytes";
+import { getBytes } from "ethers";
 import EvmAddress from "./EvmAddress.js";
 
 /**
@@ -586,7 +586,7 @@ export function publicKeyToAlias(publicKey) {
             publicKey = `0x${publicKey}`;
         }
 
-        const bytes = arrayify(publicKey);
+        const bytes = getBytes(publicKey);
         if (!bytes) {
             return null;
         }
@@ -612,8 +612,8 @@ export function publicKeyToAlias(publicKey) {
         publicKeyHex = `0x${publicKeyHex}`;
     }
 
-    const leadingBytes = arrayify(leadingHex);
-    const publicKeyBytes = arrayify(publicKeyHex);
+    const leadingBytes = getBytes(leadingHex);
+    const publicKeyBytes = getBytes(publicKeyHex);
     const publicKeyInBytes = appendBuffer(leadingBytes, publicKeyBytes);
     const alias = base32.encode(publicKeyInBytes);
     return alias;

--- a/src/EthereumTransactionDataEip1559.js
+++ b/src/EthereumTransactionDataEip1559.js
@@ -1,4 +1,4 @@
-import * as rlp from "@ethersproject/rlp";
+import { decodeRlp, encodeRlp } from "ethers";
 import * as hex from "./encoding/hex.js";
 import EthereumTransactionData from "./EthereumTransactionData.js";
 import CACHE from "./Cache.js";
@@ -62,7 +62,7 @@ export default class EthereumTransactionDataEip1559 extends EthereumTransactionD
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (rlp.decode(bytes.subarray(1)));
+        const decoded = /** @type {string[]} */ (decodeRlp(bytes.subarray(1)));
 
         if (!Array.isArray(decoded)) {
             throw new Error("ethereum data is not a list");
@@ -96,7 +96,7 @@ export default class EthereumTransactionDataEip1559 extends EthereumTransactionD
      * @returns {Uint8Array}
      */
     toBytes() {
-        const encoded = rlp.encode([
+        const encoded = encodeRlp([
             this.chainId,
             this.nonce,
             this.maxPriorityGas,

--- a/src/EthereumTransactionDataEip2930.js
+++ b/src/EthereumTransactionDataEip2930.js
@@ -1,4 +1,4 @@
-import * as rlp from "@ethersproject/rlp";
+import { decodeRlp, encodeRlp } from "ethers";
 import * as hex from "./encoding/hex.js";
 import EthereumTransactionData from "./EthereumTransactionData.js";
 import CACHE from "./Cache.js";
@@ -59,7 +59,7 @@ export default class EthereumTransactionDataEip2930 extends EthereumTransactionD
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (rlp.decode(bytes.subarray(1)));
+        const decoded = /** @type {string[]} */ (decodeRlp(bytes.subarray(1)));
 
         if (!Array.isArray(decoded)) {
             throw new Error("ethereum data is not a list");
@@ -92,7 +92,7 @@ export default class EthereumTransactionDataEip2930 extends EthereumTransactionD
      * @returns {Uint8Array}
      */
     toBytes() {
-        const encoded = rlp.encode([
+        const encoded = encodeRlp([
             this.chainId,
             this.nonce,
             this.gasPrice,

--- a/src/EthereumTransactionDataEip7702.js
+++ b/src/EthereumTransactionDataEip7702.js
@@ -1,4 +1,4 @@
-import * as rlp from "@ethersproject/rlp";
+import { decodeRlp, encodeRlp } from "ethers";
 import * as hex from "./encoding/hex.js";
 import EthereumTransactionData from "./EthereumTransactionData.js";
 import CACHE from "./Cache.js";
@@ -66,7 +66,7 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (rlp.decode(bytes.subarray(1)));
+        const decoded = /** @type {string[]} */ (decodeRlp(bytes.subarray(1)));
 
         if (!Array.isArray(decoded)) {
             throw new Error("ethereum data is not a list");
@@ -132,7 +132,7 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
      * @returns {Uint8Array}
      */
     toBytes() {
-        const encoded = rlp.encode([
+        const encoded = encodeRlp([
             this.chainId,
             this.nonce,
             this.maxPriorityGas,

--- a/src/EthereumTransactionDataLegacy.js
+++ b/src/EthereumTransactionDataLegacy.js
@@ -1,4 +1,4 @@
-import * as rlp from "@ethersproject/rlp";
+import { decodeRlp, encodeRlp } from "ethers";
 import * as hex from "./encoding/hex.js";
 import EthereumTransactionData from "./EthereumTransactionData.js";
 import CACHE from "./Cache.js";
@@ -53,7 +53,7 @@ export default class EthereumTransactionDataLegacy extends EthereumTransactionDa
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (rlp.decode(bytes));
+        const decoded = /** @type {string[]} */ (decodeRlp(bytes));
 
         if (decoded.length != 9) {
             throw new Error("invalid ethereum transaction data");
@@ -77,7 +77,7 @@ export default class EthereumTransactionDataLegacy extends EthereumTransactionDa
      */
     toBytes() {
         return hex.decode(
-            rlp.encode([
+            encodeRlp([
                 this.nonce,
                 this.gasPrice,
                 this.gasLimit,

--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
-import { hexlify } from "@ethersproject/bytes";
+import { hexlify } from "ethers";
 import { PrivateKey as PrivateKeyCrypto } from "@hiero-ledger/cryptography";
 import { proto } from "@hiero-ledger/proto";
 import Mnemonic from "./Mnemonic.js";

--- a/src/contract/ContractFunctionParameters.js
+++ b/src/contract/ContractFunctionParameters.js
@@ -9,8 +9,9 @@ import * as hex from "../encoding/hex.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import BigNumber from "bignumber.js";
 import * as util from "../util.js";
-import { defaultAbiCoder } from "@ethersproject/abi";
-import { arrayify } from "@ethersproject/bytes";
+import { AbiCoder, getBytes } from "ethers";
+
+const defaultAbiCoder = AbiCoder.defaultAbiCoder();
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import EvmAddress from "../EvmAddress.js";
@@ -1704,7 +1705,7 @@ function argumentToBytes(param, ty) {
             );
 
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-            const dataToArrayify = arrayify(encodedData);
+            const dataToArrayify = getBytes(encodedData);
             return dataToArrayify;
         }
         case ArgumentType.address:

--- a/src/contract/ContractFunctionResult.js
+++ b/src/contract/ContractFunctionResult.js
@@ -8,7 +8,9 @@ import * as hex from "../encoding/hex.js";
 import * as utf8 from "../encoding/utf8.js";
 import * as util from "../util.js";
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { ParamType, defaultAbiCoder } from "@ethersproject/abi";
+import { AbiCoder, ParamType } from "ethers";
+
+const defaultAbiCoder = AbiCoder.defaultAbiCoder();
 import Long from "long";
 import ContractNonceInfo from "./ContractNonceInfo.js";
 
@@ -1000,10 +1002,53 @@ export default class ContractFunctionResult {
     /**
      * @description Decode the data according to the array of types, each of which may be a string or ParamType.
      * @param {Array<string | ParamType>} types
-     * @returns {string | any}
+     * @returns {Array<string | number | BigNumber>}
      */
     getResult(types) {
-        return defaultAbiCoder.decode(types, this.bytes);
+        const decoded = defaultAbiCoder.decode(types, this.bytes);
+        /** @type {Array<string | number | BigNumber>} */
+        const result = [];
+        for (let i = 0; i < decoded.length; i++) {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            result.push(this._convertEthersValue(decoded[i], types[i]));
+        }
+        return result;
+    }
+
+    /**
+     * Convert ethers v6 bigint values to maintain backward compatibility.
+     * Integer types ≤32 bits are converted to Number, >32 bits to BigNumber.
+     * Arrays are recursively converted.
+     * @param {*} value
+     * @param {string | ParamType} type
+     * @returns {string | number | BigNumber}
+     * @private
+     */
+    _convertEthersValue(value, type) {
+        const typeStr =
+            typeof type === "string" ? type : type.type || String(type);
+
+        if (Array.isArray(value)) {
+            const baseType = typeStr.replace(/\[]$/, "");
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            // @ts-ignore -- recursive array conversion
+            return value.map((v) => this._convertEthersValue(v, baseType));
+        }
+
+        if (typeof value !== "bigint") {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            return value;
+        }
+
+        const match = typeStr.match(/^u?int(\d+)?$/);
+        if (match) {
+            const bits = match[1] ? parseInt(match[1], 10) : 256;
+            if (bits <= 32) {
+                return Number(value);
+            }
+        }
+
+        return new BigNumber(value.toString());
     }
 
     /**

--- a/test/integration/EthereumFlowIntegrationTest.js
+++ b/test/integration/EthereumFlowIntegrationTest.js
@@ -15,7 +15,7 @@ import {
 } from "../../src/exports.js";
 import { wait } from "../../src/util.js";
 import { SMART_CONTRACT_BYTECODE_JUMBO } from "./contents.js";
-import * as rlp from "@ethersproject/rlp";
+import { encodeRlp } from "ethers";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
 import * as hex from "../../src/encoding/hex.js";
 
@@ -94,19 +94,17 @@ describe("EthereumFlowIntegrationTest", function () {
             ._build("test");
         const accessList = [];
 
-        const encoded = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-            ])
-            .substring(2);
+        const encoded = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+        ]).substring(2);
         expect(typeof encoded).to.equal("string");
 
         const privateKey = PrivateKey.generateECDSA();
@@ -146,22 +144,20 @@ describe("EthereumFlowIntegrationTest", function () {
         // For `recoveryId` values 1–3, we safely encode them as a single-byte Uint8Array.
         const v = new Uint8Array(recoveryId === 0 ? [] : [recoveryId]);
 
-        const data = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-                v,
-                r,
-                s,
-            ])
-            .substring(2);
+        const data = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+            v,
+            r,
+            s,
+        ]).substring(2);
         expect(typeof data).to.equal("string");
 
         const ethereumData = hex.decode(type + data);

--- a/test/integration/EthereumTransactionIntegrationTest.js
+++ b/test/integration/EthereumTransactionIntegrationTest.js
@@ -18,7 +18,7 @@ import {
     SMART_CONTRACT_BYTECODE,
     SMART_CONTRACT_BYTECODE_JUMBO,
 } from "./contents.js";
-import * as rlp from "@ethersproject/rlp";
+import { encodeRlp } from "ethers";
 import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
 import * as hex from "../../src/encoding/hex.js";
 
@@ -104,19 +104,17 @@ describe("EthereumTransactionIntegrationTest", function () {
             ._build("setMessage");
         const accessList = [];
 
-        const encoded = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-            ])
-            .substring(2);
+        const encoded = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+        ]).substring(2);
         expect(typeof encoded).to.equal("string");
 
         const privateKey = PrivateKey.generateECDSA();
@@ -155,22 +153,20 @@ describe("EthereumTransactionIntegrationTest", function () {
         // For `recoveryId` values 1–3, we safely encode them as a single-byte Uint8Array.
         const v = new Uint8Array(recoveryId === 0 ? [] : [recoveryId]);
 
-        const data = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-                v,
-                r,
-                s,
-            ])
-            .substring(2);
+        const data = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+            v,
+            r,
+            s,
+        ]).substring(2);
         expect(typeof data).to.equal("string");
 
         const ethereumData = hex.decode(type + data);
@@ -263,19 +259,17 @@ describe("EthereumTransactionIntegrationTest", function () {
             ._build("test");
         const accessList = [];
 
-        const encoded = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-            ])
-            .substring(2);
+        const encoded = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+        ]).substring(2);
         expect(typeof encoded).to.equal("string");
 
         const privateKey = PrivateKey.generateECDSA();
@@ -314,22 +308,20 @@ describe("EthereumTransactionIntegrationTest", function () {
         // For `recoveryId` values 1–3, we safely encode them as a single-byte Uint8Array.
         const v = new Uint8Array(recoveryId === 0 ? [] : [recoveryId]);
 
-        const data = rlp
-            .encode([
-                chainId,
-                nonce,
-                maxPriorityGas,
-                maxGas,
-                gasLimit,
-                to,
-                value,
-                callData,
-                accessList,
-                v,
-                r,
-                s,
-            ])
-            .substring(2);
+        const data = encodeRlp([
+            chainId,
+            nonce,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData,
+            accessList,
+            v,
+            r,
+            s,
+        ]).substring(2);
         expect(typeof data).to.equal("string");
 
         const ethereumData = hex.decode(type + data);

--- a/test/unit/ContractFunctionResult.js
+++ b/test/unit/ContractFunctionResult.js
@@ -5,7 +5,6 @@ import {
     ContractNonceInfo,
 } from "../../src/exports.js";
 import * as hex from "../../src/encoding/hex.js";
-import { BigNumber } from "@ethersproject/bignumber";
 
 describe("ContractFunctionResult", function () {
     it("provides results correctly", async function () {
@@ -40,16 +39,10 @@ describe("ContractFunctionResult", function () {
 
         expect(result.getBool(0)).to.be.true;
         expect(result.getInt32(0)).to.be.equal(-1);
-        expect(result.getInt64(0).toString()).to.be.equal(
-            (BigNumber.from(1).shl(32) - BigNumber.from(1)).toString(),
-        );
-        expect(result.getInt256(0).toString()).to.be.equal(
-            (BigNumber.from(1).shl(32) - BigNumber.from(1)).toString(),
-        );
+        expect(result.getInt64(0).toString()).to.be.equal("4294967295");
+        expect(result.getInt256(0).toString()).to.be.equal("4294967295");
         expect(result.getInt256(1).toString()).to.be.equal(
-            (BigNumber.from(1).shl(255) - BigNumber.from(1))
-                .toExponential(76)
-                .replace("8e+76", "7e+76"),
+            "5.7896044618658097711785492504343953926634992332820282019728792003956564819967e+76",
         );
         expect(result.getAddress(2)).to.be.equal(
             "11223344556677889900aabbccddeeff00112233",
@@ -58,9 +51,7 @@ describe("ContractFunctionResult", function () {
         //expect(result.getUint32(3)).to.be.equal(-1);
         //expect(result.getUint64(3)).to.be.equal(-1);
         expect(result.getUint256(3).toString()).to.be.equal(
-            (BigNumber.from(1).shl(256) - BigNumber.from(1))
-                .toExponential(77)
-                .replace("36e+77", "35e+77"),
+            "1.15792089237316195423570985008687907853269984665640564039457584007913129639935e+77",
         );
 
         expect(result.getString(4)).to.be.equal("Hello, world!");

--- a/test/unit/node/EthereumFlowMocking.js
+++ b/test/unit/node/EthereumFlowMocking.js
@@ -1,5 +1,5 @@
 import * as hex from "../../../src/encoding/hex.js";
-import * as rlp from "@ethersproject/rlp";
+import { decodeRlp, encodeRlp } from "ethers";
 import { proto } from "@hiero-ledger/proto";
 import Mocker from "../Mocker.js";
 import { EthereumFlow, FileId } from "../../../src/index.js";
@@ -97,12 +97,12 @@ describe("EthereumFlowMocking", function () {
     });
 
     it("extracts the calldata if it's too large", async function () {
-        const decoded = rlp.decode(bytes);
+        const decoded = decodeRlp(bytes);
         const longCallData = "0x" + "00".repeat(133121);
         decoded[5] = longCallData;
-        const encoded = hex.decode(rlp.encode(decoded));
+        const encoded = hex.decode(encodeRlp(decoded));
         decoded[5] = "0x";
-        const encodedWithoutCallData = hex.decode(rlp.encode(decoded));
+        const encodedWithoutCallData = hex.decode(encodeRlp(decoded));
 
         ({ client, servers } = await Mocker.withResponses([
             [
@@ -196,12 +196,12 @@ describe("EthereumFlowMocking", function () {
     });
 
     it("extracts the calldata if it's too large and try to deploy it by chunks, but thrown", async function () {
-        const decoded = rlp.decode(bytes);
+        const decoded = decodeRlp(bytes);
         const longCallData = "0x" + "00".repeat(7000);
         decoded[5] = longCallData;
-        const encoded = hex.decode(rlp.encode(decoded));
+        const encoded = hex.decode(encodeRlp(decoded));
         decoded[5] = "0x";
-        const encodedWithoutCallData = hex.decode(rlp.encode(decoded));
+        const encodedWithoutCallData = hex.decode(encodeRlp(decoded));
 
         ({ client, servers } = await Mocker.withResponses([
             [
@@ -347,12 +347,12 @@ describe("EthereumFlowMocking", function () {
     });
 
     it("extracts the calldata if it's too large and deploy it by the right amount of chunks", async function () {
-        const decoded = rlp.decode(bytes);
+        const decoded = decodeRlp(bytes);
         const longCallData = "0x" + "00".repeat(133121);
         decoded[5] = longCallData;
-        const encoded = hex.decode(rlp.encode(decoded));
+        const encoded = hex.decode(encodeRlp(decoded));
         decoded[5] = "0x";
-        const encodedWithoutCallData = hex.decode(rlp.encode(decoded));
+        const encodedWithoutCallData = hex.decode(encodeRlp(decoded));
 
         ({ client, servers } = await Mocker.withResponses([
             [


### PR DESCRIPTION
**Description**:
This PR migrates the project dependency from ethers v5 to ethers v6.

**Related issue(s)**:

Fixes: N/A

**Notes for reviewer**:

Ethers v5 contains dependencies that included some minor vulnerabilities that will not be fixed (i.e. elliptic). Tweaking with those dependencies is complex and risky. Migrating to ethers v6 solves the issue entirely.

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
