### PR TITLE
refactor(token): replace wildcard Client typedefs with explicit channel generics

### DIFF
--- a/src/token/TokenBurnTransaction.js
+++ b/src/token/TokenBurnTransaction.js
@@ -20,7 +20,8 @@ import { convertAmountToLong } from "../util.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("bignumber.js").default} BigNumber

--- a/src/token/TokenDeleteTransaction.js
+++ b/src/token/TokenDeleteTransaction.js
@@ -18,7 +18,8 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  */

--- a/src/token/TokenId.js
+++ b/src/token/TokenId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/token/TokenInfoQuery.js
+++ b/src/token/TokenInfoQuery.js
@@ -19,7 +19,8 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 

--- a/src/token/TokenMintTransaction.js
+++ b/src/token/TokenMintTransaction.js
@@ -20,7 +20,8 @@ import { convertAmountToLong } from "../util.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("bignumber.js").default} BigNumber

--- a/src/token/TokenNftsUpdateTransaction.js
+++ b/src/token/TokenNftsUpdateTransaction.js
@@ -18,7 +18,8 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */

--- a/src/token/TokenPauseTransaction.js
+++ b/src/token/TokenPauseTransaction.js
@@ -18,7 +18,8 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */

--- a/src/token/TokenUnpauseTransaction.js
+++ b/src/token/TokenUnpauseTransaction.js
@@ -18,7 +18,8 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */

--- a/src/token/TokenUpdateNftsTransaction.js
+++ b/src/token/TokenUpdateNftsTransaction.js
@@ -18,7 +18,8 @@ import Transaction, {
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  * @typedef {import("../account/AccountId.js").default} AccountId
  */


### PR DESCRIPTION
**Description**:

This PR addresses the typing cleanup requested in issue #3822.

- Replace wildcard `Client<*, *>` typedef in `src/token/TokenId.js` with:
  - `Channel`
  - `MirrorChannel`
  - `Client<Channel, MirrorChannel>`
- Align dependent token files that pass `client` into `TokenId` methods so typings remain consistent and lint/type checks pass.
- Typing-only changes; no runtime or behavior changes.

**Related issue(s)**:

Fixes #3822

**Notes for reviewer**:

Validation performed:

- `task.cmd lint` ✅
- `npx vitest --config=test/vitest-node.config.ts --maxWorkers=1` ✅

(Serial node test run used to avoid intermittent local port-collision flake in parallel runs.)

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
