### PR TITLE
docs: fix broken Solo documentation links (#4052)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,7 +60,7 @@ To run integration tests locally, you need to set up [Solo](https://solo.hiero.o
 - **Platform:** macOS or Linux only (Windows users must use WSL2)
 - **RAM:** Minimum 12 GB for single node, 24 GB for dual node (required for DAB tests)
 
-For complete system requirements, see the [official Solo documentation](https://solo.hiero.org/latest/docs/step-by-step-guide/#prerequisites).
+For complete system requirements, see the [official Solo documentation](https://solo.hiero.org/docs/simple-solo-setup/system-readiness/).
 
 1. **Install dependencies:**
    ```bash

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ For contributors and developers who want to run integration tests locally, we pr
 > -   Single node setup: Minimum **12 GB RAM**
 > -   Dual node setup: Minimum **24 GB RAM** (required for dynamic address book tests)
 >
-> For complete system requirements, see the [official Solo documentation](https://solo.hiero.org/latest/docs/step-by-step-guide/#prerequisites).
+> For complete system requirements, see the [official Solo documentation](https://solo.hiero.org/docs/simple-solo-setup/system-readiness/).
 
 ### Quick Setup
 


### PR DESCRIPTION
## Summary

Fixes broken links to the Solo documentation in `README.md` and `CONTRIBUTING.md`.

## Problem

The URL `https://solo.hiero.org/latest/docs/step-by-step-guide/#prerequisites` 
returns **404** — the Solo docs site was restructured and this path no longer exists.

## Fix

Updated both references to point to the current system requirements page:  
`https://solo.hiero.org/docs/simple-solo-setup/system-readiness/`

This page explicitly covers prerequisites, hardware requirements (RAM, platform), 
and Docker/Podman setup — the exact content the original link intended.

## Files Changed

- `README.md` — line 214
- `CONTRIBUTING.md` — line 63

Fixes #4052