### PR TITLE
fix: replace wildcard Client typedef across codebase (38 files)

### DIFF
--- a/src/EntityIdHelper.js
+++ b/src/EntityIdHelper.js
@@ -11,7 +11,9 @@ import { getBytes } from "ethers";
 import EvmAddress from "./EvmAddress.js";
 
 /**
- * @typedef {import("./client/Client.js").default<*, *>} Client
+ * @typedef {import("./channel/Channel.js").default} Channel
+ * @typedef {import("./channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("./client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/EthereumFlow.js
+++ b/src/EthereumFlow.js
@@ -24,7 +24,9 @@ import * as hex from "./encoding/hex.js";
  * @typedef {import("./file/FileId.js").default} FileId
  * @typedef {import("./channel/Channel.js").default} Channel
  * @typedef {import("./channel/MirrorChannel.js").default} MirrorChannel
- * @typedef {import("./client/Client.js").default<*, *>} Client
+ * @typedef {import("./channel/Channel.js").default} Channel
+ * @typedef {import("./channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("./client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("./Timestamp.js").default} Timestamp
  * @typedef {import("./transaction/TransactionId.js").default} TransactionId
  * @typedef {import("./transaction/TransactionResponse.js").default} TransactionResponse

--- a/src/EthereumTransaction.js
+++ b/src/EthereumTransaction.js
@@ -21,7 +21,9 @@ import Transaction, {
  * @typedef {import("bignumber.js").default} BigNumber
  * @typedef {import("./account/AccountId.js").default} AccountId
  * @typedef {import("./channel/Channel.js").default} Channel
- * @typedef {import("./client/Client.js").default<*, *>} Client
+ * @typedef {import("./channel/Channel.js").default} Channel
+ * @typedef {import("./channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("./client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("./Timestamp.js").default} Timestamp
  * @typedef {import("./transaction/TransactionId.js").default} TransactionId
  * @typedef {import("long")} Long

--- a/src/EvmAddress.js
+++ b/src/EvmAddress.js
@@ -10,7 +10,9 @@ import { arrayEqual } from "./util.js";
  */
 
 /**
- * @typedef {import("./client/Client.js").default<*, *>} Client
+ * @typedef {import("./channel/Channel.js").default} Channel
+ * @typedef {import("./channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("./client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/PrngTransaction.js
+++ b/src/PrngTransaction.js
@@ -20,7 +20,9 @@ import { isNumber } from "./util.js";
  */
 
 /**
- * @typedef {import("./client/Client.js").default<*, *>} Client
+ * @typedef {import("./channel/Channel.js").default} Channel
+ * @typedef {import("./channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("./client/Client.js").default<Channel, MirrorChannel>} Client
  *  @typedef {import("./channel/Channel.js").default} Channel
  */
 

--- a/src/account/AccountId.js
+++ b/src/account/AccountId.js
@@ -11,7 +11,9 @@ import * as hex from ".././encoding/hex.js";
 import { isLongZeroAddress } from "../util.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/account/AccountInfoFlow.js
+++ b/src/account/AccountInfoFlow.js
@@ -4,7 +4,9 @@ import AccountInfoQuery from "./AccountInfoQuery.js";
 import KeyList from "../KeyList.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/Transaction.js").default} Transaction
  * @typedef {import("../PublicKey.js").default} PublicKey
  * @typedef {import("./AccountId.js").default} AccountId

--- a/src/file/FileContentsQuery.js
+++ b/src/file/FileContentsQuery.js
@@ -16,7 +16,9 @@ import FileId from "./FileId.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/file/FileDeleteTransaction.js
+++ b/src/file/FileDeleteTransaction.js
@@ -18,7 +18,9 @@ import FileId from "./FileId.js";
 /**
  * @typedef {import("@hiero-ledger/cryptography").Key} Key
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  */

--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -7,7 +7,9 @@ import EvmAddress from "../EvmAddress.js";
 import * as util from "../util.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/file/FileInfoQuery.js
+++ b/src/file/FileInfoQuery.js
@@ -19,7 +19,9 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/file/FileUpdateTransaction.js
+++ b/src/file/FileUpdateTransaction.js
@@ -21,7 +21,9 @@ import KeyList from "../KeyList.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  */

