### PR TITLE
test(account): add unit tests for NullableTokenDecimalMap class

### DIFF
--- a/test/unit/account/NullableTokenDecimalMap.js
+++ b/test/unit/account/NullableTokenDecimalMap.js
@@ -1,0 +1,20 @@
+import NullableTokenDecimalMap from "../../../src/account/NullableTokenDecimalMap.js";
+import TokenId from "../../../src/token/TokenId.js";
+
+describe("NullableTokenDecimalMap", function () {
+    it("should instantiate without throwing and return a valid instance", function () {
+        const map = new NullableTokenDecimalMap();
+        expect(map).to.be.instanceOf(NullableTokenDecimalMap);
+    });
+
+    it("should correctly parse TokenId strings as keys using _set and get", function () {
+        const map = new NullableTokenDecimalMap();
+        // Since TokenId.fromString is used behind the scenes, keys should be recognized.
+        map._set("0.0.1234", 100);
+        expect(map.get("0.0.1234")).to.equal(100);
+
+        // Ensure the string was mapped using TokenId correctly
+        const tokenId = TokenId.fromString("0.0.1234");
+        expect(map.get(tokenId)).to.equal(100);
+    });
+});


### PR DESCRIPTION
**Description:**

Add unit tests for NullableTokenDecimalMap to improve test coverage.

Add new test file test/unit/account/NullableTokenDecimalMap.test.js
Verify instance creation without errors
Test key mapping behavior using both string and TokenId inputs
Ensure constructor logic is covered

**Related issue(s):**

Fixes #3965 

**Notes for reviewer**

This PR introduces unit tests for NullableTokenDecimalMap, which previously had no test coverage.

**The tests:**

Confirm that an instance can be created successfully
Validate that string keys are correctly parsed via TokenId.fromString
Verify consistent behavior when using both string and TokenId keys

All unit tests pass successfully and no production code has been modified.

**Checklist:**
 []   Documented (Code comments, README, etc.)
 [x] Tested (unit, integration, etc.)