### PR TITLE
test: add MirrorChannel unit coverage

### DIFF
--- a/test/unit/channel/MirrorChannel.js
+++ b/test/unit/channel/MirrorChannel.js
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import MirrorChannel from "../../../src/channel/MirrorChannel.js";
+
+class TestMirrorChannel extends MirrorChannel {
+    constructor() {
+        super();
+
+        this.closed = false;
+        this.serverStreamRequested = false;
+        this.serverStreamCancelled = false;
+    }
+
+    close() {
+        this.closed = true;
+    }
+
+    makeServerStreamRequest() {
+        this.serverStreamRequested = true;
+
+        return () => {
+            this.serverStreamCancelled = true;
+        };
+    }
+}
+
+describe("MirrorChannel", function () {
+    it("should throw 'not implemented' when close() is called directly", function () {
+        const channel = new MirrorChannel();
+
+        expect(() => channel.close()).to.throw("not implemented");
+    });
+
+    it("should throw 'not implemented' when makeServerStreamRequest() is called directly", function () {
+        const channel = new MirrorChannel();
+
+        expect(() => channel.makeServerStreamRequest()).to.throw(
+            "not implemented",
+        );
+    });
+
+    it("should allow subclasses to override abstract methods", function () {
+        const channel = new TestMirrorChannel();
+
+        expect(() => channel.close()).to.not.throw();
+        expect(channel.closed).to.be.true;
+
+        const cancel = channel.makeServerStreamRequest();
+
+        expect(channel.serverStreamRequested).to.be.true;
+        expect(() => cancel()).to.not.throw();
+        expect(channel.serverStreamCancelled).to.be.true;
+    });
+});


### PR DESCRIPTION
Add unit coverage for the MirrorChannel abstract base class.

This PR adds tests for:
- close() throwing "not implemented" when called directly
- makeServerStreamRequest() throwing "not implemented" when called directly
- subclass overrides for both methods being callable without throwing

Note: issue #4010 mentions makeUnaryRequest(), but the current MirrorChannel abstract interface exposes makeServerStreamRequest(). This PR covers the current implementation without production-code changes.

Verification:
- npx prettier --check test/unit/channel/MirrorChannel.js
- npx eslint test/unit/channel/MirrorChannel.js
- npx vitest --config=test/vitest-node.config.ts test/unit/channel/MirrorChannel.js
- npx vitest --config=test/vitest-browser.config.ts test/unit/channel/MirrorChannel.js

Fixes #4010