### PR TITLE
fix: pretty pino worker spawn

### DIFF
--- a/src/logger/Logger.js
+++ b/src/logger/Logger.js
@@ -17,21 +17,90 @@ import LogLevel from "./LogLevel.js";
  */
 export default class Logger {
     /**
-     * @param {LogLevel} level
-     * @param {string} logFile the file to log to, if empty, logs to console
-     * @param {boolean} sync perform writes synchronously (similar to console.log)
-     * @param {boolean} fsync perform a fsyncSync every time a write is completed
-     * @param {boolean} mkdir ensure directory for dest file exists when true (default false)
-     * @param {number} minLength the minimum length of the internal buffer that is required to be full before flushing
+     * @typedef {object} LoggerOptions
+     * @property {LogLevel} level the log level
+     * @property {string} [logFile] the file to log to, if empty logs to console
+     * @property {boolean} [silent] create a no-op logger without spawning a worker thread
+     * @property {boolean} [sync] perform writes synchronously (similar to console.log) (default: true)
+     * @property {boolean} [fsync] perform a fsyncSync every time a write is completed (default: true)
+     * @property {boolean} [mkdir] ensure directory for dest file exists when true (default: true)
+     * @property {number} [minLength] the minimum length of the internal buffer that is required to be full before flushing (default: 0)
+     */
+
+    /**
+     * Creates a new Logger instance.
+     *
+     * @overload
+     * @param {LoggerOptions} options the logger configuration options
+     */
+    /**
+     * Creates a new Logger instance.
+     *
+     * @overload
+     * @param {LogLevel} level the log level
+     * @param {string} [logFile] the file to log to, if empty, logs to console
+     * @param {boolean} [sync] perform writes synchronously (similar to console.log)
+     * @param {boolean} [fsync] perform a fsyncSync every time a write is completed
+     * @param {boolean} [mkdir] ensure directory for dest file exists when true (default true)
+     * @param {number} [minLength] the minimum length of the internal buffer that is required to be full before flushing
+     */
+    /**
+     * @param {LogLevel | LoggerOptions} levelOrOptions
+     * @param {string} [logFile]
+     * @param {boolean} [sync]
+     * @param {boolean} [fsync]
+     * @param {boolean} [mkdir]
+     * @param {number} [minLength]
      */
     constructor(
-        level,
+        levelOrOptions,
         logFile = "",
         sync = true,
         fsync = true,
         mkdir = true,
         minLength = 0,
     ) {
+        /** @type {LogLevel} */
+        let level;
+        /** @type {boolean} */
+        let silent;
+
+        if (
+            typeof levelOrOptions === "object" &&
+            levelOrOptions !== null &&
+            !(levelOrOptions instanceof LogLevel)
+        ) {
+            // Options object overload
+            ({
+                logFile = "",
+                silent = false,
+                sync = true,
+                fsync = true,
+                mkdir = true,
+                minLength = 0,
+            } = levelOrOptions);
+            level = levelOrOptions.level;
+        } else {
+            // Legacy positional arguments overload
+            level = levelOrOptions;
+            silent = false;
+        }
+
+        /**
+         * @private
+         * @type {LogLevel}
+         */
+        this._previousLevel = level;
+
+        if (silent) {
+            /**
+             * @private
+             * @type {import("pino").Logger}
+             */
+            this._logger = pino({ level: "silent", enabled: false });
+            return;
+        }
+
         const fileTransport = logFile
             ? pino.destination({
                   dest: logFile,
@@ -68,19 +137,9 @@ export default class Logger {
                   },
               };
 
-        /**
-         * @private
-         * @type {import("pino").Logger}
-         */
         this._logger = fileTransport
             ? pino(loggerOptions, fileTransport)
             : pino(loggerOptions);
-
-        /**
-         * @private
-         * @type {LogLevel}
-         */
-        this._previousLevel = level;
     }
 
     /**

--- a/test/unit/node/LoggerTest.js
+++ b/test/unit/node/LoggerTest.js
@@ -107,6 +107,42 @@ describe("Logger", function () {
         expect(assertionCount).to.be.equal(6, "should have made 6 assertions");
     });
 
+    it("should not spawn a worker thread when constructed with silent option", function () {
+        const logger = new Logger({ level: LogLevel.Info, silent: true });
+
+        // Logger should be in silent mode with no transport worker thread
+        expect(logger.level).to.be.equal(LogLevel.Silent);
+
+        // Logging methods should be callable without errors (no-op)
+        expect(() => logger.info("test")).to.not.throw();
+        expect(() => logger.warn("test")).to.not.throw();
+        expect(() => logger.error("test")).to.not.throw();
+    });
+
+    it("should accept logFile via options object", function () {
+        const logFile = `${tmpdir()}/test_options_obj.log`;
+        fs.rmSync(logFile, { force: true });
+        const logger = new Logger({ level: LogLevel.Info, logFile });
+        logger.info("options object message");
+        const logContent = fs.readFileSync(logFile, "utf8");
+        expect(logContent).to.contain("options object message");
+    });
+
+    it("should allow setLogger to replace a silent logger", function () {
+        const logger = new Logger({ level: LogLevel.Info, silent: true });
+        expect(logger.level).to.be.equal(LogLevel.Silent);
+
+        // After setLogger, the logger should use the provided instance
+        const logFile = `${tmpdir()}/test_silent_replace.log`;
+        fs.rmSync(logFile, { force: true });
+        const realLogger = new Logger(LogLevel.Info, logFile);
+        logger.setLogger(realLogger._logger);
+
+        logger.info("post-replace message");
+        const logContent = fs.readFileSync(logFile, "utf8");
+        expect(logContent).to.contain("post-replace message");
+    });
+
     it("check that silent blocks output", function () {
         const logFile = `${tmpdir()}/test2.log`;
         fs.rmSync(logFile, { force: true });


### PR DESCRIPTION
## Summary                                                                                                                                               
                                         
  Fixes #3891                                                                                                                                              
                                                                                                                                                           
  - Add a new `Logger` constructor overload that accepts an options object (`LoggerOptions`) with a `silent` flag, which creates a no-op pino logger       
  (`enabled: false`) without spawning a `pino-pretty` worker thread
  - The legacy positional-arguments constructor (`new Logger(level, logFile, sync, ...)`) remains fully intact — no breaking changes                       
  - Add JSDoc `@overload` annotations for both constructor signatures                                                                                      
                                                                                                                                                           
  ## Usage                                                                                                                                                 
                                                                                                                                                           
  ```js                                                                                                                                                    
  // New options object overload — silent, no worker thread
  const logger = new Logger({ level: LogLevel.Info, silent: true });                                                                                       
  logger.setLogger(realPinoInstance); // replace later                                                                                                     
                                                                                                                                                           
  // Legacy overload — unchanged                                                                                                                           
  const logger = new Logger(LogLevel.Info);                                                                                                                
  const logger = new Logger(LogLevel.Info, "/path/to/file");                                                                                               
                                                                                                                                                           
  Test plan                                                                                                                                                
                                                                                                                                                           
  - Existing Logger tests pass unchanged (legacy overload)                                                                                                 
  - New test: silent option creates a no-op logger without throwing
  - New test: options object with logFile writes to file correctly                                                                                         
  - New test: setLogger() replaces a silent logger with a real one    