### PR TITLE
refactor: use generic Client<Channel, MirrorChannel> in topic/TopicId

### DIFF
--- a/src/topic/TopicDeleteTransaction.js
+++ b/src/topic/TopicDeleteTransaction.js
@@ -17,7 +17,8 @@ import TopicId from "./TopicId.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  * @typedef {import("../transaction/TransactionId.js").default} TransactionId
  */

--- a/src/topic/TopicId.js
+++ b/src/topic/TopicId.js
@@ -7,7 +7,9 @@ import * as util from "../util.js";
 
 /**
  * @typedef {import("long")} Long
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/Channel.js").default} Channel
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  */
 
 /**

--- a/src/topic/TopicInfoQuery.js
+++ b/src/topic/TopicInfoQuery.js
@@ -23,7 +23,8 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 


### PR DESCRIPTION
Fixes #3823

Replaced wildcard Client<*, *> typedef with properly typed Channel and MirrorChannel generics in:

- src/topic/TopicId.js (as required by the issue)
- src/topic/TopicDeleteTransaction.js (was causing type conflict with the updated TopicId.js)
- src/topic/TopicInfoQuery.js (was causing type conflict with the updated TopicId.js)

The two additional files were throwing "Unsafe argument of type 'Client<any, any>' assigned to a parameter of type 'Client<Channel, MirrorChannel>'" after updating TopicId.js, so they required the same fix to resolve the type conflicts.

All changes are typing-only. No runtime or behavior changes.