### PR TITLE
refactor(topic): use generic Client<Channel, MirrorChannel> in TopicId

### DIFF
--- a/src/topic/TopicId.js
+++ b/src/topic/TopicId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**


### PR DESCRIPTION
## Summary

Fixes #3823

Replaces the loose wildcard typedef `Client<*, *>` in `src/topic/TopicId.js` with properly typed generics using `Channel` and `MirrorChannel`, consistent with the rest of the SDK codebase.

## Changes

- Removed `@typedef {import("../client/Client.js").default<*, *>} Client`
- Added `@typedef {import("../channel/Channel.js").default} Channel`
- Added `@typedef {import("../channel/MirrorChannel.js").default} MirrorChannel`
- Added `@typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client`

## Checklist

- [x] Scope: Changes are limited to this issue
- [x] Behavior: No SDK behavior or public API changes
- [x] Tests: Existing CI checks should pass (typing-only change)
- [x] Commit is signed off (`-s` flag)