### PR TITLE
fix(PrivateKey): replace try-catch DER heuristic with deterministic prefix check

### DIFF
--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -533,14 +533,16 @@ export default class PrivateKey extends Key {
      * @returns {boolean}
      */
     static isDerKey(key) {
-        try {
-            const data = Uint8Array.from(decode(key));
-            const decoder = new ASN1Decoder(data);
-            decoder.read(); // Attempt to read the ASN.1 structure
-            return true;
-        } catch (error) {
-            return false;
-        }
+        const lower = key.toLowerCase();
+        // DER-encoded private keys in the SDK are always PKCS#8 structures whose
+        // AlgorithmIdentifier is fixed for each supported algorithm.  Matching the
+        // first 16 bytes (32 hex chars) of that fixed prefix is O(1), deterministic,
+        // and avoids the ~2.8 % false-positive rate of the old try-catch ASN.1 parse
+        // (any raw key whose first byte is a valid ASN.1 tag would pass silently).
+        return (
+            lower.startsWith("302e020100300506032b657004220420") || // Ed25519 PKCS#8
+            lower.startsWith("3030020100300706052b8104000a0422") //   ECDSA secp256k1 PKCS#8
+        );
     }
 }
 

--- a/src/PrivateKey.js
+++ b/src/PrivateKey.js
@@ -533,15 +533,24 @@ export default class PrivateKey extends Key {
      * @returns {boolean}
      */
     static isDerKey(key) {
-        const lower = key.toLowerCase();
-        // DER-encoded private keys in the SDK are always PKCS#8 structures whose
-        // AlgorithmIdentifier is fixed for each supported algorithm.  Matching the
-        // first 16 bytes (32 hex chars) of that fixed prefix is O(1), deterministic,
-        // and avoids the ~2.8 % false-positive rate of the old try-catch ASN.1 parse
-        // (any raw key whose first byte is a valid ASN.1 tag would pass silently).
+        // The SDK encodes private keys with one of three fixed DER prefixes.
+        // Matching the leading bytes is O(1), deterministic, and avoids the
+        // ~2.8 % false-positive rate of the previous try-catch ASN.1 parse
+        // (any raw key whose first byte happened to be a valid ASN.1 tag
+        // would pass silently).
+        //
+        // The Ed25519 prefix is forced by RFC 8410 §3 (parameters MUST be
+        // absent for id-Ed25519) + RFC 5958 §2 + DER's shortest-length rule,
+        // so any conformant Ed25519 PKCS#8 v1 key starts with these bytes.
+        // The two ECDSA prefixes are the Hedera-style PKCS#8 (with the
+        // secp256k1 OID embedded directly as the algorithm OID) and the
+        // bare SEC1 ECPrivateKey SEQUENCE from RFC 5915 §3, both of which
+        // EcdsaPrivateKey.fromBytesDer accepts.
+        const lower = (key.startsWith("0x") ? key.slice(2) : key).toLowerCase();
         return (
             lower.startsWith("302e020100300506032b657004220420") || // Ed25519 PKCS#8
-            lower.startsWith("3030020100300706052b8104000a0422") //   ECDSA secp256k1 PKCS#8
+            lower.startsWith("3030020100300706052b8104000a0422") || // ECDSA secp256k1 PKCS#8 (Hedera)
+            lower.startsWith("30540201010420") //                     ECDSA secp256k1 SEC1 / RFC 5915
         );
     }
 }

--- a/test/unit/PrivateKey.js
+++ b/test/unit/PrivateKey.js
@@ -232,6 +232,27 @@ describe("PrivateKey", function () {
             expect(PrivateKey.isDerKey(rawKey)).to.be.false;
         });
 
+        it("should detect ECDSA SEC1 / RFC 5915 encoded keys", function () {
+            // SEC1 ECPrivateKey: SEQUENCE { INTEGER 1, OCTET STRING(32) <key>, [0] secp256k1 OID, [1] pubkey }
+            const sec1Key =
+                "30540201010420" +
+                "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef" +
+                "a00706052b8104000a";
+            expect(PrivateKey.isDerKey(sec1Key)).to.be.true;
+        });
+
+        it("should accept keys with a 0x prefix", function () {
+            const derKey = "0x" + PrivateKey.generateED25519().toStringDer();
+            expect(PrivateKey.isDerKey(derKey)).to.be.true;
+        });
+
+        it("should accept uppercase DER hex", function () {
+            const derKey = PrivateKey.generateED25519()
+                .toStringDer()
+                .toUpperCase();
+            expect(PrivateKey.isDerKey(derKey)).to.be.true;
+        });
+
         it("should generate key from der string on ecdsa", function () {
             const derKey = PrivateKey.generateECDSA().toStringDer();
             const key = PrivateKey.fromStringDer(derKey);

--- a/test/unit/PrivateKey.js
+++ b/test/unit/PrivateKey.js
@@ -224,8 +224,12 @@ describe("PrivateKey", function () {
         });
 
         it("should return false if the key is not a DER key", function () {
-            const derKey = PrivateKey.generateECDSA().toStringRaw();
-            expect(PrivateKey.isDerKey(derKey)).to.be.false;
+            // Use a fixed raw key string instead of a randomly generated one.
+            // Generating a random ECDSA key here is flaky: ~2.8 % of raw keys happen
+            // to start with a valid ASN.1 tag byte (0x02/0x03/0x04/0x06/0x30/0xa0/0xa1),
+            // which caused the old try-catch heuristic in isDerKey to return true.
+            const rawKey = "aa".repeat(32); // 64 hex chars, first byte 0xaa is not a DER tag
+            expect(PrivateKey.isDerKey(rawKey)).to.be.false;
         });
 
         it("should generate key from der string on ecdsa", function () {


### PR DESCRIPTION
## Summary

- `PrivateKey.isDerKey` previously used a try-catch ASN.1 parse to detect DER encoding — any raw key whose first byte happened to be a valid ASN.1 tag (≈2.8 % of randomly generated ECDSA keys) would silently pass and return `true`, causing intermittent test failure
- Replaced with an O(1) prefix comparison against the two fixed PKCS#8 AlgorithmIdentifier headers for the SDK's supported key types (Ed25519 and ECDSA secp256k1)
- Hardened the negative unit test to use a fixed, deterministic hex string instead of a freshly generated random key

## Root cause

`ASN1Decoder.read()` only inspects the outer ASN.1 tag byte and declared length; it does **not** validate that the structure is specifically a PKCS#8 private key. The 7 valid tag values `{0x02, 0x03, 0x04, 0x06, 0x30, 0xa0, 0xa1}` cover 7/256 ≈ 2.8 % of the first-byte range, so roughly 1-in-36 raw ECDSA keys would pass the old heuristic undetected.

## Test plan

- [x] All 19 `test/unit/PrivateKey.js` tests pass (`task test:unit:node -- test/unit/PrivateKey.js`)
- [x] `isDerKey` returns `true` for Ed25519 and ECDSA DER keys, `false` for raw keys and arbitrary strings
- [ ] `task test:unit:browser -- test/unit/PrivateKey.js`
- [ ] `task lint`
- [ ] All CI checks pass

Closes #4005

🤖 Generated with [Claude Code](https://claude.com/claude-code)