### PR TITLE
fix: exclude more spam from slack bot

### DIFF
--- a/.github/workflows/slack-issue-comment-notify.yml
+++ b/.github/workflows/slack-issue-comment-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ !github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' && github.event.comment.user.login != 'lfdt-bot' }}
+    if: ${{ !github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' && github.event.comment.user.login != 'lfdt-bot' && github.event.comment.user.login != 'codecov[bot]' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/slack-issue-comment-notify.yml
+++ b/.github/workflows/slack-issue-comment-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ !github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' }}
+    if: ${{ !github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' && github.event.comment.user.login != 'lfdt-bot' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/slack-issue-notify.yml
+++ b/.github/workflows/slack-issue-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ github.event.issue.user.login != 'dependabot[bot]' && github.event.issue.user.login != 'codacy-production[bot]' && github.event.issue.user.login != 'lfdt-bot' }}
+    if: ${{ github.event.issue.user.login != 'dependabot[bot]' && github.event.issue.user.login != 'codacy-production[bot]' && github.event.issue.user.login != 'lfdt-bot' && github.event.issue.user.login != 'codecov[bot]' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/slack-issue-notify.yml
+++ b/.github/workflows/slack-issue-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ github.event.issue.user.login != 'dependabot[bot]' && github.event.issue.user.login != 'codacy-production[bot]' }}
+    if: ${{ github.event.issue.user.login != 'dependabot[bot]' && github.event.issue.user.login != 'codacy-production[bot]' && github.event.issue.user.login != 'lfdt-bot' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/slack-merge-notify.yml
+++ b/.github/workflows/slack-merge-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
     notify-slack:
         name: Notify Slack
-        if: ${{ github.event.pull_request.merged == true && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' && github.event.pull_request.user.login != 'lfdt-bot' }}
+        if: ${{ github.event.pull_request.merged == true && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' && github.event.pull_request.user.login != 'lfdt-bot' && github.event.pull_request.user.login != 'codecov[bot]' }}
         runs-on: hiero-client-sdk-linux-medium
         steps:
             - name: Harden Runner

--- a/.github/workflows/slack-merge-notify.yml
+++ b/.github/workflows/slack-merge-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
     notify-slack:
         name: Notify Slack
-        if: ${{ github.event.pull_request.merged == true && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' }}
+        if: ${{ github.event.pull_request.merged == true && github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' && github.event.pull_request.user.login != 'lfdt-bot' }}
         runs-on: hiero-client-sdk-linux-medium
         steps:
             - name: Harden Runner

--- a/.github/workflows/slack-pr-comment-notify.yml
+++ b/.github/workflows/slack-pr-comment-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' && github.event.comment.user.login != 'lfdt-bot' }}
+    if: ${{ github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' && github.event.comment.user.login != 'lfdt-bot' && github.event.comment.user.login != 'codecov[bot]' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/slack-pr-comment-notify.yml
+++ b/.github/workflows/slack-pr-comment-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' }}
+    if: ${{ github.event.issue.pull_request && github.event.comment.user.login != 'dependabot[bot]' && github.event.comment.user.login != 'codacy-production[bot]' && github.event.comment.user.login != 'lfdt-bot' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/slack-pr-notify.yml
+++ b/.github/workflows/slack-pr-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' && github.event.pull_request.user.login != 'lfdt-bot' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' && github.event.pull_request.user.login != 'lfdt-bot' && github.event.pull_request.user.login != 'codecov[bot]' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner

--- a/.github/workflows/slack-pr-notify.yml
+++ b/.github/workflows/slack-pr-notify.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   notify-slack:
     name: Notify Slack
-    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' }}
+    if: ${{ github.event.pull_request.user.login != 'dependabot[bot]' && github.event.pull_request.user.login != 'codacy-production[bot]' && github.event.pull_request.user.login != 'lfdt-bot' }}
     runs-on: hiero-client-sdk-linux-medium
     steps:
       - name: Harden Runner


### PR DESCRIPTION
**Description**:
Exclude lfdt bot and codecov bot from spamming slack channels. 

**Related issue(s)**:

Fixes #

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
