### PR TITLE
fix: replace wildcard Client typedef in FileId.js

### DIFF
--- a/src/file/FileId.js
+++ b/src/file/FileId.js
@@ -7,7 +7,9 @@ import EvmAddress from "../EvmAddress.js";
 import * as util from "../util.js";
 
 /**
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**


### PR DESCRIPTION
Closes #3820

Replaces the generic `*, *` Client type import with explicit Channel and MirrorChannel types for better type safety.

Changes:
- Added `@typedef` for `Channel` and `MirrorChannel` 
- Updated `Client` typedef to use the specific channel types

This is a typing-only change with no runtime behavior impact.