### PR TITLE
fix: correct CustomRoyaltyFee class name typo and add unit tests

### DIFF
--- a/src/token/CustomRoyaltyFee.js
+++ b/src/token/CustomRoyaltyFee.js
@@ -13,7 +13,7 @@ import CustomFixedFee from "./CustomFixedFee.js";
  * @typedef {import("@hiero-ledger/proto").proto.IFixedFee} HieroProto.proto.IFixedFee
  */
 
-export default class CustomRoyalyFee extends CustomFee {
+export default class CustomRoyaltyFee extends CustomFee {
     /**
      * @param {object} props
      * @param {AccountId | string} [props.feeCollectorAccountId]
@@ -62,7 +62,7 @@ export default class CustomRoyalyFee extends CustomFee {
 
     /**
      * @param {CustomFixedFee} fallbackFee
-     * @returns {CustomRoyalyFee}
+     * @returns {CustomRoyaltyFee}
      */
     setFallbackFee(fallbackFee) {
         this._fallbackFee = fallbackFee;
@@ -78,7 +78,7 @@ export default class CustomRoyalyFee extends CustomFee {
 
     /**
      * @param {Long | number} numerator
-     * @returns {CustomRoyalyFee}
+     * @returns {CustomRoyaltyFee}
      */
     setNumerator(numerator) {
         this._numerator =
@@ -97,7 +97,7 @@ export default class CustomRoyalyFee extends CustomFee {
 
     /**
      * @param {Long | number} denominator
-     * @returns {CustomRoyalyFee}
+     * @returns {CustomRoyaltyFee}
      */
     setDenominator(denominator) {
         this._denominator =
@@ -122,7 +122,7 @@ export default class CustomRoyalyFee extends CustomFee {
             fee.exchangeValueFraction
         );
 
-        return new CustomRoyalyFee({
+        return new CustomRoyaltyFee({
             feeCollectorAccountId:
                 info.feeCollectorAccountId != null
                     ? AccountId._fromProtobuf(info.feeCollectorAccountId)

--- a/test/unit/CustomRoyaltyFee.js
+++ b/test/unit/CustomRoyaltyFee.js
@@ -1,0 +1,37 @@
+import CustomRoyaltyFee from "../../src/token/CustomRoyaltyFee.js";
+import CustomFixedFee from "../../src/token/CustomFixedFee.js";
+import AccountId from "../../src/account/AccountId.js";
+
+describe("CustomRoyaltyFee", function () {
+    it("setters store and getters return values", function () {
+        const fee = new CustomRoyaltyFee()
+            .setNumerator(1)
+            .setDenominator(10);
+        expect(fee.numerator).to.equal(1);
+        expect(fee.denominator).to.equal(10);
+    });
+
+    it("_toProtobuf serialises correctly", function () {
+        const fee = new CustomRoyaltyFee()
+            .setFeeCollectorAccountId(new AccountId(0, 0, 3))
+            .setNumerator(2)
+            .setDenominator(5);
+        const proto = fee._toProtobuf();
+        expect(proto.royaltyFee.exchangeValueFraction.numerator).to.equal(2);
+        expect(proto.royaltyFee.exchangeValueFraction.denominator).to.equal(5);
+    });
+
+    it("_fromProtobuf round-trips correctly", function () {
+        const proto = {
+            feeCollectorAccountId: { shardNum: 0, realmNum: 0, num: 3 },
+            allCollectorsAreExempt: false,
+            royaltyFee: {
+                exchangeValueFraction: { numerator: 1, denominator: 4 },
+                fallbackFee: null,
+            },
+        };
+        const fee = CustomRoyaltyFee._fromProtobuf(proto);
+        expect(fee.numerator).to.equal(1);
+        expect(fee.denominator).to.equal(4);
+    });
+});


### PR DESCRIPTION
## Summary
Fixed the misspelled class name `CustomRoyalyFee` → `CustomRoyaltyFee` in `src/token/CustomRoyaltyFee.js` and added unit tests for the class.

## What changed
1. **Bug fix:** Corrected class name typo in:
   - Class declaration
   - JSDoc `@returns` annotations
   - `_fromProtobuf` instantiation
2. **Tests:** Created `test/unit/CustomRoyaltyFee.js` with tests for:
   - Getters and setters
   - `_toProtobuf()` serialization
   - `_fromProtobuf()` round-trip

Closes #4026