### PR TITLE
test: add SubscriptionHandle unit tests

### DIFF
--- a/test/unit/topic/SubscriptionHandle.js
+++ b/test/unit/topic/SubscriptionHandle.js
@@ -1,0 +1,26 @@
+import SubscriptionHandle from "../../../src/topic/SubscriptionHandle.js";
+
+describe("SubscriptionHandle", function () {
+    it("unsubscribe calls the stored callback", function () {
+        const handle = new SubscriptionHandle();
+        let called = false;
+        handle._setCall(() => {
+            called = true;
+        });
+        handle.unsubscribe();
+        expect(called).to.be.true;
+    });
+
+    it("unsubscribe sets _unsubscribed to true", function () {
+        const handle = new SubscriptionHandle();
+        handle._setCall(() => {});
+        handle.unsubscribe();
+        expect(handle._unsubscribed).to.be.true;
+    });
+
+    it("unsubscribe does nothing when no callback is set", function () {
+        const handle = new SubscriptionHandle();
+        expect(() => handle.unsubscribe()).to.not.throw();
+        expect(handle._unsubscribed).to.be.false;
+    });
+});


### PR DESCRIPTION
**Description**:

Add unit tests for `SubscriptionHandle`.

* Add tests for `unsubscribe()` calling the stored callback
* Add tests for `_unsubscribed` being set to `true`
* Add tests for `unsubscribe()` doing nothing when no callback is set

**Related issue(s)**:

Fixes #4029

**Notes for reviewer**:

Tested with:

```bash
task test:unit:node -- test/unit/topic/SubscriptionHandle.js
task test:unit:browser -- test/unit/topic/SubscriptionHandle.js
npx prettier test/unit/topic/SubscriptionHandle.js --check
