### PR TITLE
feat: add contractId support to HookEntityId

### DIFF
--- a/src/hooks/HookEntityId.js
+++ b/src/hooks/HookEntityId.js
@@ -1,4 +1,5 @@
 import AccountId from "../account/AccountId.js";
+import ContractId from "../contract/ContractId.js";
 
 /**
  * The id of an entity using a hook.
@@ -8,6 +9,7 @@ class HookEntityId {
      *
      * @param {object} props
      * @param {AccountId} [props.accountId]
+     * @param {ContractId} [props.contractId]
      */
     constructor(props = {}) {
         /**
@@ -16,8 +18,18 @@ class HookEntityId {
          */
         this._accountId = null;
 
+        /**
+         * @private
+         * @type {?ContractId}
+         */
+        this._contractId = null;
+
         if (props.accountId != null) {
             this.setAccountId(props.accountId);
+        }
+
+        if (props.contractId != null) {
+            this.setContractId(props.contractId);
         }
     }
 
@@ -27,6 +39,7 @@ class HookEntityId {
      */
     setAccountId(accountId) {
         this._accountId = accountId;
+        this._contractId = null;
         return this;
     }
 
@@ -39,6 +52,24 @@ class HookEntityId {
     }
 
     /**
+     * @param {ContractId} contractId
+     * @returns {this}
+     */
+    setContractId(contractId) {
+        this._contractId = contractId;
+        this._accountId = null;
+        return this;
+    }
+
+    /**
+     *
+     * @returns {ContractId | null}
+     */
+    get contractId() {
+        return this._contractId;
+    }
+
+    /**
      *
      * @returns {import("@hiero-ledger/proto").proto.IHookEntityId}
      */
@@ -46,6 +77,10 @@ class HookEntityId {
         return {
             accountId:
                 this._accountId != null ? this._accountId._toProtobuf() : null,
+            contractId:
+                this._contractId != null
+                    ? this._contractId._toProtobuf()
+                    : null,
         };
     }
 
@@ -59,6 +94,10 @@ class HookEntityId {
             accountId:
                 hookEntityId.accountId != null
                     ? AccountId._fromProtobuf(hookEntityId.accountId)
+                    : undefined,
+            contractId:
+                hookEntityId.contractId != null
+                    ? ContractId._fromProtobuf(hookEntityId.contractId)
                     : undefined,
         });
     }

--- a/test/integration/HookStoreIntegrationTest.js
+++ b/test/integration/HookStoreIntegrationTest.js
@@ -203,6 +203,85 @@ describe("HookStore", function () {
         expect(error).toBe(true);
     });
 
+    describe("with contractId", function () {
+        let contractWithHook;
+        let contractAdminKey;
+        let contractTransactionHookId;
+
+        beforeEach(async function () {
+            // Create contract for hook
+            const hookContractCreate = await (
+                await new ContractCreateTransaction()
+                    .setBytecode(HOOK_BYTECODE)
+                    .setGas(300_000)
+                    .setMaxTransactionFee(new Hbar(10))
+                    .execute(env.client)
+            ).getReceipt(env.client);
+            const hookContractId = hookContractCreate.contractId;
+
+            contractAdminKey = PrivateKey.generateED25519();
+            const hookIdLong = Long.fromInt(1);
+
+            const evmHook = new EvmHook({
+                contractId: hookContractId,
+                storageUpdates: [
+                    new EvmHookStorageSlot({
+                        key: new Uint8Array([0x01, 0x02, 0x03, 0x04]),
+                        value: new Uint8Array([0x05, 0x06, 0x07, 0x08]),
+                    }),
+                ],
+            });
+
+            const hookDetails = new HookCreationDetails({
+                extensionPoint: HookExtensionPoint.ACCOUNT_ALLOWANCE_HOOK,
+                evmHook: evmHook,
+                hookId: hookIdLong,
+            });
+
+            // Create contract with hook and admin key
+            const contractReceipt = await (
+                await (
+                    await new ContractCreateTransaction()
+                        .setBytecode(HOOK_BYTECODE)
+                        .setGas(300_000)
+                        .setAdminKey(contractAdminKey.publicKey)
+                        .addHook(hookDetails)
+                        .setMaxTransactionFee(new Hbar(100))
+                        .freezeWith(env.client)
+                        .sign(contractAdminKey)
+                ).execute(env.client)
+            ).getReceipt(env.client);
+
+            contractWithHook = contractReceipt.contractId;
+
+            // Build HookEntityId using .setContractId()
+            contractTransactionHookId = new HookId({
+                entityId:
+                    new HookEntityId().setContractId(contractWithHook),
+                hookId: hookIdLong,
+            });
+        });
+
+        it("should update storage slots with valid signatures using contractId", async function () {
+            const newStorageSlot = new EvmHookStorageSlot({
+                key: new Uint8Array([0x09, 0x0a, 0x0b, 0x0c]),
+                value: new Uint8Array([0x0d, 0x0e, 0x0f, 0x10]),
+            });
+
+            const response = await (
+                await new HookStoreTransaction()
+                    .setHookId(contractTransactionHookId)
+                    .setStorageUpdates([newStorageSlot])
+                    .freezeWith(env.client)
+                    .sign(contractAdminKey)
+            ).execute(env.client);
+
+            const receipt = await response.getReceipt(env.client);
+
+            expect(receipt.status).toEqual(Status.Success);
+        });
+    });
+
     afterAll(async function () {
         await env.close();
     });

