### PR TITLE
fix: node js doesnt exit until timers are finished

### DIFF
--- a/src/Executable.js
+++ b/src/Executable.js
@@ -375,10 +375,13 @@ export default class Executable {
 
         try {
             // Whichever settles first wins: the real response or the deadline error.
-            return await Promise.race([
-                this._execute(channel, request),
-                deadlinePromise,
-            ]);
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            return /** @type {Promise<ResponseT>} */ (
+                await Promise.race([
+                    this._execute(channel, request),
+                    deadlinePromise,
+                ])
+            );
         } finally {
             // Always cancel the timer — prevents it from keeping the process alive
             // after a successful call (the original timer-leak bug).


### PR DESCRIPTION
**Description**:
The timer ID was never saved, so clearTimeout was never called.

Even in the happy path (gRPC responds in 200ms), the 10-second countdown was still ticking in the background — orphaned, with no way to cancel it. Every gRPC call leaked one timer like this.

Node.js won't exit while there are active timers, so after client.close() the process would just sit there waiting for all those 10-second countdowns to expire naturally before finally quitting.

The fix just saves the timer ID so it can be cancelled the moment 

**Related issue(s)**: #3701
 
Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
