### PR TITLE
fix(ethereum): add proper access list support for tx types 1, 2 and 4

### DIFF
--- a/src/EthereumTransactionDataEip1559.js
+++ b/src/EthereumTransactionDataEip1559.js
@@ -4,6 +4,16 @@ import EthereumTransactionData from "./EthereumTransactionData.js";
 import CACHE from "./Cache.js";
 
 /**
+ * @typedef {[Uint8Array, Uint8Array[]]} AccessListItem - [address, storageKeys[]]
+ */
+
+/**
+ * @typedef {object} AccessListItemJSON
+ * @property {string} address
+ * @property {string[]} storageKeys
+ */
+
+/**
  * @typedef {object} EthereumTransactionDataEip1559JSON
  * @property {string} chainId
  * @property {string} nonce
@@ -13,7 +23,7 @@ import CACHE from "./Cache.js";
  * @property {string} to
  * @property {string} value
  * @property {string} callData
- * @property {string[]} accessList
+ * @property {AccessListItemJSON[]} accessList
  * @property {string} recId
  * @property {string} r
  * @property {string} s
@@ -31,7 +41,7 @@ export default class EthereumTransactionDataEip1559 extends EthereumTransactionD
      * @param {Uint8Array} props.to
      * @param {Uint8Array} props.value
      * @param {Uint8Array} props.callData
-     * @param {Uint8Array[]} props.accessList
+     * @param {AccessListItem[]} props.accessList
      * @param {Uint8Array} props.recId
      * @param {Uint8Array} props.r
      * @param {Uint8Array} props.s
@@ -61,8 +71,9 @@ export default class EthereumTransactionDataEip1559 extends EthereumTransactionD
             throw new Error("empty bytes");
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (decodeRlp(bytes.subarray(1)));
+        const decoded = /** @type {unknown[]} */ (
+            /** @type {unknown} */ (decodeRlp(bytes.subarray(1)))
+        );
 
         if (!Array.isArray(decoded)) {
             throw new Error("ethereum data is not a list");
@@ -82,9 +93,20 @@ export default class EthereumTransactionDataEip1559 extends EthereumTransactionD
             to: hex.decode(/** @type {string} */ (decoded[5])),
             value: hex.decode(/** @type {string} */ (decoded[6])),
             callData: hex.decode(/** @type {string} */ (decoded[7])),
-            // @ts-ignore
-            accessList: /** @type {string[]} */ (decoded[8]).map((v) =>
-                hex.decode(v),
+            accessList: /** @type {AccessListItem[]} */ (
+                /** @type {Array<[string, string[]]>} */ (
+                    /** @type {unknown} */ (decoded[8])
+                ).map((item) => {
+                    if (!Array.isArray(item) || item.length !== 2) {
+                        throw new Error(
+                            "invalid access list entry: must be [address, storageKeys[]]",
+                        );
+                    }
+                    return [
+                        hex.decode(item[0]),
+                        item[1].map((key) => hex.decode(key)),
+                    ];
+                })
             ),
             recId: hex.decode(/** @type {string} */ (decoded[9])),
             r: hex.decode(/** @type {string} */ (decoded[10])),
@@ -133,7 +155,10 @@ export default class EthereumTransactionDataEip1559 extends EthereumTransactionD
             to: hex.encode(this.to),
             value: hex.encode(this.value),
             callData: hex.encode(this.callData),
-            accessList: this.accessList.map((v) => hex.encode(v)),
+            accessList: this.accessList.map(([address, storageKeys]) => ({
+                address: hex.encode(address),
+                storageKeys: storageKeys.map((key) => hex.encode(key)),
+            })),
             recId: hex.encode(this.recId),
             r: hex.encode(this.r),
             s: hex.encode(this.s),

--- a/src/EthereumTransactionDataEip2930.js
+++ b/src/EthereumTransactionDataEip2930.js
@@ -4,6 +4,16 @@ import EthereumTransactionData from "./EthereumTransactionData.js";
 import CACHE from "./Cache.js";
 
 /**
+ * @typedef {[Uint8Array, Uint8Array[]]} AccessListItem - [address, storageKeys[]]
+ */
+
+/**
+ * @typedef {object} AccessListItemJSON
+ * @property {string} address
+ * @property {string[]} storageKeys
+ */
+
+/**
  * @typedef {object} EthereumTransactionDataEip2930JSON
  * @property {string} chainId
  * @property {string} nonce
@@ -12,7 +22,7 @@ import CACHE from "./Cache.js";
  * @property {string} to
  * @property {string} value
  * @property {string} callData
- * @property {string[]} accessList
+ * @property {AccessListItemJSON[]} accessList
  * @property {string} recId
  * @property {string} r
  * @property {string} s
@@ -29,7 +39,7 @@ export default class EthereumTransactionDataEip2930 extends EthereumTransactionD
      * @param {Uint8Array} props.to
      * @param {Uint8Array} props.value
      * @param {Uint8Array} props.callData
-     * @param {Uint8Array[]} props.accessList
+     * @param {AccessListItem[]} props.accessList
      * @param {Uint8Array} props.recId
      * @param {Uint8Array} props.r
      * @param {Uint8Array} props.s
@@ -58,8 +68,9 @@ export default class EthereumTransactionDataEip2930 extends EthereumTransactionD
             throw new Error("empty bytes");
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (decodeRlp(bytes.subarray(1)));
+        const decoded = /** @type {unknown[]} */ (
+            /** @type {unknown} */ (decodeRlp(bytes.subarray(1)))
+        );
 
         if (!Array.isArray(decoded)) {
             throw new Error("ethereum data is not a list");
@@ -78,9 +89,20 @@ export default class EthereumTransactionDataEip2930 extends EthereumTransactionD
             to: hex.decode(/** @type {string} */ (decoded[4])),
             value: hex.decode(/** @type {string} */ (decoded[5])),
             callData: hex.decode(/** @type {string} */ (decoded[6])),
-            // @ts-ignore
-            accessList: /** @type {string[]} */ (decoded[7]).map((v) =>
-                hex.decode(v),
+            accessList: /** @type {AccessListItem[]} */ (
+                /** @type {Array<[string, string[]]>} */ (
+                    /** @type {unknown} */ (decoded[7])
+                ).map((item) => {
+                    if (!Array.isArray(item) || item.length !== 2) {
+                        throw new Error(
+                            "invalid access list entry: must be [address, storageKeys[]]",
+                        );
+                    }
+                    return [
+                        hex.decode(item[0]),
+                        item[1].map((key) => hex.decode(key)),
+                    ];
+                })
             ),
             recId: hex.decode(/** @type {string} */ (decoded[8])),
             r: hex.decode(/** @type {string} */ (decoded[9])),
@@ -127,7 +149,10 @@ export default class EthereumTransactionDataEip2930 extends EthereumTransactionD
             to: hex.encode(this.to),
             value: hex.encode(this.value),
             callData: hex.encode(this.callData),
-            accessList: this.accessList.map((v) => hex.encode(v)),
+            accessList: this.accessList.map(([address, storageKeys]) => ({
+                address: hex.encode(address),
+                storageKeys: storageKeys.map((key) => hex.encode(key)),
+            })),
             recId: hex.encode(this.recId),
             r: hex.encode(this.r),
             s: hex.encode(this.s),

--- a/src/EthereumTransactionDataEip7702.js
+++ b/src/EthereumTransactionDataEip7702.js
@@ -4,6 +4,20 @@ import EthereumTransactionData from "./EthereumTransactionData.js";
 import CACHE from "./Cache.js";
 
 /**
+ * @typedef {[Uint8Array, Uint8Array[]]} AccessListItem - [address, storageKeys[]]
+ */
+
+/**
+ * @typedef {[Uint8Array, Uint8Array, Uint8Array, Uint8Array, Uint8Array, Uint8Array]} AuthorizationItem - [chainId, contractAddress, nonce, yParity, r, s]
+ */
+
+/**
+ * @typedef {object} AccessListItemJSON
+ * @property {string} address
+ * @property {string[]} storageKeys
+ */
+
+/**
  * @typedef {object} EthereumTransactionDataEip7702JSON
  * @property {string} chainId
  * @property {string} nonce
@@ -14,7 +28,7 @@ import CACHE from "./Cache.js";
  * @property {string} value
  * @property {string} callData
  * @property {Array<[string, string, string, string, string, string]>} authorizationList - Array of [chainId, contractAddress, nonce, yParity, r, s] tuples
- * @property {string[]} accessList
+ * @property {AccessListItemJSON[]} accessList
  * @property {string} recId
  * @property {string} r
  * @property {string} s
@@ -32,8 +46,8 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
      * @param {Uint8Array} props.to
      * @param {Uint8Array} props.value
      * @param {Uint8Array} props.callData
-     * @param {Array<[Uint8Array, Uint8Array, Uint8Array, Uint8Array, Uint8Array, Uint8Array]>} props.authorizationList - Array of [chainId, contractAddress, nonce, yParity, r, s] tuples
-     * @param {Uint8Array[]} props.accessList
+     * @param {AuthorizationItem[]} props.authorizationList - Array of [chainId, contractAddress, nonce, yParity, r, s] tuples
+     * @param {AccessListItem[]} props.accessList
      * @param {Uint8Array} props.recId
      * @param {Uint8Array} props.r
      * @param {Uint8Array} props.s
@@ -65,8 +79,9 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
             throw new Error("empty bytes");
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (decodeRlp(bytes.subarray(1)));
+        const decoded = /** @type {unknown[]} */ (
+            /** @type {unknown} */ (decodeRlp(bytes.subarray(1)))
+        );
 
         if (!Array.isArray(decoded)) {
             throw new Error("ethereum data is not a list");
@@ -81,30 +96,24 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
         if (!Array.isArray(decoded[9])) {
             throw new Error("authorization list must be an array");
         }
-        // @ts-ignore
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        const authorizationList = /** @type {string[]} */ (decoded[9]).map(
-            (authTuple) => {
+        const authorizationList = /** @type {AuthorizationItem[]} */ (
+            /** @type {Array<[string, string, string, string, string, string]>} */ (
+                /** @type {unknown} */ (decoded[9])
+            ).map((authTuple) => {
                 if (!Array.isArray(authTuple) || authTuple.length !== 6) {
                     throw new Error(
                         "invalid authorization list entry: must be [chainId, contractAddress, nonce, yParity, r, s]",
                     );
                 }
                 return [
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    hex.decode(/** @type {string} */ (authTuple[0])), // chainId
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    hex.decode(/** @type {string} */ (authTuple[1])), // contractAddress (20 bytes)
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    hex.decode(/** @type {string} */ (authTuple[2])), // nonce
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    hex.decode(/** @type {string} */ (authTuple[3])), // yParity (0 or 1)
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    hex.decode(/** @type {string} */ (authTuple[4])), // r (32 bytes)
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    hex.decode(/** @type {string} */ (authTuple[5])), // s (32 bytes)
+                    hex.decode(authTuple[0]), // chainId
+                    hex.decode(authTuple[1]), // contractAddress (20 bytes)
+                    hex.decode(authTuple[2]), // nonce
+                    hex.decode(authTuple[3]), // yParity (0 or 1)
+                    hex.decode(authTuple[4]), // r (32 bytes)
+                    hex.decode(authTuple[5]), // s (32 bytes)
                 ];
-            },
+            })
         );
 
         return new EthereumTransactionDataEip7702({
@@ -116,11 +125,21 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
             to: hex.decode(/** @type {string} */ (decoded[5])),
             value: hex.decode(/** @type {string} */ (decoded[6])),
             callData: hex.decode(/** @type {string} */ (decoded[7])),
-            // @ts-ignore
-            accessList: /** @type {string[]} */ (decoded[8]).map((v) =>
-                hex.decode(v),
+            accessList: /** @type {AccessListItem[]} */ (
+                /** @type {Array<[string, string[]]>} */ (
+                    /** @type {unknown} */ (decoded[8])
+                ).map((item) => {
+                    if (!Array.isArray(item) || item.length !== 2) {
+                        throw new Error(
+                            "invalid access list entry: must be [address, storageKeys[]]",
+                        );
+                    }
+                    return [
+                        hex.decode(item[0]),
+                        item[1].map((key) => hex.decode(key)),
+                    ];
+                })
             ),
-            // @ts-ignore
             authorizationList: authorizationList,
             recId: hex.decode(/** @type {string} */ (decoded[10])),
             r: hex.decode(/** @type {string} */ (decoded[11])),
@@ -180,7 +199,10 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
                     hex.encode(s),
                 ],
             ),
-            accessList: this.accessList.map((v) => hex.encode(v)),
+            accessList: this.accessList.map(([address, storageKeys]) => ({
+                address: hex.encode(address),
+                storageKeys: storageKeys.map((key) => hex.encode(key)),
+            })),
             recId: hex.encode(this.recId),
             r: hex.encode(this.r),
             s: hex.encode(this.s),

--- a/src/EthereumTransactionDataLegacy.js
+++ b/src/EthereumTransactionDataLegacy.js
@@ -52,8 +52,9 @@ export default class EthereumTransactionDataLegacy extends EthereumTransactionDa
             throw new Error("empty bytes");
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        const decoded = /** @type {string[]} */ (decodeRlp(bytes));
+        const decoded = /** @type {unknown[]} */ (
+            /** @type {unknown} */ (decodeRlp(bytes))
+        );
 
         if (decoded.length != 9) {
             throw new Error("invalid ethereum transaction data");

--- a/test/integration/EthereumTransactionAccessListIntegrationTest.js
+++ b/test/integration/EthereumTransactionAccessListIntegrationTest.js
@@ -1,0 +1,540 @@
+import {
+    FileCreateTransaction,
+    ContractFunctionParameters,
+    ContractCreateTransaction,
+    EthereumTransaction,
+    EthereumTransactionData,
+    PrivateKey,
+    TransferTransaction,
+    Hbar,
+    Status,
+} from "../../src/exports.js";
+import { SMART_CONTRACT_BYTECODE } from "./contents.js";
+import { encodeRlp } from "ethers";
+import IntegrationTestEnv from "./client/NodeIntegrationTestEnv.js";
+import * as hex from "../../src/encoding/hex.js";
+
+/**
+ * @summary Integration tests for access list support in EIP-2930 (type 1),
+ * EIP-1559 (type 2), and EIP-7702 (type 4) Ethereum transactions.
+ *
+ * @description
+ * Each test deploys a contract, then submits two transactions with the same
+ * call — once without an access list and once with — and verifies that the
+ * access list is properly encoded/decoded and that both succeed.
+ * Relates to: https://github.com/hiero-ledger/hiero-sdk-js/issues/3885
+ */
+
+describe("EthereumTransactionAccessListIntegrationTest", function () {
+    let env, operatorKey, wallet, operatorId;
+
+    beforeAll(async function () {
+        env = await IntegrationTestEnv.new();
+        wallet = env.wallet;
+        operatorKey = wallet.getAccountKey();
+        operatorId = wallet.getAccountId();
+    });
+
+    /**
+     * Helper: deploy a fresh contract and return its EVM address.
+     */
+    async function deployContract() {
+        const fileResponse = await (
+            await (
+                await new FileCreateTransaction()
+                    .setKeys([wallet.getAccountKey()])
+                    .setContents(SMART_CONTRACT_BYTECODE)
+                    .setMaxTransactionFee(new Hbar(2))
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const fileReceipt = await fileResponse.getReceiptWithSigner(wallet);
+        expect(fileReceipt.status).to.be.equal(Status.Success);
+        const fileId = fileReceipt.fileId;
+
+        const contractResponse = await (
+            await (
+                await new ContractCreateTransaction()
+                    .setAdminKey(operatorKey)
+                    .setGas(300_000)
+                    .setConstructorParameters(
+                        new ContractFunctionParameters()
+                            .addString("Hello from Hedera.")
+                            ._build(),
+                    )
+                    .setBytecodeFileId(fileId)
+                    .setContractMemo("[e2e::EthereumTransactionAccessList]")
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const contractReceipt =
+            await contractResponse.getReceiptWithSigner(wallet);
+        expect(contractReceipt.status).to.be.equal(Status.Success);
+        return contractReceipt.contractId.toEvmAddress();
+    }
+
+    /**
+     * Helper: fund a new ECDSA account and return the private key.
+     */
+    async function fundNewEcdsaAccount() {
+        const privateKey = PrivateKey.generateECDSA();
+        const accountAlias = privateKey.publicKey.toEvmAddress();
+
+        const transfer = await new TransferTransaction()
+            .addHbarTransfer(operatorId, new Hbar(10).negated())
+            .addHbarTransfer(accountAlias, new Hbar(10))
+            .setMaxTransactionFee(new Hbar(1))
+            .freezeWithSigner(wallet);
+
+        const transferResponse = await transfer.executeWithSigner(wallet);
+        const transferReceipt =
+            await transferResponse.getReceiptWithSigner(wallet);
+        expect(transferReceipt.status).to.be.equal(Status.Success);
+
+        return privateKey;
+    }
+
+    /**
+     * Helper: sign a raw Ethereum message and return { v, r, s }.
+     */
+    function signMessage(privateKey, message) {
+        const signedBytes = privateKey.sign(message);
+        const mid = signedBytes.length / 2;
+        const r = signedBytes.slice(0, mid);
+        const s = signedBytes.slice(mid);
+        const recoveryId = privateKey.getRecoveryId(r, s, message);
+        const v = new Uint8Array(recoveryId === 0 ? [] : [recoveryId]);
+        return { v, r, s };
+    }
+
+    it("EIP-1559 (type 2): access list reduces or matches gas usage", async function () {
+        const evmAddress = await deployContract();
+        const privateKey = await fundNewEcdsaAccount();
+
+        const type = "02";
+        const chainId = hex.decode("012a");
+        const maxPriorityGas = hex.decode("00");
+        const maxGas = hex.decode("d1385c7bf0");
+        const gasLimit = hex.decode("0249f0");
+        const value = new Uint8Array();
+        const to = hex.decode(evmAddress);
+
+        // --- First call: setMessage WITHOUT access list (nonce 0) ---
+        const callData1 = new ContractFunctionParameters()
+            .addString("message without access list")
+            ._build("setMessage");
+        const nonce1 = new Uint8Array();
+        const accessListEmpty = [];
+
+        const encoded1 = encodeRlp([
+            chainId,
+            nonce1,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData1,
+            accessListEmpty,
+        ]).substring(2);
+
+        const message1 = hex.decode(type + encoded1);
+        const { v: v1, r: r1, s: s1 } = signMessage(privateKey, message1);
+
+        const data1 = encodeRlp([
+            chainId,
+            nonce1,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData1,
+            accessListEmpty,
+            v1,
+            r1,
+            s1,
+        ]).substring(2);
+
+        const ethereumData1 = hex.decode(type + data1);
+
+        const response1 = await (
+            await (
+                await new EthereumTransaction()
+                    .setEthereumData(ethereumData1)
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const record1 = await response1.getRecordWithSigner(wallet);
+        expect(
+            record1.contractFunctionResult.signerNonce.toNumber(),
+        ).to.be.equal(1);
+        const gasUsedWithout =
+            record1.contractFunctionResult.gasUsed.toNumber();
+
+        // --- Second call: setMessage WITH access list (nonce 1) ---
+        const callData2 = new ContractFunctionParameters()
+            .addString("message with access list")
+            ._build("setMessage");
+        const nonce2 = new Uint8Array([0x01]);
+
+        const storageSlot0 = new Uint8Array(32);
+        const accessListWithEntry = [[to, [storageSlot0]]];
+
+        const encoded2 = encodeRlp([
+            chainId,
+            nonce2,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData2,
+            accessListWithEntry,
+        ]).substring(2);
+
+        const message2 = hex.decode(type + encoded2);
+        const { v: v2, r: r2, s: s2 } = signMessage(privateKey, message2);
+
+        const data2 = encodeRlp([
+            chainId,
+            nonce2,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData2,
+            accessListWithEntry,
+            v2,
+            r2,
+            s2,
+        ]).substring(2);
+
+        const ethereumData2 = hex.decode(type + data2);
+
+        // Verify fromBytes correctly parses non-empty access list
+        const txData = EthereumTransactionData.fromBytes(ethereumData2);
+        expect(txData.accessList).to.be.an("array");
+        expect(txData.accessList.length).to.equal(1);
+        expect(txData.accessList[0][0]).to.be.instanceOf(Uint8Array);
+        expect(txData.accessList[0][1]).to.be.an("array");
+        expect(txData.accessList[0][1].length).to.equal(1);
+
+        // Verify toJSON format
+        const json = txData.toJSON();
+        expect(json.accessList[0]).to.have.property("address");
+        expect(json.accessList[0]).to.have.property("storageKeys");
+
+        // Verify roundtrip
+        expect(txData.toBytes()).to.deep.equal(ethereumData2);
+
+        const response2 = await (
+            await (
+                await new EthereumTransaction()
+                    .setEthereumData(ethereumData2)
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const record2 = await response2.getRecordWithSigner(wallet);
+        expect(
+            record2.contractFunctionResult.signerNonce.toNumber(),
+        ).to.be.equal(2);
+        const gasUsedWith = record2.contractFunctionResult.gasUsed.toNumber();
+
+        expect(gasUsedWithout).to.be.gte(gasUsedWith);
+    });
+
+    it("EIP-2930 (type 1): access list reduces or matches gas usage", async function () {
+        const evmAddress = await deployContract();
+        const privateKey = await fundNewEcdsaAccount();
+
+        const type = "01";
+        const chainId = hex.decode("012a");
+        const gasPrice = hex.decode("d1385c7bf0");
+        const gasLimit = hex.decode("0249f0");
+        const value = new Uint8Array();
+        const to = hex.decode(evmAddress);
+
+        // --- First call: setMessage WITHOUT access list (nonce 0) ---
+        const callData1 = new ContractFunctionParameters()
+            .addString("message without access list")
+            ._build("setMessage");
+        const nonce1 = new Uint8Array();
+        const accessListEmpty = [];
+
+        const encoded1 = encodeRlp([
+            chainId,
+            nonce1,
+            gasPrice,
+            gasLimit,
+            to,
+            value,
+            callData1,
+            accessListEmpty,
+        ]).substring(2);
+
+        const message1 = hex.decode(type + encoded1);
+        const { v: v1, r: r1, s: s1 } = signMessage(privateKey, message1);
+
+        const data1 = encodeRlp([
+            chainId,
+            nonce1,
+            gasPrice,
+            gasLimit,
+            to,
+            value,
+            callData1,
+            accessListEmpty,
+            v1,
+            r1,
+            s1,
+        ]).substring(2);
+
+        const ethereumData1 = hex.decode(type + data1);
+
+        const response1 = await (
+            await (
+                await new EthereumTransaction()
+                    .setEthereumData(ethereumData1)
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const record1 = await response1.getRecordWithSigner(wallet);
+        expect(
+            record1.contractFunctionResult.signerNonce.toNumber(),
+        ).to.be.equal(1);
+        const gasUsedWithout =
+            record1.contractFunctionResult.gasUsed.toNumber();
+
+        // --- Second call: setMessage WITH access list (nonce 1) ---
+        const callData2 = new ContractFunctionParameters()
+            .addString("message with access list")
+            ._build("setMessage");
+        const nonce2 = new Uint8Array([0x01]);
+
+        const storageSlot0 = new Uint8Array(32);
+        const accessListWithEntry = [[to, [storageSlot0]]];
+
+        const encoded2 = encodeRlp([
+            chainId,
+            nonce2,
+            gasPrice,
+            gasLimit,
+            to,
+            value,
+            callData2,
+            accessListWithEntry,
+        ]).substring(2);
+
+        const message2 = hex.decode(type + encoded2);
+        const { v: v2, r: r2, s: s2 } = signMessage(privateKey, message2);
+
+        const data2 = encodeRlp([
+            chainId,
+            nonce2,
+            gasPrice,
+            gasLimit,
+            to,
+            value,
+            callData2,
+            accessListWithEntry,
+            v2,
+            r2,
+            s2,
+        ]).substring(2);
+
+        const ethereumData2 = hex.decode(type + data2);
+
+        // Verify fromBytes correctly parses non-empty access list
+        const txData = EthereumTransactionData.fromBytes(ethereumData2);
+        expect(txData.accessList).to.be.an("array");
+        expect(txData.accessList.length).to.equal(1);
+        expect(txData.accessList[0][0]).to.be.instanceOf(Uint8Array);
+        expect(txData.accessList[0][1]).to.be.an("array");
+        expect(txData.accessList[0][1].length).to.equal(1);
+
+        // Verify toJSON format
+        const json = txData.toJSON();
+        expect(json.accessList[0]).to.have.property("address");
+        expect(json.accessList[0]).to.have.property("storageKeys");
+
+        // Verify roundtrip
+        expect(txData.toBytes()).to.deep.equal(ethereumData2);
+
+        const response2 = await (
+            await (
+                await new EthereumTransaction()
+                    .setEthereumData(ethereumData2)
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const record2 = await response2.getRecordWithSigner(wallet);
+        expect(
+            record2.contractFunctionResult.signerNonce.toNumber(),
+        ).to.be.equal(2);
+        const gasUsedWith = record2.contractFunctionResult.gasUsed.toNumber();
+
+        expect(gasUsedWithout).to.be.gte(gasUsedWith);
+    });
+
+    // TODO: unskip when a consensus node tag supports EIP-7702 (Pectra) type 4 transactions
+    // eslint-disable-next-line vitest/no-disabled-tests
+    it.skip("EIP-7702 (type 4): access list reduces or matches gas usage", async function () {
+        const evmAddress = await deployContract();
+        const privateKey = await fundNewEcdsaAccount();
+
+        const type = "04";
+        const chainId = hex.decode("012a");
+        const maxPriorityGas = hex.decode("00");
+        const maxGas = hex.decode("d1385c7bf0");
+        const gasLimit = hex.decode("0249f0");
+        const value = new Uint8Array();
+        const to = hex.decode(evmAddress);
+
+        // Empty authorization list is valid per EIP-7702.
+        // Our focus here is testing access list support in type-4 transactions.
+        const authorizationList = [];
+
+        // --- First call: setMessage WITHOUT access list (nonce 0) ---
+        const callData1 = new ContractFunctionParameters()
+            .addString("message without access list")
+            ._build("setMessage");
+        const nonce1 = new Uint8Array();
+        const accessListEmpty = [];
+
+        const encoded1 = encodeRlp([
+            chainId,
+            nonce1,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData1,
+            accessListEmpty,
+            authorizationList,
+        ]).substring(2);
+
+        const message1 = hex.decode(type + encoded1);
+        const { v: v1, r: r1, s: s1 } = signMessage(privateKey, message1);
+
+        const data1 = encodeRlp([
+            chainId,
+            nonce1,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData1,
+            accessListEmpty,
+            authorizationList,
+            v1,
+            r1,
+            s1,
+        ]).substring(2);
+
+        const ethereumData1 = hex.decode(type + data1);
+
+        const response1 = await (
+            await (
+                await new EthereumTransaction()
+                    .setEthereumData(ethereumData1)
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const record1 = await response1.getRecordWithSigner(wallet);
+        expect(
+            record1.contractFunctionResult.signerNonce.toNumber(),
+        ).to.be.equal(1);
+        const gasUsedWithout =
+            record1.contractFunctionResult.gasUsed.toNumber();
+
+        // --- Second call: setMessage WITH access list (nonce 1) ---
+        const callData2 = new ContractFunctionParameters()
+            .addString("message with access list")
+            ._build("setMessage");
+        const nonce2 = new Uint8Array([0x01]);
+
+        const storageSlot0 = new Uint8Array(32);
+        const accessListWithEntry = [[to, [storageSlot0]]];
+
+        const encoded2 = encodeRlp([
+            chainId,
+            nonce2,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData2,
+            accessListWithEntry,
+            authorizationList,
+        ]).substring(2);
+
+        const message2 = hex.decode(type + encoded2);
+        const { v: v2, r: r2, s: s2 } = signMessage(privateKey, message2);
+
+        const data2 = encodeRlp([
+            chainId,
+            nonce2,
+            maxPriorityGas,
+            maxGas,
+            gasLimit,
+            to,
+            value,
+            callData2,
+            accessListWithEntry,
+            authorizationList,
+            v2,
+            r2,
+            s2,
+        ]).substring(2);
+
+        const ethereumData2 = hex.decode(type + data2);
+
+        // Verify fromBytes correctly parses access list and authorization list
+        const txData = EthereumTransactionData.fromBytes(ethereumData2);
+        expect(txData.accessList).to.be.an("array");
+        expect(txData.accessList.length).to.equal(1);
+        expect(txData.accessList[0][0]).to.be.instanceOf(Uint8Array);
+        expect(txData.accessList[0][1]).to.be.an("array");
+        expect(txData.accessList[0][1].length).to.equal(1);
+
+        // Verify authorization list is preserved (empty)
+        expect(txData.authorizationList).to.be.an("array");
+        expect(txData.authorizationList.length).to.equal(0);
+
+        // Verify toJSON format
+        const json = txData.toJSON();
+        expect(json.accessList[0]).to.have.property("address");
+        expect(json.accessList[0]).to.have.property("storageKeys");
+
+        // Verify roundtrip
+        expect(txData.toBytes()).to.deep.equal(ethereumData2);
+
+        const response2 = await (
+            await (
+                await new EthereumTransaction()
+                    .setEthereumData(ethereumData2)
+                    .freezeWithSigner(wallet)
+            ).signWithSigner(wallet)
+        ).executeWithSigner(wallet);
+
+        const record2 = await response2.getRecordWithSigner(wallet);
+        expect(
+            record2.contractFunctionResult.signerNonce.toNumber(),
+        ).to.be.equal(2);
+        const gasUsedWith = record2.contractFunctionResult.gasUsed.toNumber();
+
+        expect(gasUsedWithout).to.be.gte(gasUsedWith);
+    });
+});

--- a/test/unit/EthereumTransactionData.js
+++ b/test/unit/EthereumTransactionData.js
@@ -1,5 +1,8 @@
 import * as hex from "../../src/encoding/hex.js";
 import { EthereumTransactionData } from "../../src/index.js";
+import { encodeRlp, decodeRlp } from "ethers";
+import EthereumTransactionDataEip2930 from "../../src/EthereumTransactionDataEip2930.js";
+import EthereumTransactionDataEip1559 from "../../src/EthereumTransactionDataEip1559.js";
 import EthereumTransactionDataEip7702 from "../../src/EthereumTransactionDataEip7702.js";
 
 const rawTxType0 = hex.decode(
@@ -29,6 +32,242 @@ describe("EthereumTransactionData", function () {
         expect(
             EthereumTransactionData.fromBytes(rawTxType2).toBytes(),
         ).to.deep.equal(rawTxType2);
+    });
+
+    describe("RLP access list structure", function () {
+        it("decodeRlp returns access list as [address, storageKeys[]] tuples, not flat strings", function () {
+            const address = hex.decode(
+                "0000000000000000000000000000000000000001",
+            );
+            const storageKey1 = hex.decode(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            );
+            const storageKey2 = hex.decode(
+                "0000000000000000000000000000000000000000000000000000000000000002",
+            );
+
+            // Build a type-1 (EIP-2930) RLP payload with a non-empty access list
+            const accessList = [[address, [storageKey1, storageKey2]]];
+            const rlp = encodeRlp([
+                hex.decode("01"), // chainId
+                hex.decode("00"), // nonce
+                hex.decode("0a"), // gasPrice
+                hex.decode("0a"), // gasLimit
+                hex.decode("0000000000000000000000000000000000000001"), // to
+                hex.decode("00"), // value
+                new Uint8Array(), // callData
+                accessList,
+                hex.decode("00"), // v
+                hex.decode(
+                    "38ba8bdbcd8684ff089b8efaf7b5aaf2071a11ab01b6cc65757af79f1199f2ef",
+                ), // r
+                hex.decode(
+                    "570b83f85d578427becab466ced52da857e2a9e48bf9ec5850cc2f541e9305e9",
+                ), // s
+            ]);
+
+            // Decode the raw RLP and inspect the access list field (index 7)
+            const decoded = decodeRlp(rlp);
+            const rawAccessList = decoded[7];
+
+            // Prove it is NOT a flat array of strings
+            expect(rawAccessList).to.be.an("array");
+            expect(rawAccessList.length).to.equal(1);
+
+            // Each entry is a tuple: [addressHex, [storageKeyHex, ...]]
+            const entry = rawAccessList[0];
+            expect(entry).to.be.an("array");
+            expect(entry.length).to.equal(2);
+
+            // First element is the address (hex string)
+            expect(typeof entry[0]).to.equal("string");
+
+            // Second element is an array of storage keys, NOT a string
+            expect(entry[1]).to.be.an("array");
+            expect(entry[1].length).to.equal(2);
+            expect(typeof entry[1][0]).to.equal("string");
+            expect(typeof entry[1][1]).to.equal("string");
+        });
+
+        it("fromBytes correctly parses a raw EIP-1559 tx with non-empty access list", function () {
+            const address = hex.decode(
+                "7e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181",
+            );
+            const storageKey = hex.decode(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            );
+
+            // Build a type-2 (EIP-1559) raw transaction with access list
+            const accessList = [[address, [storageKey]]];
+            const rlpPayload = encodeRlp([
+                hex.decode("012a"), // chainId
+                hex.decode("02"), // nonce
+                hex.decode("2f"), // maxPriorityGas
+                hex.decode("2f"), // maxGas
+                hex.decode("018000"), // gasLimit
+                address, // to
+                hex.decode("0de0b6b3a7640000"), // value
+                hex.decode("123456"), // callData
+                accessList,
+                hex.decode("01"), // v
+                hex.decode(
+                    "df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce911fd479",
+                ), // r
+                hex.decode(
+                    "1aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66",
+                ), // s
+            ]);
+
+            // Prepend type byte 0x02
+            const rawTx = hex.decode("02" + rlpPayload.substring(2));
+
+            // fromBytes must not throw
+            const txData = EthereumTransactionData.fromBytes(rawTx);
+
+            // Access list must be parsed as [Uint8Array, Uint8Array[]] tuples
+            expect(txData.accessList).to.be.an("array");
+            expect(txData.accessList.length).to.equal(1);
+            expect(txData.accessList[0][0]).to.be.instanceOf(Uint8Array);
+            expect(hex.encode(txData.accessList[0][0])).to.equal(
+                hex.encode(address),
+            );
+            expect(txData.accessList[0][1]).to.be.an("array");
+            expect(txData.accessList[0][1].length).to.equal(1);
+            expect(txData.accessList[0][1][0]).to.be.instanceOf(Uint8Array);
+            expect(hex.encode(txData.accessList[0][1][0])).to.equal(
+                hex.encode(storageKey),
+            );
+        });
+    });
+
+    describe("EthereumTransactionDataEip2930 access list", function () {
+        it("toBytes and fromBytes preserve non-empty access list", function () {
+            const address1 = hex.decode(
+                "0000000000000000000000000000000000000001",
+            );
+            const storageKey1 = hex.decode(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            );
+            const storageKey2 = hex.decode(
+                "0000000000000000000000000000000000000000000000000000000000000002",
+            );
+
+            const original = new EthereumTransactionDataEip2930({
+                chainId: hex.decode("01"),
+                nonce: hex.decode("01"),
+                gasPrice: hex.decode("0a"),
+                gasLimit: hex.decode("0a"),
+                to: hex.decode("0000000000000000000000000000000000000001"),
+                value: hex.decode("0a"),
+                callData: new Uint8Array(),
+                accessList: [[address1, [storageKey1, storageKey2]]],
+                recId: hex.decode("00"),
+                r: hex.decode(
+                    "38ba8bdbcd8684ff089b8efaf7b5aaf2071a11ab01b6cc65757af79f1199f2ef",
+                ),
+                s: hex.decode(
+                    "570b83f85d578427becab466ced52da857e2a9e48bf9ec5850cc2f541e9305e9",
+                ),
+            });
+
+            const bytes = original.toBytes();
+            const decoded = EthereumTransactionDataEip2930.fromBytes(bytes);
+
+            expect(decoded.accessList).to.be.an("array");
+            expect(decoded.accessList.length).to.equal(1);
+            expect(hex.encode(decoded.accessList[0][0])).to.equal(
+                hex.encode(address1),
+            );
+            expect(decoded.accessList[0][1].length).to.equal(2);
+            expect(hex.encode(decoded.accessList[0][1][0])).to.equal(
+                hex.encode(storageKey1),
+            );
+            expect(hex.encode(decoded.accessList[0][1][1])).to.equal(
+                hex.encode(storageKey2),
+            );
+
+            // Verify roundtrip
+            expect(decoded.toBytes()).to.deep.equal(bytes);
+        });
+
+        it("toJSON produces correct access list format", function () {
+            const address1 = hex.decode(
+                "0000000000000000000000000000000000000001",
+            );
+            const storageKey1 = hex.decode(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            );
+
+            const tx = new EthereumTransactionDataEip2930({
+                chainId: hex.decode("01"),
+                nonce: hex.decode("01"),
+                gasPrice: hex.decode("0a"),
+                gasLimit: hex.decode("0a"),
+                to: hex.decode("0000000000000000000000000000000000000001"),
+                value: hex.decode("0a"),
+                callData: new Uint8Array(),
+                accessList: [[address1, [storageKey1]]],
+                recId: hex.decode("00"),
+                r: hex.decode(
+                    "38ba8bdbcd8684ff089b8efaf7b5aaf2071a11ab01b6cc65757af79f1199f2ef",
+                ),
+                s: hex.decode(
+                    "570b83f85d578427becab466ced52da857e2a9e48bf9ec5850cc2f541e9305e9",
+                ),
+            });
+
+            const json = tx.toJSON();
+            expect(json.accessList).to.be.an("array");
+            expect(json.accessList[0]).to.have.property("address");
+            expect(json.accessList[0]).to.have.property("storageKeys");
+            expect(json.accessList[0].storageKeys).to.be.an("array");
+        });
+    });
+
+    describe("EthereumTransactionDataEip1559 access list", function () {
+        it("toBytes and fromBytes preserve non-empty access list", function () {
+            const address1 = hex.decode(
+                "0000000000000000000000000000000000000001",
+            );
+            const storageKey1 = hex.decode(
+                "0000000000000000000000000000000000000000000000000000000000000001",
+            );
+
+            const original = new EthereumTransactionDataEip1559({
+                chainId: hex.decode("012a"),
+                nonce: hex.decode("02"),
+                maxPriorityGas: hex.decode("2f"),
+                maxGas: hex.decode("2f"),
+                gasLimit: hex.decode("018000"),
+                to: hex.decode("7e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181"),
+                value: hex.decode("0de0b6b3a7640000"),
+                callData: hex.decode("123456"),
+                accessList: [[address1, [storageKey1]]],
+                recId: hex.decode("01"),
+                r: hex.decode(
+                    "df48f2efd10421811de2bfb125ab75b2d3c44139c4642837fb1fccce911fd479",
+                ),
+                s: hex.decode(
+                    "1aaf7ae92bee896651dfc9d99ae422a296bf5d9f1ca49b2d96d82b79eb112d66",
+                ),
+            });
+
+            const bytes = original.toBytes();
+            const decoded = EthereumTransactionDataEip1559.fromBytes(bytes);
+
+            expect(decoded.accessList).to.be.an("array");
+            expect(decoded.accessList.length).to.equal(1);
+            expect(hex.encode(decoded.accessList[0][0])).to.equal(
+                hex.encode(address1),
+            );
+            expect(decoded.accessList[0][1].length).to.equal(1);
+            expect(hex.encode(decoded.accessList[0][1][0])).to.equal(
+                hex.encode(storageKey1),
+            );
+
+            // Verify roundtrip
+            expect(decoded.toBytes()).to.deep.equal(bytes);
+        });
     });
 
     describe("EthereumTransactionDataEip7702", function () {


### PR DESCRIPTION
  ## Summary
  - Fix TypeError: text.startsWith is not a function when decoding Ethereum
  transactions with non-empty access lists                                 
  - Properly decode access list entries as [address, storageKeys[]] tuples per
  EIP-2930 spec                                                               
  - Applied across EIP-2930 (type 1), EIP-1559 (type 2), and EIP-7702 (type 4)  
  - Closes #3885