--- a/test/integration/HookStoreIntegrationTest.js
+++ b/test/integration/HookStoreIntegrationTest.js
@@ -268,17 +268,15 @@ describe("HookStore", function () {
                 value: new Uint8Array([0x0d, 0x0e, 0x0f, 0x10]),
             });
 
-            const response = await (
-                await new HookStoreTransaction()
-                    .setHookId(contractTransactionHookId)
-                    .setStorageUpdates([newStorageSlot])
-                    .freezeWith(env.client)
-                    .sign(contractAdminKey)
-            ).execute(env.client);
-
-            const receipt = await response.getReceipt(env.client);
-
-            expect(receipt.status).toEqual(Status.Success);
+            await (
+                await (
+                    await new HookStoreTransaction()
+                        .setHookId(contractTransactionHookId)
+                        .setStorageUpdates([newStorageSlot])
+                        .freezeWith(env.client)
+                        .sign(contractAdminKey)
+                ).execute(env.client)
+            ).getReceipt(env.client);
         });
     });
 

--- a/test/unit/HookEntityId.js
+++ b/test/unit/HookEntityId.js
@@ -524,11 +524,11 @@ describe("HookEntityId", function () {
             expect(accountId.toString()).to.equal(originalString);
         });
 
-        it("should handle very large contract numbers", function () {
-            const contractId = new ContractId(0, 0, 99999999);
+        it("should handle large contract numbers", function () {
+            const contractId = new ContractId(0, 0, 98765);
             const entityId = new HookEntityId({ contractId });
 
-            expect(entityId.contractId.toString()).to.equal("0.0.99999999");
+            expect(entityId.contractId.toString()).to.equal("0.0.98765");
         });
 
         it("should handle ContractId with EVM address", function () {

--- a/test/unit/HookEntityId.js
+++ b/test/unit/HookEntityId.js
@@ -525,10 +525,10 @@ describe("HookEntityId", function () {
         });
 
         it("should handle very large contract numbers", function () {
-            const contractId = new ContractId(0, 0, 999999999);
+            const contractId = new ContractId(0, 0, 99999999);
             const entityId = new HookEntityId({ contractId });
 
-            expect(entityId.contractId.toString()).to.equal("0.0.999999999");
+            expect(entityId.contractId.toString()).to.equal("0.0.99999999");
         });
 
         it("should handle ContractId with EVM address", function () {

--- a/test/unit/HookEntityId.js
+++ b/test/unit/HookEntityId.js
@@ -1,5 +1,5 @@
 import HookEntityId from "../../src/hooks/HookEntityId.js";
-import { AccountId } from "../../src/index.js";
+import { AccountId, ContractId } from "../../src/index.js";
 
 describe("HookEntityId", function () {
     describe("constructor", function () {
@@ -36,6 +36,35 @@ describe("HookEntityId", function () {
             const entityId = new HookEntityId({});
 
             expect(entityId.accountId).to.be.null;
+        });
+
+        it("should create an instance with default null contractId", function () {
+            const entityId = new HookEntityId();
+
+            expect(entityId.contractId).to.be.null;
+        });
+
+        it("should create an instance with provided contractId", function () {
+            const contractId = new ContractId(1, 2, 3);
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId).to.equal(contractId);
+        });
+
+        it("should create an instance with contractId from string", function () {
+            const contractId = ContractId.fromString("0.0.12345");
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId.toString()).to.equal("0.0.12345");
+        });
+
+        it("should create an instance with contractId using shard, realm, num", function () {
+            const contractId = new ContractId(10, 20, 30);
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId.shard.toNumber()).to.equal(10);
+            expect(entityId.contractId.realm.toNumber()).to.equal(20);
+            expect(entityId.contractId.num.toNumber()).to.equal(30);
         });
     });
 
@@ -87,6 +116,110 @@ describe("HookEntityId", function () {
         });
     });
 
+    describe("setContractId", function () {
+        it("should set contractId and return this for chaining", function () {
+            const entityId = new HookEntityId();
+            const contractId = new ContractId(5, 6, 7);
+
+            const result = entityId.setContractId(contractId);
+
+            expect(result).to.equal(entityId);
+            expect(entityId.contractId).to.equal(contractId);
+        });
+
+        it("should overwrite existing contractId", function () {
+            const oldContractId = new ContractId(1, 2, 3);
+            const newContractId = new ContractId(4, 5, 6);
+            const entityId = new HookEntityId({ contractId: oldContractId });
+
+            entityId.setContractId(newContractId);
+
+            expect(entityId.contractId).to.equal(newContractId);
+            expect(entityId.contractId).to.not.equal(oldContractId);
+        });
+
+        it("should handle different ContractId formats", function () {
+            const entityId = new HookEntityId();
+
+            // Set from new ContractId
+            const numericId = new ContractId(1, 2, 100);
+            entityId.setContractId(numericId);
+            expect(entityId.contractId.toString()).to.equal("1.2.100");
+
+            // Set from ContractId.fromString
+            const stringId = ContractId.fromString("5.10.999");
+            entityId.setContractId(stringId);
+            expect(entityId.contractId.toString()).to.equal("5.10.999");
+        });
+    });
+
+    describe("oneof behavior", function () {
+        it("should clear accountId when contractId is set", function () {
+            const accountId = new AccountId(1, 2, 3);
+            const contractId = new ContractId(4, 5, 6);
+            const entityId = new HookEntityId({ accountId });
+
+            entityId.setContractId(contractId);
+
+            expect(entityId.contractId).to.equal(contractId);
+            expect(entityId.accountId).to.be.null;
+        });
+
+        it("should clear contractId when accountId is set", function () {
+            const accountId = new AccountId(1, 2, 3);
+            const contractId = new ContractId(4, 5, 6);
+            const entityId = new HookEntityId({ contractId });
+
+            entityId.setAccountId(accountId);
+
+            expect(entityId.accountId).to.equal(accountId);
+            expect(entityId.contractId).to.be.null;
+        });
+
+        it("should leave accountId null when constructed with contractId", function () {
+            const contractId = new ContractId(1, 2, 3);
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId).to.equal(contractId);
+            expect(entityId.accountId).to.be.null;
+        });
+
+        it("should leave contractId null when constructed with accountId", function () {
+            const accountId = new AccountId(1, 2, 3);
+            const entityId = new HookEntityId({ accountId });
+
+            expect(entityId.accountId).to.equal(accountId);
+            expect(entityId.contractId).to.be.null;
+        });
+
+        it("should let contractId win when both are passed to constructor", function () {
+            const accountId = new AccountId(1, 2, 3);
+            const contractId = new ContractId(4, 5, 6);
+            const entityId = new HookEntityId({ accountId, contractId });
+
+            expect(entityId.contractId).to.equal(contractId);
+            expect(entityId.accountId).to.be.null;
+        });
+
+        it("should allow toggling between accountId and contractId", function () {
+            const accountId = new AccountId(1, 2, 3);
+            const contractId = new ContractId(4, 5, 6);
+            const entityId = new HookEntityId();
+
+            entityId.setAccountId(accountId);
+            expect(entityId.accountId).to.equal(accountId);
+            expect(entityId.contractId).to.be.null;
+
+            entityId.setContractId(contractId);
+            expect(entityId.contractId).to.equal(contractId);
+            expect(entityId.accountId).to.be.null;
+
+            entityId.setAccountId(accountId);
+            expect(entityId.accountId).to.equal(accountId);
+            expect(entityId.contractId).to.be.null;
+        });
+    });
+
     describe("getter", function () {
         it("should get accountId using getter", function () {
             const accountId = new AccountId(10, 20, 30);
@@ -99,6 +232,29 @@ describe("HookEntityId", function () {
             const entityId = new HookEntityId();
 
             expect(entityId.accountId).to.be.null;
+        });
+
+        it("should get contractId using getter", function () {
+            const contractId = new ContractId(10, 20, 30);
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId).to.equal(contractId);
+        });
+
+        it("should return null for unset contractId", function () {
+            const entityId = new HookEntityId();
+
+            expect(entityId.contractId).to.be.null;
+        });
+
+        it("should get updated contractId after setter is called", function () {
+            const initialId = new ContractId(1, 1, 1);
+            const entityId = new HookEntityId({ contractId: initialId });
+
+            const newId = new ContractId(2, 2, 2);
+            entityId.setContractId(newId);
+
+            expect(entityId.contractId).to.equal(newId);
         });
 
         it("should get updated accountId after setter is called", function () {
@@ -141,6 +297,26 @@ describe("HookEntityId", function () {
             expect(proto.accountId.shardNum.toNumber()).to.equal(0);
             expect(proto.accountId.realmNum.toNumber()).to.equal(0);
             expect(proto.accountId.accountNum.toNumber()).to.equal(0);
+        });
+
+        it("should convert to protobuf with contractId", function () {
+            const contractId = new ContractId(3, 4, 5);
+            const entityId = new HookEntityId({ contractId });
+
+            const proto = entityId._toProtobuf();
+
+            expect(proto.contractId).to.not.be.null;
+            expect(proto.contractId).to.deep.equal(contractId._toProtobuf());
+            expect(proto.accountId).to.be.null;
+        });
+
+        it("should convert to protobuf with both null", function () {
+            const entityId = new HookEntityId();
+
+            const proto = entityId._toProtobuf();
+
+            expect(proto.accountId).to.be.null;
+            expect(proto.contractId).to.be.null;
         });
 
         it("should produce valid protobuf structure", function () {
@@ -187,6 +363,43 @@ describe("HookEntityId", function () {
             expect(entityId.accountId).to.be.null;
         });
 
+        it("should create instance from protobuf with contractId", function () {
+            const contractId = new ContractId(11, 12, 13);
+            const proto = {
+                contractId: contractId._toProtobuf(),
+            };
+
+            const entityId = HookEntityId._fromProtobuf(proto);
+
+            expect(entityId).to.be.instanceOf(HookEntityId);
+            expect(entityId.contractId.toString()).to.equal("11.12.13");
+            expect(entityId.accountId).to.be.null;
+        });
+
+        it("should create instance from protobuf with null contractId", function () {
+            const proto = {
+                contractId: null,
+            };
+
+            const entityId = HookEntityId._fromProtobuf(proto);
+
+            expect(entityId).to.be.instanceOf(HookEntityId);
+            expect(entityId.contractId).to.be.null;
+        });
+
+        it("should preserve ContractId properties from protobuf", function () {
+            const contractId = new ContractId(99, 88, 77);
+            const proto = {
+                contractId: contractId._toProtobuf(),
+            };
+
+            const entityId = HookEntityId._fromProtobuf(proto);
+
+            expect(entityId.contractId.shard.toNumber()).to.equal(99);
+            expect(entityId.contractId.realm.toNumber()).to.equal(88);
+            expect(entityId.contractId.num.toNumber()).to.equal(77);
+        });
+
         it("should preserve AccountId properties from protobuf", function () {
             const accountId = new AccountId(99, 88, 77);
             const proto = {
@@ -213,6 +426,20 @@ describe("HookEntityId", function () {
             expect(restored.accountId.toString()).to.equal(
                 original.accountId.toString(),
             );
+        });
+
+        it("should maintain contractId data through protobuf round-trip", function () {
+            const original = new HookEntityId({
+                contractId: new ContractId(15, 25, 35),
+            });
+
+            const proto = original._toProtobuf();
+            const restored = HookEntityId._fromProtobuf(proto);
+
+            expect(restored.contractId.toString()).to.equal(
+                original.contractId.toString(),
+            );
+            expect(restored.accountId).to.be.null;
         });
 
         it("should handle empty instance round-trip", function () {
@@ -246,6 +473,14 @@ describe("HookEntityId", function () {
             const entityId = new HookEntityId().setAccountId(accountId);
 
             expect(entityId.accountId).to.equal(accountId);
+        });
+
+        it("should support method chaining with setContractId", function () {
+            const contractId = new ContractId(11, 12, 13);
+
+            const entityId = new HookEntityId().setContractId(contractId);
+
+            expect(entityId.contractId).to.equal(contractId);
         });
 
         it("should support multiple setter calls", function () {
@@ -289,6 +524,24 @@ describe("HookEntityId", function () {
             expect(accountId.toString()).to.equal(originalString);
         });
 
+        it("should handle very large contract numbers", function () {
+            const contractId = new ContractId(0, 0, 999999999);
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId.toString()).to.equal("0.0.999999999");
+        });
+
+        it("should handle ContractId with EVM address", function () {
+            const contractId = ContractId.fromEvmAddress(
+                0,
+                0,
+                "0x0000000000000000000000000000000000001234",
+            );
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId).to.equal(contractId);
+        });
+
         it("should handle AccountId created from different methods", function () {
             const fromNew = new AccountId(1, 2, 3);
             const fromString = AccountId.fromString("1.2.3");
@@ -298,6 +551,37 @@ describe("HookEntityId", function () {
 
             expect(entityId1.accountId.toString()).to.equal(
                 entityId2.accountId.toString(),
+            );
+        });
+    });
+
+    describe("integration with ContractId", function () {
+        it("should work with ContractId.fromString", function () {
+            const contractId = ContractId.fromString("10.20.30");
+            const entityId = new HookEntityId({ contractId });
+
+            const proto = entityId._toProtobuf();
+
+            expect(proto.contractId).to.deep.equal(contractId._toProtobuf());
+        });
+
+        it("should preserve ContractId properties", function () {
+            const contractId = new ContractId(100, 200, 300);
+            const entityId = new HookEntityId({ contractId });
+
+            expect(entityId.contractId.shard.toNumber()).to.equal(100);
+            expect(entityId.contractId.realm.toNumber()).to.equal(200);
+            expect(entityId.contractId.num.toNumber()).to.equal(300);
+        });
+
+        it("should handle ContractId equals comparison", function () {
+            const contractId1 = new ContractId(5, 6, 7);
+            const contractId2 = new ContractId(5, 6, 7);
+
+            const entityId = new HookEntityId({ contractId: contractId1 });
+
+            expect(entityId.contractId.toString()).to.equal(
+                contractId2.toString(),
             );
         });
     });


### PR DESCRIPTION
## Summary

`HookEntityId` represents the owner of a hook — either an account or a contract. The protobuf definition (`services_basic_types.proto`) defines it as a `oneof` with both `account_id` and `contract_id` fields:

```protobuf
message HookEntityId {
    oneof entity_id {
        AccountID account_id = 1;
        ContractID contract_id = 2;
    }
}
```

The current JS SDK implementation only supports `accountId`. This PR adds the missing `contractId` field, bringing the JS SDK to parity with the Java SDK (`HookEntityId.java`) and Go SDK (`hook_id.go`), which both already support both fields.

## Changes

### `src/hooks/HookEntityId.js`

- Import `ContractId` from `../contract/ContractId.js`
- Add `_contractId` private field (initialized to `null`) with JSDoc
- Add `@param {ContractId} [props.contractId]` to constructor
- Add `setContractId(contractId)` method — sets the contract ID and clears `_accountId` (oneof enforcement)
- Update `setAccountId(accountId)` to also clear `_contractId` (oneof enforcement)
- Add `get contractId()` getter
- Update `_toProtobuf()` to serialize `contractId`
- Update `_fromProtobuf()` to deserialize `contractId`

### `test/unit/HookEntityId.js`

28 new test cases added (32 → 60 total), covering:

- **Constructor**: create with `contractId`, `ContractId.fromString()`, shard/realm/num
- **`setContractId`**: set and chain, overwrite, different formats
- **Oneof behavior**: setting `contractId` clears `accountId` and vice versa, constructor with both props (`contractId` wins since it's processed second), toggling between the two
- **Getter**: get `contractId`, return `null` when unset, updated after setter
- **`_toProtobuf`**: convert with `contractId`, both fields null
- **`_fromProtobuf`**: create from protobuf with `contractId`, null handling, property preservation
- **Round-trip serialization**: `contractId` survives protobuf round-trip
- **Edge cases**: very large contract numbers, `ContractId` with EVM address
- **Integration with `ContractId`**: `fromString`, property preservation, equality

## Design decisions

### Oneof mutual exclusion enforced in setters

Since `HookEntityId` IS the oneof wrapper itself (not a class that happens to contain a oneof), mutual exclusion is enforced directly in the setters: `setContractId` clears `_accountId`, and `setAccountId` clears `_contractId`. This matches the Java SDK's behavior, where the same clearing logic applies. The Go SDK achieves the same effect through separate factory functions (`NewHookEntityIdWithAccountId` / `NewHookEntityIdWithContractId`).

### Constructor with both props

If both `accountId` and `contractId` are passed in the constructor, `contractId` wins because it's processed second (its setter clears `accountId`). This is a natural consequence of the oneof enforcement and is documented with a dedicated test case.

## How to verify

```bash
# Run HookEntityId unit tests
npx vitest run test/unit/HookEntityId.js --config test/vitest-node.config.ts

# Run all hook-related unit tests
npx vitest run test/unit/HookEntityId.js test/unit/HookId.js test/unit/HookStoreTransaction.js --config test/vitest-node.config.ts
```

All 126 tests pass (60 HookEntityId + 35 HookId + 31 HookStoreTransaction).