### PR TITLE
test: add unit test for sha384.native.js

### DIFF
--- a/test/unit/cryptography/sha384.native.js
+++ b/test/unit/cryptography/sha384.native.js
@@ -1,0 +1,22 @@
+import { digest } from "../../../src/cryptography/sha384.native.js";
+
+describe("sha384 (native)", function () {
+    const input = new TextEncoder().encode("hello world");
+
+    it("digest resolves to a 48-byte Uint8Array", async function () {
+        const result = await digest(input);
+        expect(result).to.be.instanceOf(Uint8Array);
+        expect(result.length).to.equal(48);
+    });
+
+    it("digest produces the correct SHA-384 hash", async function () {
+        const result = await digest(input);
+        const hexStr = Array.from(result)
+            .map((b) => b.toString(16).padStart(2, "0"))
+            .join("");
+        // Known SHA-384 of "hello world"
+        expect(hexStr).to.equal(
+            "fdbd8e75a67f29f701a4e040385e2e23986303ea10239211af907fcbb83578b3e417cb71ce646efd0819dd8c088de1bd",
+        );
+    });
+});


### PR DESCRIPTION
**Description**:

Add unit tests for the native sha384 implementation to ensure parity and reliability across environments.

- Add unit tests for sha384.native.js
- Validates that the digest function returns a 48-byte Uint8Array and produces mathematically correct hashes.

**Related issue(s)**:

Fixes #4022 

**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [ ] Tested (unit, integration, etc.)
