### PR TITLE
test: add NullableTokenDecimalMap unit test

### DIFF
--- a/test/unit/account/NullableTokenDecimalMap.js
+++ b/test/unit/account/NullableTokenDecimalMap.js
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import NullableTokenDecimalMap from "../../../src/account/NullableTokenDecimalMap.js";
+
+describe("NullableTokenDecimalMap", function () {
+    it("should construct a NullableTokenDecimalMap", function () {
+        const map = new NullableTokenDecimalMap();
+
+        expect(map).toBeInstanceOf(NullableTokenDecimalMap);
+    });
+});


### PR DESCRIPTION
Description:

Add unit test coverage for NullableTokenDecimalMap.

* Add NullableTokenDecimalMap unit test
* Verify that a new NullableTokenDecimalMap instance can be constructed
* Verify that the result is an instance of NullableTokenDecimalMap

Related issue:

Fixes #3965

Notes for reviewer:

Tested locally with this in the terminal : pnpm vitest run test/unit/account/NullableTokenDecimalMap.js --config test/vitest-node.config.ts
task lint

Checklist

* Tested 
