### PR TITLE
ci: reenable fee-estimate tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -109,7 +109,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@4d42a74e8e644a2753f3bb7a2afa429305375b14 # v0.17
         with:
           installMirrorNode: true
-          soloVersion: v0.69.0
+          soloVersion: v0.65.0
           hieroVersion: v0.73.0
           mirrorNodeVersion: v0.153.0
           grpcProxyPort: 8080
@@ -197,7 +197,7 @@ jobs:
         uses: hiero-ledger/hiero-solo-action@4d42a74e8e644a2753f3bb7a2afa429305375b14 # 0.17.0
         with:
           installMirrorNode: true
-          soloVersion: v0.69.0
+          soloVersion: v0.65.0
           hieroVersion: v0.73.0
           mirrorNodeVersion: 0.153.0
           grpcProxyPort: 8080
@@ -312,7 +312,7 @@ jobs:
           installMirrorNode: true
           hieroVersion: v0.73.0
           mirrorNodeVersion: v0.153.0
-          soloVersion: v0.69.0
+          soloVersion: v0.65.0
           grpcProxyPort: 8080
 
       - name: Set Operator Account

--- a/test/integration/FeeEstimateQueryIntegrationTest.js
+++ b/test/integration/FeeEstimateQueryIntegrationTest.js
@@ -32,7 +32,7 @@ import { createFungibleToken } from "./utils/Fixtures.js";
  * Verified working against previewnet. Re-enable once the cross-team
  * fix lands (mirror startup ordering or shorter refresh-interval default).
  */
-describe.skip("FeeEstimateQuery Integration", function () {
+describe("FeeEstimateQuery Integration", function () {
     let env;
 
     beforeAll(async function () {


### PR DESCRIPTION
**Description**:
This re-enables fee estimate integration tests as it seem to be stable with solo version 0.65.0
