### PR TITLE
fix(jsdoc): use generic Client<Channel, MirrorChannel> in ScheduleInfoQuery

### DIFF
--- a/src/schedule/ScheduleInfoQuery.js
+++ b/src/schedule/ScheduleInfoQuery.js
@@ -19,7 +19,8 @@ import Hbar from "../Hbar.js";
 
 /**
  * @typedef {import("../channel/Channel.js").default} Channel
- * @typedef {import("../client/Client.js").default<*, *>} Client
+ * @typedef {import("../channel/MirrorChannel.js").default} MirrorChannel
+ * @typedef {import("../client/Client.js").default<Channel, MirrorChannel>} Client
  * @typedef {import("../account/AccountId.js").default} AccountId
  */
 
@@ -87,7 +88,7 @@ export default class ScheduleInfoQuery extends Query {
 
     /**
      * @override
-     * @param {import("../client/Client.js").default<Channel, *>} client
+     * @param {Client} client
      * @returns {Promise<Hbar>}
      */
     async getCost(client) {


### PR DESCRIPTION
Fixes #3799

This PR resolves the `jsdoc/reject-any-type` warnings by replacing wildcard (`*`) types with the specific Channel and MirrorChannel types in ScheduleInfoQuery.

Changes:
- Added MirrorChannel typedef import
- Updated Client typedef to use `<Channel, MirrorChannel>` instead of `<*, *>`
- Updated getCost() @param to use the Client typedef instead of inline import with wildcard

Verification:
- eslint no longer reports jsdoc/reject-any-type warnings for this file (verified: 3 warnings before fix, 0 after)
- unit tests pass (1725/1726 passing; 1 pre-existing flaky timeout test unrelated to this change)