### PR TITLE
fix(util): use Long.isLong for cross-module compatibility (#4076)

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -93,7 +93,7 @@ export function isBigNumber(variable) {
  * @returns {boolean}
  */
 export function isLong(variable) {
-    return isNonNull(variable) && variable instanceof Long;
+    return isNonNull(variable) && Long.isLong(variable);
 }
 
 /**

--- a/test/unit/util.js
+++ b/test/unit/util.js
@@ -41,6 +41,27 @@ describe("util", function () {
         expect(util.isBigNumber("1")).to.eql(false);
     });
 
+    it("soft check: isLong should return true for a Long instance from the SDK's import", function () {
+        expect(util.isLong(Long.fromNumber(42))).to.eql(true);
+    });
+
+    it("soft check: isLong should return true for a duck-typed Long from a different module", function () {
+        // Simulates a Long instance created by an externally installed copy of the long package
+        const externalLong = Object.create({ __isLong__: true });
+        externalLong.low = 42;
+        externalLong.high = 0;
+        externalLong.unsigned = false;
+        expect(util.isLong(externalLong)).to.eql(true);
+    });
+
+    it("soft check: isLong should return false for non-Long values", function () {
+        expect(util.isLong(null)).to.eql(false);
+        expect(util.isLong(undefined)).to.eql(false);
+        expect(util.isLong(42)).to.eql(false);
+        expect(util.isLong("42")).to.eql(false);
+        expect(util.isLong({})).to.eql(false);
+    });
+
     it("soft check: isString should return true if instanceof string and non-null", function () {
         expect(util.isString("")).to.eql(true);
         expect(util.isString("")).to.eql(true);


### PR DESCRIPTION
## Summary

`util.isLong()` used `instanceof Long`, which fails when the value is a `Long` from an externally-installed `long` package (different module instance). This caused `ContractFunctionParameters.addUint256()` and other paths that go through `convertToBigNumber()` / `requireLong()` to throw `"This value must be a String, Number, or BigNumber to be converted."` despite the TypeScript types accepting `Long`.

Replaces the `instanceof` check with `Long.isLong()`.

Closes #4076.

## Test plan

- [x] `task test:unit:node -- test/unit/util.js` passes (21/21)
- [x] `task test:unit:browser -- test/unit/util.js` passes (21/21)
- [x] End-to-end repro from the issue (`new ContractFunctionParameters().addUint256(Long.fromString("5000000000"))` with an externally-imported `Long`) no longer throws