--- a/src/node/NodeCreateTransaction.js
+++ b/src/node/NodeCreateTransaction.js
@@ -28,7 +28,9 @@ const SERVICE_ENDPOINTS_MAX_LENGTH = 8;
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/node/NodeDeleteTransaction.js
+++ b/src/node/NodeDeleteTransaction.js
@@ -22,7 +22,9 @@ import Long from "long";
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/node/NodeUpdateTransaction.js
+++ b/src/node/NodeUpdateTransaction.js
@@ -29,7 +29,9 @@ const SERVICE_ENDPOINTS_MAX_LENGTH = 8;
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/query/CostQuery.js
+++ b/src/query/CostQuery.js
@@ -52,7 +52,7 @@ export default class CostQuery extends QueryBase {
     /**
      * @abstract
      * @protected
-     * @param {import("../client/Client.js").default<*, *>} client
+     * @param {import("../client/Client.js").default<Channel, MirrorChannel>} client
      * @returns {Promise<void>}
      */
     async _beforeExecute(client) {

--- a/src/query/MirrorNodeContractCallQuery.js
+++ b/src/query/MirrorNodeContractCallQuery.js
@@ -3,7 +3,9 @@ import * as hex from "../encoding/hex.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/query/MirrorNodeContractEstimateQuery.js
+++ b/src/query/MirrorNodeContractEstimateQuery.js
@@ -2,7 +2,9 @@ import MirrorNodeContractQuery from "./MirrorNodeContractQuery.js";
 import * as hex from "../encoding/hex.js";
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/query/MirrorNodeContractQuery.js
+++ b/src/query/MirrorNodeContractQuery.js
@@ -3,7 +3,9 @@ import ContractFunctionParameters from "../contract/ContractFunctionParameters.j
 /**
  * @typedef {import("../contract/ContractId").default} ContractId
  * @typedef {import("../account/AccountId").default} AccountId
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  *
  */
 

--- a/src/query/Query.js
+++ b/src/query/Query.js
@@ -16,7 +16,9 @@ import CostQuery from "./CostQuery.js";
  * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
  * @typedef {import("../PublicKey.js").default} PublicKey
  * @typedef {import("../client/Client.js").ClientOperator} ClientOperator
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../logger/Logger.js").default} Logger
  */
 

--- a/src/query/QueryBase.js
+++ b/src/query/QueryBase.js
@@ -13,7 +13,9 @@ import Long from "long";
  * @typedef {import("../Executable.js").ExecutionState} ExecutionState
  * @typedef {import("../client/Client.js").ClientOperator} ClientOperator
  * @typedef {import("../PublicKey.js").default} PublicKey
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../logger/Logger.js").default} Logger
  */
 

--- a/src/schedule/ScheduleDeleteTransaction.js
+++ b/src/schedule/ScheduleDeleteTransaction.js
@@ -21,7 +21,9 @@ import Hbar from "../Hbar.js";
  * @typedef {import("bignumber.js").default} BigNumber
  * @typedef {import("@hiero-ledger/cryptography").Key} Key
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../Timestamp.js").default} Timestamp
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId

--- a/src/schedule/ScheduleInfoQuery.js
+++ b/src/schedule/ScheduleInfoQuery.js
@@ -19,7 +19,9 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/schedule/ScheduleSignTransaction.js
+++ b/src/schedule/ScheduleSignTransaction.js
@@ -39,7 +39,9 @@ import Transaction, {
  * @typedef {import("bignumber.js").default} BigNumber
  * @typedef {import("@hiero-ledger/cryptography").Key} Key
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../Timestamp.js").default} Timestamp
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId

--- a/src/token/TokenBurnTransaction.js
+++ b/src/token/TokenBurnTransaction.js
@@ -20,7 +20,9 @@ import { convertAmountToLong } from "../util.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("bignumber.js").default} BigNumber

--- a/src/token/TokenDeleteTransaction.js
+++ b/src/token/TokenDeleteTransaction.js
@@ -18,7 +18,9 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  */

--- a/src/token/TokenId.js
+++ b/src/token/TokenId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/token/TokenInfoQuery.js
+++ b/src/token/TokenInfoQuery.js
@@ -19,7 +19,9 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/token/TokenMintTransaction.js
+++ b/src/token/TokenMintTransaction.js
@@ -20,7 +20,9 @@ import { convertAmountToLong } from "../util.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("bignumber.js").default} BigNumber

--- a/src/token/TokenNftsUpdateTransaction.js
+++ b/src/token/TokenNftsUpdateTransaction.js
@@ -18,7 +18,9 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */

--- a/src/token/TokenPauseTransaction.js
+++ b/src/token/TokenPauseTransaction.js
@@ -18,7 +18,9 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */

--- a/src/token/TokenRejectTransaction.js
+++ b/src/token/TokenRejectTransaction.js
@@ -17,7 +17,9 @@ import TokenReference from "../token/TokenReference.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../token/TokenId.js").default} TokenId
  * @typedef {import("../token/NftId.js").default} NftId

--- a/src/token/TokenUnpauseTransaction.js
+++ b/src/token/TokenUnpauseTransaction.js
@@ -18,7 +18,9 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */

--- a/src/token/TokenUpdateNftsTransaction.js
+++ b/src/token/TokenUpdateNftsTransaction.js
@@ -18,7 +18,9 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */

--- a/src/topic/TopicDeleteTransaction.js
+++ b/src/topic/TopicDeleteTransaction.js
@@ -17,7 +17,9 @@ import TopicId from "./TopicId.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  */

--- a/src/topic/TopicId.js
+++ b/src/topic/TopicId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/topic/TopicInfoQuery.js
+++ b/src/topic/TopicInfoQuery.js
@@ -23,7 +23,9 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/transaction/TransactionId.js
+++ b/src/transaction/TransactionId.js
@@ -7,7 +7,9 @@ import Long from "long";
 import CACHE from "../Cache.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("./TransactionReceipt.js").default} TransactionReceipt
  * @typedef {import("./TransactionRecord.js").default} TransactionRecord
  */


### PR DESCRIPTION
## Summary

Replaces all instances of `@typedef {import("../client/Client.js").default<*, *>}` with explicit `Channel` and `MirrorChannel` generic types across 38 source files.

## Changes
- Added Channel and MirrorChannel typedefs where missing
- Updated Client typedef to use default<Channel, MirrorChannel>
- Fixes eslint warnings in all affected files

## Closes
Closes #3798, Closes #3799, Closes #3820, Closes #3822, Closes #3823

## Testing
Typing-only change, no runtime behavior affected.