### PR TITLE
feat(TCK): add executeFeeEstimateQuery JSON-RPC method (HIP-1261)

### DIFF
--- a/tck/methods/fee-estimate.ts
+++ b/tck/methods/fee-estimate.ts
@@ -1,0 +1,331 @@
+import {
+    FeeEstimateQuery,
+    FeeEstimateMode,
+    ContractCreateTransaction,
+    FileCreateTransaction,
+    FileAppendTransaction,
+    Hbar,
+    Timestamp,
+    Transaction,
+    Client,
+} from "@hiero-ledger/sdk";
+import Long from "long";
+
+import { sdk } from "../sdk_data";
+import {
+    ExecuteFeeEstimateQueryParams,
+    FeeEstimateModeName,
+    FeeEstimateTransactionType,
+} from "../params/fee-estimate";
+import {
+    FeeEstimateQueryResponse,
+    FeeExtraResponse,
+} from "../response/fee-estimate";
+import { applyCommonTransactionParams } from "../params/common-tx-params";
+import { getKeyFromString } from "../utils/key";
+import { decode } from "../utils/hex";
+import { DEFAULT_GRPC_DEADLINE } from "../utils/constants/config";
+
+import { buildCreateAccount, buildTransferCrypto } from "./account";
+import { buildCreateToken, buildMintToken } from "./token";
+import { buildCreateTopic, buildSubmitTopicMessage } from "./topic";
+
+const MODE_MAP: Record<
+    FeeEstimateModeName,
+    typeof FeeEstimateMode.STATE | typeof FeeEstimateMode.INTRINSIC
+> = {
+    STATE: FeeEstimateMode.STATE,
+    INTRINSIC: FeeEstimateMode.INTRINSIC,
+};
+
+/**
+ * Build a FileCreateTransaction from the same params shape used by createFile.
+ * Kept local so we don't have to refactor file.ts.
+ */
+const buildCreateFile = (
+    {
+        keys,
+        contents,
+        expirationTime,
+        memo,
+        commonTransactionParams,
+    }: Record<string, any>,
+    client: Client,
+): FileCreateTransaction => {
+    const transaction = new FileCreateTransaction().setGrpcDeadline(
+        DEFAULT_GRPC_DEADLINE,
+    );
+
+    if (keys?.length && keys.length > 0) {
+        transaction.setKeys(keys.map((key: string) => getKeyFromString(key)));
+    }
+
+    if (contents != null) {
+        transaction.setContents(contents);
+    }
+
+    if (expirationTime != null) {
+        transaction.setExpirationTime(
+            new Timestamp(Long.fromString(expirationTime), 0),
+        );
+    }
+
+    if (memo != null) {
+        transaction.setFileMemo(memo);
+    }
+
+    if (commonTransactionParams != null) {
+        applyCommonTransactionParams(
+            commonTransactionParams,
+            transaction,
+            client,
+        );
+    }
+
+    return transaction;
+};
+
+/**
+ * Build a FileAppendTransaction from the same params shape used by appendFile.
+ */
+const buildAppendFile = (
+    {
+        fileId,
+        contents,
+        maxChunks,
+        chunkSize,
+        commonTransactionParams,
+    }: Record<string, any>,
+    client: Client,
+): FileAppendTransaction => {
+    const transaction = new FileAppendTransaction().setGrpcDeadline(
+        DEFAULT_GRPC_DEADLINE,
+    );
+
+    if (fileId != null) {
+        transaction.setFileId(fileId);
+    }
+
+    if (contents != null) {
+        transaction.setContents(contents);
+    }
+
+    if (maxChunks != null) {
+        transaction.setMaxChunks(maxChunks);
+    }
+
+    if (chunkSize != null) {
+        transaction.setChunkSize(chunkSize);
+    }
+
+    if (commonTransactionParams != null) {
+        applyCommonTransactionParams(
+            commonTransactionParams,
+            transaction,
+            client,
+        );
+    }
+
+    return transaction;
+};
+
+/**
+ * Build a ContractCreateTransaction from the same params shape used by createContract.
+ */
+const buildCreateContract = (
+    {
+        adminKey,
+        autoRenewPeriod,
+        autoRenewAccountId,
+        initialBalance,
+        bytecodeFileId,
+        initcode,
+        stakedAccountId,
+        stakedNodeId,
+        gas,
+        declineStakingReward,
+        memo,
+        maxAutomaticTokenAssociations,
+        constructorParameters,
+        commonTransactionParams,
+    }: Record<string, any>,
+    client: Client,
+): ContractCreateTransaction => {
+    const transaction = new ContractCreateTransaction().setGrpcDeadline(
+        DEFAULT_GRPC_DEADLINE,
+    );
+
+    if (adminKey != null) {
+        transaction.setAdminKey(getKeyFromString(adminKey));
+    }
+    if (autoRenewPeriod != null) {
+        transaction.setAutoRenewPeriod(Long.fromString(autoRenewPeriod));
+    }
+    if (gas != null) {
+        transaction.setGas(Long.fromString(gas));
+    }
+    if (autoRenewAccountId != null) {
+        transaction.setAutoRenewAccountId(autoRenewAccountId);
+    }
+    if (initialBalance != null) {
+        transaction.setInitialBalance(Hbar.fromTinybars(initialBalance));
+    }
+    if (initcode != null) {
+        transaction.setBytecode(decode(initcode));
+    }
+    if (bytecodeFileId != null) {
+        transaction.setBytecodeFileId(bytecodeFileId);
+    }
+    if (stakedAccountId != null) {
+        transaction.setStakedAccountId(stakedAccountId);
+    }
+    if (stakedNodeId != null) {
+        transaction.setStakedNodeId(Long.fromString(stakedNodeId));
+    }
+    if (declineStakingReward != null) {
+        transaction.setDeclineStakingReward(declineStakingReward);
+    }
+    if (memo != null) {
+        transaction.setContractMemo(memo);
+    }
+    if (maxAutomaticTokenAssociations != null) {
+        transaction.setMaxAutomaticTokenAssociations(
+            maxAutomaticTokenAssociations,
+        );
+    }
+    if (constructorParameters != null) {
+        transaction.setConstructorParameters(decode(constructorParameters));
+    }
+    if (commonTransactionParams != null) {
+        applyCommonTransactionParams(
+            commonTransactionParams,
+            transaction,
+            client,
+        );
+    }
+
+    return transaction;
+};
+
+/**
+ * Dispatch a transactionType + params to the correct builder.
+ */
+const buildTransactionForFeeEstimate = (
+    transactionType: FeeEstimateTransactionType,
+    transactionParams: Record<string, any>,
+    sessionId: string | undefined,
+    client: Client,
+): Transaction => {
+    const params = { ...transactionParams, sessionId };
+
+    switch (transactionType) {
+        case "AccountCreate":
+            return buildCreateAccount(params as any, client);
+        case "TransferCrypto":
+            return buildTransferCrypto(params as any, client);
+        case "TokenCreate":
+            return buildCreateToken(params as any, client);
+        case "TokenMint":
+            return buildMintToken(params as any, client);
+        case "TopicCreate":
+            return buildCreateTopic(params as any, client);
+        case "TopicMessageSubmit":
+            return buildSubmitTopicMessage(params as any, client);
+        case "ContractCreate":
+            return buildCreateContract(params, client);
+        case "FileCreate":
+            return buildCreateFile(params, client);
+        case "FileAppend":
+            return buildAppendFile(params, client);
+        default:
+            throw new Error(
+                `Unsupported transactionType for FeeEstimateQuery: ${transactionType}`,
+            );
+    }
+};
+
+/**
+ * Convert a FeeEstimateResponse from the SDK into the TCK JSON-RPC response
+ * shape (Long values stringified for precision).
+ */
+const formatExtras = (
+    extras: Array<{
+        name: string;
+        included: number;
+        count: number;
+        charged: number;
+        feePerUnit: { toString: () => string };
+        subtotal: { toString: () => string };
+    }>,
+): FeeExtraResponse[] => {
+    return extras.map((extra) => ({
+        name: extra.name,
+        included: extra.included,
+        count: extra.count,
+        charged: extra.charged,
+        feePerUnit: extra.feePerUnit.toString(),
+        subtotal: extra.subtotal.toString(),
+    }));
+};
+
+/**
+ * Execute a FeeEstimateQuery (HIP-1261).
+ *
+ * Builds the inner transaction from the supplied transactionType +
+ * transactionParams, wraps it in FeeEstimateQuery, and returns the response
+ * in JSON form with all tinycent values stringified.
+ */
+export const executeFeeEstimateQuery = async (
+    params: ExecuteFeeEstimateQueryParams,
+): Promise<FeeEstimateQueryResponse> => {
+    const { sessionId, mode, highVolumeThrottle, transactionType } = params;
+    const client = sdk.getClient(sessionId);
+
+    if (transactionType == null) {
+        throw new Error(
+            "executeFeeEstimateQuery requires a transactionType parameter",
+        );
+    }
+
+    const transaction = buildTransactionForFeeEstimate(
+        transactionType,
+        params.transactionParams ?? {},
+        sessionId,
+        client,
+    );
+
+    const query = new FeeEstimateQuery().setTransaction(transaction);
+
+    if (mode != null) {
+        const modeValue = MODE_MAP[mode];
+        if (modeValue == null) {
+            throw new Error(
+                `Invalid FeeEstimateQuery mode: ${mode}. Must be one of: STATE, INTRINSIC`,
+            );
+        }
+        query.setMode(modeValue);
+    }
+
+    if (highVolumeThrottle != null) {
+        query.setHighVolumeThrottle(highVolumeThrottle);
+    }
+
+    const response = await query.execute(client);
+
+    return {
+        highVolumeMultiplier: response.highVolumeMultiplier.toString(),
+        networkFee: {
+            multiplier: response.networkFee.multiplier,
+            subtotal: response.networkFee.subtotal.toString(),
+        },
+        nodeFee: {
+            base: response.nodeFee.base.toString(),
+            extras: formatExtras(response.nodeFee.extras as any),
+        },
+        serviceFee: {
+            base: response.serviceFee.base.toString(),
+            extras: formatExtras(response.serviceFee.extras as any),
+        },
+        total: response.total.toString(),
+    };
+};

--- a/tck/methods/token.ts
+++ b/tck/methods/token.ts
@@ -72,7 +72,7 @@ import {
 } from "../response/token";
 
 // buildCreateToken builds a TokenCreateTransaction from parameters
-const buildCreateToken = (
+export const buildCreateToken = (
     {
         name,
         symbol,

--- a/tck/package-lock.json
+++ b/tck/package-lock.json
@@ -9,13 +9,15 @@
             "version": "1.0.0",
             "license": "ISC",
             "dependencies": {
-                "@hiero-ledger/sdk": "2.79.0-beta.12",
+                "@hiero-ledger/proto": "^2.30.0",
+                "@hiero-ledger/sdk": "2.84.0",
                 "ansi-regex": "6.2.2",
                 "ansi-styles": "6.2.3",
                 "body-parser": "1.20.3",
                 "express": "4.22.1",
                 "glob": "11.0.3",
                 "json-rpc-2.0": "1.7.0",
+                "long": "^5.3.1",
                 "lossless-json": "1.0.5",
                 "strip-ansi": "7.1.2"
             },
@@ -28,6 +30,12 @@
                 "nodemon": "3.1.10",
                 "ts-node": "10.9.2"
             }
+        },
+        "node_modules/@adraffy/ens-normalize": {
+            "version": "1.10.1",
+            "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+            "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+            "license": "MIT"
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.0",
@@ -45,9 +53,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-            "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.3.tgz",
+            "integrity": "sha512-LIVqM46zQWZhj17qA8wb4nW/ixr2y1Nw+r1etiAWgRM6U1IqP+LNhL1yg440jYZR72jCWcWbLWzIosH+uP1fqg==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -96,9 +104,9 @@
             }
         },
         "node_modules/@babel/generator": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.0.tgz",
-            "integrity": "sha512-vSH118/wwM/pLR38g/Sgk05sNtro6TlTJKuiMXDaZqPUfjTFcudpCOt00IhOfj+1BFAX+UFAlzCU+6WXr3GLFQ==",
+            "version": "7.29.1",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+            "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -202,16 +210,6 @@
                 "@babel/core": "^7.0.0"
             }
         },
-        "node_modules/@babel/helper-plugin-utils": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-            "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
         "node_modules/@babel/helper-string-parser": {
             "version": "7.27.1",
             "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
@@ -243,23 +241,23 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
-            "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+            "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/template": "^7.28.6",
-                "@babel/types": "^7.28.6"
+                "@babel/types": "^7.29.0"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.0.tgz",
-            "integrity": "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==",
+            "version": "7.29.3",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+            "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -272,217 +270,10 @@
                 "node": ">=6.0.0"
             }
         },
-        "node_modules/@babel/plugin-syntax-async-generators": {
-            "version": "7.8.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.8.4.tgz",
-            "integrity": "sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-bigint": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
-            "integrity": "sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-class-properties": {
-            "version": "7.12.13",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.12.13.tgz",
-            "integrity": "sha512-fm4idjKla0YahUNgFNLCB0qySdsoPiZP3iQE3rky0mBUtMZ23yDJ9SJdg6dXTSDnulOVqiF3Hgr9nbXvXTQZYA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.12.13"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-class-static-block": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-static-block/-/plugin-syntax-class-static-block-7.14.5.tgz",
-            "integrity": "sha512-b+YyPmr6ldyNnM6sqYeMWE+bgJcJpO6yS4QD7ymxgH34GBPNDM/THBh8iunyvKIZztiwLH4CJZ0RxTk9emgpjw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-import-attributes": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.28.6.tgz",
-            "integrity": "sha512-jiLC0ma9XkQT3TKJ9uYvlakm66Pamywo+qwL+oL8HJOvc6TWdZXVfhqJr8CCzbSGUAbDOzlGHJC1U+vRfLQDvw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.28.6"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-import-meta": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-meta/-/plugin-syntax-import-meta-7.10.4.tgz",
-            "integrity": "sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-json-strings": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-json-strings/-/plugin-syntax-json-strings-7.8.3.tgz",
-            "integrity": "sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-logical-assignment-operators": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-logical-assignment-operators/-/plugin-syntax-logical-assignment-operators-7.10.4.tgz",
-            "integrity": "sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-nullish-coalescing-operator": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz",
-            "integrity": "sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-numeric-separator": {
-            "version": "7.10.4",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-numeric-separator/-/plugin-syntax-numeric-separator-7.10.4.tgz",
-            "integrity": "sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.10.4"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-object-rest-spread": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-object-rest-spread/-/plugin-syntax-object-rest-spread-7.8.3.tgz",
-            "integrity": "sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-optional-catch-binding": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-catch-binding/-/plugin-syntax-optional-catch-binding-7.8.3.tgz",
-            "integrity": "sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-optional-chaining": {
-            "version": "7.8.3",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-optional-chaining/-/plugin-syntax-optional-chaining-7.8.3.tgz",
-            "integrity": "sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.8.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-private-property-in-object": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-private-property-in-object/-/plugin-syntax-private-property-in-object-7.14.5.tgz",
-            "integrity": "sha512-0wVnp9dxJ72ZUJDV27ZfbSj6iHLoytYZmh3rFcxNnvsJF3ktkzLDZPy/mA17HGsaQT3/DQsWYX1f1QGWkCoVUg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
-        "node_modules/@babel/plugin-syntax-top-level-await": {
-            "version": "7.14.5",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.14.5.tgz",
-            "integrity": "sha512-hx++upLv5U1rgYfwe1xBQUhRmU41NEvpUvrp8jkrSCdvGSnM5/qdRMtylJ6PG5OFkBaHkbTAKTnd3/YyESRHFw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.14.5"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0-0"
-            }
-        },
         "node_modules/@babel/runtime": {
-            "version": "7.28.6",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
-            "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+            "version": "7.29.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+            "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -505,26 +296,6 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.29.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-            "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.29.0",
-                "@babel/generator": "^7.29.0",
-                "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.29.0",
-                "@babel/template": "^7.28.6",
-                "@babel/types": "^7.29.0",
-                "debug": "^4.3.1"
-            },
-            "engines": {
-                "node": ">=6.9.0"
-            }
-        },
-        "node_modules/@babel/traverse--for-generate-function-map": {
-            "name": "@babel/traverse",
             "version": "7.29.0",
             "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
             "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
@@ -570,410 +341,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@ethersproject/abi": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abi/-/abi-5.8.0.tgz",
-            "integrity": "sha512-b9YS/43ObplgyV6SlyQsG53/vkSal0MNA1fskSC4mbnCMi8R+NkcH8K9FPYNESf6jUefBUniE4SOKms0E/KK1Q==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/address": "^5.8.0",
-                "@ethersproject/bignumber": "^5.8.0",
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/constants": "^5.8.0",
-                "@ethersproject/hash": "^5.8.0",
-                "@ethersproject/keccak256": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/properties": "^5.8.0",
-                "@ethersproject/strings": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/abstract-provider": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-provider/-/abstract-provider-5.8.0.tgz",
-            "integrity": "sha512-wC9SFcmh4UK0oKuLJQItoQdzS/qZ51EJegK6EmAWlh+OptpQ/npECOR3QqECd8iGHC0RJb4WKbVdSfif4ammrg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bignumber": "^5.8.0",
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/networks": "^5.8.0",
-                "@ethersproject/properties": "^5.8.0",
-                "@ethersproject/transactions": "^5.8.0",
-                "@ethersproject/web": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/abstract-signer": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/abstract-signer/-/abstract-signer-5.8.0.tgz",
-            "integrity": "sha512-N0XhZTswXcmIZQdYtUnd79VJzvEwXQw6PK0dTl9VoYrEBxxCPXqS0Eod7q5TNKRxe1/5WUMuR0u0nqTF/avdCA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/abstract-provider": "^5.8.0",
-                "@ethersproject/bignumber": "^5.8.0",
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/properties": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/address": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/address/-/address-5.8.0.tgz",
-            "integrity": "sha512-GhH/abcC46LJwshoN+uBNoKVFPxUuZm6dA257z0vZkKmU1+t8xTn8oK7B9qrj8W2rFRMch4gbJl6PmVxjxBEBA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bignumber": "^5.8.0",
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/keccak256": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/rlp": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/base64": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/base64/-/base64-5.8.0.tgz",
-            "integrity": "sha512-lN0oIwfkYj9LbPx4xEkie6rAMJtySbpOAFXSDVQaBnAzYfB4X2Qr+FXJGxMoc3Bxp2Sm8OwvzMrywxyw0gLjIQ==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bytes": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/bignumber": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bignumber/-/bignumber-5.8.0.tgz",
-            "integrity": "sha512-ZyaT24bHaSeJon2tGPKIiHszWjD/54Sz8t57Toch475lCLljC6MgPmxk7Gtzz+ddNN5LuHea9qhAe0x3D+uYPA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "bn.js": "^5.2.1"
-            }
-        },
-        "node_modules/@ethersproject/bignumber/node_modules/bn.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-            "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
-            "license": "MIT"
-        },
-        "node_modules/@ethersproject/bytes": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/bytes/-/bytes-5.8.0.tgz",
-            "integrity": "sha512-vTkeohgJVCPVHu5c25XWaWQOZ4v+DkGoC42/TS2ond+PARCxTJvgTFUNDZovyQ/uAQ4EcpqqowKydcdmRKjg7A==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/logger": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/constants": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/constants/-/constants-5.8.0.tgz",
-            "integrity": "sha512-wigX4lrf5Vu+axVTIvNsuL6YrV4O5AXl5ubcURKMEME5TnWBouUh0CDTWxZ2GpnRn1kcCgE7l8O5+VbV9QTTcg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bignumber": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/hash": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/hash/-/hash-5.8.0.tgz",
-            "integrity": "sha512-ac/lBcTbEWW/VGJij0CNSw/wPcw9bSRgCB0AIBz8CvED/jfvDoV9hsIIiWfvWmFEi8RcXtlNwp2jv6ozWOsooA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/abstract-signer": "^5.8.0",
-                "@ethersproject/address": "^5.8.0",
-                "@ethersproject/base64": "^5.8.0",
-                "@ethersproject/bignumber": "^5.8.0",
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/keccak256": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/properties": "^5.8.0",
-                "@ethersproject/strings": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/keccak256": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.8.0.tgz",
-            "integrity": "sha512-A1pkKLZSz8pDaQ1ftutZoaN46I6+jvuqugx5KYNeQOPqq+JZ0Txm7dlWesCHB5cndJSu5vP2VKptKf7cksERng==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bytes": "^5.8.0",
-                "js-sha3": "0.8.0"
-            }
-        },
-        "node_modules/@ethersproject/logger": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.8.0.tgz",
-            "integrity": "sha512-Qe6knGmY+zPPWTC+wQrpitodgBfH7XoceCGL5bJVejmH+yCS3R8jJm8iiWuvWbG76RUmyEG53oqv6GMVWqunjA==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT"
-        },
-        "node_modules/@ethersproject/networks": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/networks/-/networks-5.8.0.tgz",
-            "integrity": "sha512-egPJh3aPVAzbHwq8DD7Po53J4OUSsA1MjQp8Vf/OZPav5rlmWUaFLiq8cvQiGK0Z5K6LYzm29+VA/p4RL1FzNg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/logger": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/properties": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/properties/-/properties-5.8.0.tgz",
-            "integrity": "sha512-PYuiEoQ+FMaZZNGrStmN7+lWjlsoufGIHdww7454FIaGdbe/p5rnaCXTr5MtBYl3NkeoVhHZuyzChPeGeKIpQw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/logger": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/rlp": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/rlp/-/rlp-5.8.0.tgz",
-            "integrity": "sha512-LqZgAznqDbiEunaUvykH2JAoXTT9NV0Atqk8rQN9nx9SEgThA/WMx5DnW8a9FOufo//6FZOCHZ+XiClzgbqV9Q==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/signing-key": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/signing-key/-/signing-key-5.8.0.tgz",
-            "integrity": "sha512-LrPW2ZxoigFi6U6aVkFN/fa9Yx/+4AtIUe4/HACTvKJdhm0eeb107EVCIQcrLZkxaSIgc/eCrX8Q1GtbH+9n3w==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/properties": "^5.8.0",
-                "bn.js": "^5.2.1",
-                "elliptic": "6.6.1",
-                "hash.js": "1.1.7"
-            }
-        },
-        "node_modules/@ethersproject/signing-key/node_modules/bn.js": {
-            "version": "5.2.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.2.tgz",
-            "integrity": "sha512-v2YAxEmKaBLahNwE1mjp4WON6huMNeuDvagFZW+ASCuA/ku0bXR9hSMw0XpiqMoA3+rmnyck/tPRSFQkoC9Cuw==",
-            "license": "MIT"
-        },
-        "node_modules/@ethersproject/strings": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.8.0.tgz",
-            "integrity": "sha512-qWEAk0MAvl0LszjdfnZ2uC8xbR2wdv4cDabyHiBh3Cldq/T8dPH3V4BbBsAYJUeonwD+8afVXld274Ls+Y1xXg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/constants": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/transactions": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/transactions/-/transactions-5.8.0.tgz",
-            "integrity": "sha512-UglxSDjByHG0TuU17bDfCemZ3AnKO2vYrL5/2n2oXvKzvb7Cz+W9gOWXKARjp2URVwcWlQlPOEQyAviKwT4AHg==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/address": "^5.8.0",
-                "@ethersproject/bignumber": "^5.8.0",
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/constants": "^5.8.0",
-                "@ethersproject/keccak256": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/properties": "^5.8.0",
-                "@ethersproject/rlp": "^5.8.0",
-                "@ethersproject/signing-key": "^5.8.0"
-            }
-        },
-        "node_modules/@ethersproject/web": {
-            "version": "5.8.0",
-            "resolved": "https://registry.npmjs.org/@ethersproject/web/-/web-5.8.0.tgz",
-            "integrity": "sha512-j7+Ksi/9KfGviws6Qtf9Q7KCqRhpwrYKQPs+JBA/rKVFF/yaWLHJEH3zfVP2plVu+eys0d2DlFmhoQJayFewcw==",
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-                },
-                {
-                    "type": "individual",
-                    "url": "https://www.buymeacoffee.com/ricmoo"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "@ethersproject/base64": "^5.8.0",
-                "@ethersproject/bytes": "^5.8.0",
-                "@ethersproject/logger": "^5.8.0",
-                "@ethersproject/properties": "^5.8.0",
-                "@ethersproject/strings": "^5.8.0"
-            }
-        },
         "node_modules/@grpc/grpc-js": {
             "version": "1.12.6",
             "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.12.6.tgz",
@@ -1005,24 +372,54 @@
                 "node": ">=6"
             }
         },
+        "node_modules/@grpc/proto-loader/node_modules/long": {
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+            "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+            "license": "Apache-2.0"
+        },
+        "node_modules/@grpc/proto-loader/node_modules/protobufjs": {
+            "version": "7.6.0",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.0.tgz",
+            "integrity": "sha512-LtESOsMPTZgyYtwxhvdgdjGL0HmXEaRA/hVD6sol4zA60hVXXXP/SGmxnqDbgGE8gy7pYex7cym+5vYPcmaXBQ==",
+            "hasInstallScript": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "@protobufjs/aspromise": "^1.1.2",
+                "@protobufjs/base64": "^1.1.2",
+                "@protobufjs/codegen": "^2.0.5",
+                "@protobufjs/eventemitter": "^1.1.0",
+                "@protobufjs/fetch": "^1.1.1",
+                "@protobufjs/float": "^1.0.2",
+                "@protobufjs/inquire": "^1.1.2",
+                "@protobufjs/path": "^1.1.2",
+                "@protobufjs/pool": "^1.1.0",
+                "@protobufjs/utf8": "^1.1.1",
+                "@types/node": ">=13.7.0",
+                "long": "^5.3.2"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            }
+        },
         "node_modules/@hiero-ledger/cryptography": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/@hiero-ledger/cryptography/-/cryptography-1.15.0.tgz",
-            "integrity": "sha512-KLbueVfPuTotZfGT+HxcA3zz455eIZW/dBGxkpj9MEp+J2pruR9TyWzenozkuFAzvQ+ouJexE8OmtJMwV5XBBg==",
+            "version": "1.18.0",
+            "resolved": "https://registry.npmjs.org/@hiero-ledger/cryptography/-/cryptography-1.18.0.tgz",
+            "integrity": "sha512-fLLAcpssJkPjCtTJRge6NmWIRAG3GcZ3IaOA006e/m/aMvwNkdFyWyeFbDuqNe1hG/sY28/9mc3IHL/suyVi2A==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@noble/curves": "1.8.1",
                 "ansi-regex": "6.2.2",
                 "ansi-styles": "6.2.3",
                 "asn1js": "3.0.6",
-                "bignumber.js": "9.1.1",
-                "bn.js": "5.2.1",
+                "bignumber.js": "10.0.2",
+                "bn.js": "5.2.3",
                 "buffer": "6.0.3",
                 "crypto-js": "4.2.0",
                 "debug": "4.4.1",
                 "forge-light": "1.1.4",
                 "js-base64": "3.7.7",
-                "react-native-get-random-values": "1.11.0",
+                "react-native-get-random-values": "2.0.0",
                 "spark-md5": "3.0.2",
                 "strip-ansi": "7.1.2",
                 "tweetnacl": "1.0.3",
@@ -1037,12 +434,6 @@
                 }
             }
         },
-        "node_modules/@hiero-ledger/cryptography/node_modules/bn.js": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
-            "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
-            "license": "MIT"
-        },
         "node_modules/@hiero-ledger/cryptography/node_modules/js-base64": {
             "version": "3.7.7",
             "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.7.tgz",
@@ -1050,12 +441,13 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@hiero-ledger/proto": {
-            "version": "2.25.0",
-            "resolved": "https://registry.npmjs.org/@hiero-ledger/proto/-/proto-2.25.0.tgz",
-            "integrity": "sha512-yZ9gb/2FMUSvH+txR1g1Z/03vbl4T11H8qw1NQyIuKhXe4PE8Ct8iHAL62aS0BN+OcR6CaF2wkfkQa16kgIkSA==",
+            "version": "2.30.0",
+            "resolved": "https://registry.npmjs.org/@hiero-ledger/proto/-/proto-2.30.0.tgz",
+            "integrity": "sha512-6n91VQ3smh5HHChz1sO8X8nj4D6IwoQ+9BTpqzNkGv+1At2PwIR8W3FPZVU6QGckHXp8WkB95E0ny18PeuQJvw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "long": "5.3.1"
+                "long": "5.3.1",
+                "rimraf": "6.1.2"
             },
             "engines": {
                 "node": ">=10.0.0"
@@ -1064,34 +456,31 @@
                 "ansi-regex": "6.2.2",
                 "ansi-styles": "6.2.3",
                 "debug": "4.4.1",
-                "protobufjs": "7.5.4",
+                "protobufjs": "8.0.1",
                 "strip-ansi": "7.1.2"
             }
         },
         "node_modules/@hiero-ledger/sdk": {
-            "version": "2.79.0-beta.12",
-            "resolved": "https://registry.npmjs.org/@hiero-ledger/sdk/-/sdk-2.79.0-beta.12.tgz",
-            "integrity": "sha512-6yazlMWkhwZ2gHo/qd8GF8lpay30qY1Y8ELc5HXJRnCkLoQ5ctmYvtWhLAyYXYfvcSRxroL1Fca69vgTzU9u2w==",
+            "version": "2.84.0",
+            "resolved": "https://registry.npmjs.org/@hiero-ledger/sdk/-/sdk-2.84.0.tgz",
+            "integrity": "sha512-FR8MTeHTuH+87XU2jP9PhU77yjA3q0oDx8C+KdnvJ75SW0rYMmo5g1WV3eWx4/s2gc7rKBr5grRFDmuSNyJxZw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@ethersproject/abi": "5.8.0",
-                "@ethersproject/bignumber": "5.8.0",
-                "@ethersproject/bytes": "5.8.0",
-                "@ethersproject/rlp": "5.8.0",
                 "@grpc/grpc-js": "1.12.6",
-                "@hiero-ledger/cryptography": "1.15.0",
-                "@hiero-ledger/proto": "2.25.0",
+                "@hiero-ledger/cryptography": "1.18.0",
+                "@hiero-ledger/proto": "2.30.0",
                 "ansi-regex": "6.2.2",
                 "ansi-styles": "6.2.3",
-                "bignumber.js": "9.1.1",
-                "bn.js": "5.1.1",
+                "bignumber.js": "10.0.2",
+                "bn.js": "5.2.3",
                 "crypto-js": "4.2.0",
                 "debug": "4.4.1",
+                "ethers": "6.16.0",
                 "js-base64": "3.7.4",
                 "long": "5.3.1",
                 "pino": "10.1.0",
                 "pino-pretty": "13.0.0",
-                "protobufjs": "7.5.4",
+                "protobufjs": "8.0.1",
                 "rfc4648": "1.5.3",
                 "strip-ansi": "7.1.2",
                 "utf8": "3.0.0"
@@ -1100,7 +489,7 @@
                 "node": ">=18.0.0"
             },
             "peerDependencies": {
-                "bn.js": "5.2.1"
+                "bn.js": "5.2.3"
             }
         },
         "node_modules/@isaacs/cliui": {
@@ -1130,80 +519,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/@istanbuljs/load-nyc-config": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.1.0.tgz",
-            "integrity": "sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "camelcase": "^5.3.1",
-                "find-up": "^4.1.0",
-                "get-package-type": "^0.1.0",
-                "js-yaml": "^3.13.1",
-                "resolve-from": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@istanbuljs/schema": {
-            "version": "0.1.3",
-            "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
-            "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/@jest/create-cache-key-function": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/create-cache-key-function/-/create-cache-key-function-29.7.0.tgz",
-            "integrity": "sha512-4QqS3LY5PBmTRHj9sAg1HLoPzqAI0uOX6wI/TRqHIcOxlFidy6YEmCQJk6FSZjNLGCeubDMfmkWL+qaLKhSGQA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/environment": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/environment/-/environment-29.7.0.tgz",
-            "integrity": "sha512-aQIfHDq33ExsN4jP1NWGXhxgQ/wixs60gDiKO+XVMd8Mn0NWPWgc34ZQDTb2jKaUWQ7MuwoitXAsN2XVXNMpAw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-mock": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/fake-timers": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/fake-timers/-/fake-timers-29.7.0.tgz",
-            "integrity": "sha512-q4DH1Ha4TTFPdxLsqDXK1d3+ioSL7yL5oCMJZgDYm6i+6CygW5E5xVr/D1HdsGxjt1ZWSfUAs9OxSB/BNelWrQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@sinonjs/fake-timers": "^10.0.2",
-                "@types/node": "*",
-                "jest-message-util": "^29.7.0",
-                "jest-mock": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/@jest/schemas": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -1215,44 +530,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/transform": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/@jest/transform/-/transform-29.7.0.tgz",
-            "integrity": "sha512-ok/BTPFzFKVMwO5eOHRrvnBVHdRy9IrsrW1GpMaQ9MCnilNLXQKmAX8s1YXDFaai9xJpac2ySzV0YeRRECr2Vw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.11.6",
-                "@jest/types": "^29.6.3",
-                "@jridgewell/trace-mapping": "^0.3.18",
-                "babel-plugin-istanbul": "^6.1.1",
-                "chalk": "^4.0.0",
-                "convert-source-map": "^2.0.0",
-                "fast-json-stable-stringify": "^2.1.0",
-                "graceful-fs": "^4.2.9",
-                "jest-haste-map": "^29.7.0",
-                "jest-regex-util": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "pirates": "^4.0.4",
-                "slash": "^3.0.0",
-                "write-file-atomic": "^4.0.2"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/@jest/transform/node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.31",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
-            "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jridgewell/resolve-uri": "^3.1.0",
-                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@jest/types": {
@@ -1421,9 +698,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/codegen": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.4.tgz",
-            "integrity": "sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+            "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/eventemitter": {
@@ -1433,13 +710,12 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/fetch": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
-            "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+            "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "@protobufjs/aspromise": "^1.1.1",
-                "@protobufjs/inquire": "^1.1.0"
+                "@protobufjs/aspromise": "^1.1.1"
             }
         },
         "node_modules/@protobufjs/float": {
@@ -1449,9 +725,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/inquire": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.0.tgz",
-            "integrity": "sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
+            "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
             "license": "BSD-3-Clause"
         },
         "node_modules/@protobufjs/path": {
@@ -1473,93 +749,58 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@react-native/assets-registry": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.83.1.tgz",
-            "integrity": "sha512-AT7/T6UwQqO39bt/4UL5EXvidmrddXrt0yJa7ENXndAv+8yBzMsZn6fyiax6+ERMt9GLzAECikv3lj22cn2wJA==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/assets-registry/-/assets-registry-0.85.3.tgz",
+            "integrity": "sha512-u9ZiYP23vA2IFtdFQFmetzSmk6SM0xgKIoiOsr1hXNHjHaLhOm+/Ph1ud57wX6+Dbwdzx8coJgnzSKL3W21PCg==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/@react-native/codegen": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.83.1.tgz",
-            "integrity": "sha512-FpRxenonwH+c2a5X5DZMKUD7sCudHxB3eSQPgV9R+uxd28QWslyAWrpnJM/Az96AEksHnymDzEmzq2HLX5nb+g==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/codegen/-/codegen-0.85.3.tgz",
+            "integrity": "sha512-/JkS1lGLyzBWP1FbgDwaqEf7qShIC6pUC1M0a/YMAd/v4iqR24MRkQWe7jkYvcBQ2LpEhs5NGE9InhxSv21zCA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.25.2",
-                "@babel/parser": "^7.25.3",
-                "glob": "^7.1.1",
-                "hermes-parser": "0.32.0",
+                "@babel/parser": "^7.29.0",
+                "hermes-parser": "0.33.3",
                 "invariant": "^2.2.4",
                 "nullthrows": "^1.1.1",
+                "tinyglobby": "^0.2.15",
                 "yargs": "^17.6.2"
             },
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             },
             "peerDependencies": {
                 "@babel/core": "*"
             }
         },
-        "node_modules/@react-native/codegen/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/@react-native/codegen/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/@react-native/community-cli-plugin": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.83.1.tgz",
-            "integrity": "sha512-FqR1ftydr08PYlRbrDF06eRiiiGOK/hNmz5husv19sK6iN5nHj1SMaCIVjkH/a5vryxEddyFhU6PzO/uf4kOHg==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/community-cli-plugin/-/community-cli-plugin-0.85.3.tgz",
+            "integrity": "sha512-fs85dmbIqNmtzEixDb0g+q6R3Vt4H9eAt8/inIZdDKfjN76+sUJA2r1nxODQ76bU23MrIbz8sI7KFBPaWk/zQw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@react-native/dev-middleware": "0.83.1",
+                "@react-native/dev-middleware": "0.85.3",
                 "debug": "^4.4.0",
                 "invariant": "^2.2.4",
-                "metro": "^0.83.3",
-                "metro-config": "^0.83.3",
-                "metro-core": "^0.83.3",
+                "metro": "^0.84.3",
+                "metro-config": "^0.84.3",
+                "metro-core": "^0.84.3",
                 "semver": "^7.1.3"
             },
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             },
             "peerDependencies": {
                 "@react-native-community/cli": "*",
-                "@react-native/metro-config": "*"
+                "@react-native/metro-config": "0.85.3"
             },
             "peerDependenciesMeta": {
                 "@react-native-community/cli": {
@@ -1571,41 +812,42 @@
             }
         },
         "node_modules/@react-native/debugger-frontend": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.83.1.tgz",
-            "integrity": "sha512-01Rn3goubFvPjHXONooLmsW0FLxJDKIUJNOlOS0cPtmmTIx9YIjxhe/DxwHXGk7OnULd7yl3aYy7WlBsEd5Xmg==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-frontend/-/debugger-frontend-0.85.3.tgz",
+            "integrity": "sha512-uAu7rM5o/Np1zgp6fi5zM1sP1aB8DcS7DdOLcj/TkSutOAjkMqqd2lWt1/+3S7qXexRHVK5XcP+o3VXo4L/V0A==",
             "license": "BSD-3-Clause",
             "peer": true,
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/@react-native/debugger-shell": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.83.1.tgz",
-            "integrity": "sha512-d+0w446Hxth5OP/cBHSSxOEpbj13p2zToUy6e5e3tTERNJ8ueGlW7iGwGTrSymNDgXXFjErX+dY4P4/3WokPIQ==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/debugger-shell/-/debugger-shell-0.85.3.tgz",
+            "integrity": "sha512-/jRAaT9boiCttIcEwS02WPwYkUihqsjSaK/TMtHz05vT6uMgac9PaQt5kzBQLIABv5aEIa5gtrMmKVz49MjkjQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "cross-spawn": "^7.0.6",
+                "debug": "^4.4.0",
                 "fb-dotslash": "0.5.8"
             },
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/@react-native/dev-middleware": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.83.1.tgz",
-            "integrity": "sha512-QJaSfNRzj3Lp7MmlCRgSBlt1XZ38xaBNXypXAp/3H3OdFifnTZOeYOpFmcpjcXYnDqkxetuwZg8VL65SQhB8dg==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/dev-middleware/-/dev-middleware-0.85.3.tgz",
+            "integrity": "sha512-JYzBiT4A8w+KQt+dOD5v+ti+tDrGoPnsSTuApq3Ls4RB5sfWbDlYMyz3dbc8qBIHz9tv0sQ5+eOu6Xwqzr5AQA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@isaacs/ttlcache": "^1.4.1",
-                "@react-native/debugger-frontend": "0.83.1",
-                "@react-native/debugger-shell": "0.83.1",
+                "@react-native/debugger-frontend": "0.85.3",
+                "@react-native/debugger-shell": "0.85.3",
                 "chrome-launcher": "^0.15.2",
-                "chromium-edge-launcher": "^0.2.0",
+                "chromium-edge-launcher": "^0.3.0",
                 "connect": "^3.6.5",
                 "debug": "^4.4.0",
                 "invariant": "^2.2.4",
@@ -1615,40 +857,62 @@
                 "ws": "^7.5.10"
             },
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/@react-native/dev-middleware/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@react-native/gradle-plugin": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.83.1.tgz",
-            "integrity": "sha512-6ESDnwevp1CdvvxHNgXluil5OkqbjkJAkVy7SlpFsMGmVhrSxNAgD09SSRxMNdKsnLtzIvMsFCzyHLsU/S4PtQ==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/gradle-plugin/-/gradle-plugin-0.85.3.tgz",
+            "integrity": "sha512-39dY2j50Q1pntejzwt3XL7vwXtrj8jcIfHq6E+gyu3jzYxZJVvMkMutQ39vSg6zinIQOX36oQDhidXUbCXzgoA==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/@react-native/js-polyfills": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.83.1.tgz",
-            "integrity": "sha512-qgPpdWn/c5laA+3WoJ6Fak8uOm7CG50nBsLlPsF8kbT7rUHIVB9WaP6+GPsoKV/H15koW7jKuLRoNVT7c3Ht3w==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/js-polyfills/-/js-polyfills-0.85.3.tgz",
+            "integrity": "sha512-U2+aMshIXf1uFn77tpBb/xhHWB9vkVrMpt7kkucAugF8hJKYTDGB587X7WwelHduK2KBfhl4giSv0rzZGoef9A==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/@react-native/normalize-colors": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.83.1.tgz",
-            "integrity": "sha512-84feABbmeWo1kg81726UOlMKAhcQyFXYz2SjRKYkS78QmfhVDhJ2o/ps1VjhFfBz0i/scDwT1XNv9GwmRIghkg==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/normalize-colors/-/normalize-colors-0.85.3.tgz",
+            "integrity": "sha512-hj0PScZEhIbcOvQV5yMKX3ha4XEIOy/SVE1Rrpp0beW0dpNLOgSC7KDxGewmDnIHK9YdQUXGY9eMEfShUMIaZw==",
             "license": "MIT",
             "peer": true
         },
         "node_modules/@react-native/virtualized-lists": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.83.1.tgz",
-            "integrity": "sha512-MdmoAbQUTOdicCocm5XAFDJWsswxk7hxa6ALnm6Y88p01HFML0W593hAn6qOt9q6IM1KbAcebtH6oOd4gcQy8w==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/@react-native/virtualized-lists/-/virtualized-lists-0.85.3.tgz",
+            "integrity": "sha512-dsCjI//OIPEUJMyNHp4l7zNLVjCx7bcaRUceOCkU+IB17hkbtbGWvi7HjGFSzy7FJGmS/MOlcfpb72xXiy1Oig==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -1656,12 +920,12 @@
                 "nullthrows": "^1.1.1"
             },
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             },
             "peerDependencies": {
                 "@types/react": "^19.2.0",
                 "react": "*",
-                "react-native": "*"
+                "react-native": "0.85.3"
             },
             "peerDependenciesMeta": {
                 "@types/react": {
@@ -1670,31 +934,11 @@
             }
         },
         "node_modules/@sinclair/typebox": {
-            "version": "0.27.8",
-            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
-            "integrity": "sha512-+Fj43pSMwJs4KRrH/938Uf+uAELIgVBmQzg/q1YG10djyfA3TnrU8N8XzqCh/okZdszqBQTZf96idMfE5lnwTA==",
+            "version": "0.27.10",
+            "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
+            "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/@sinonjs/commons": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
-            "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "type-detect": "4.0.8"
-            }
-        },
-        "node_modules/@sinonjs/fake-timers": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
-            "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "@sinonjs/commons": "^3.0.0"
-            }
         },
         "node_modules/@tsconfig/node10": {
             "version": "1.0.11",
@@ -1723,51 +967,6 @@
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/@types/babel__core": {
-            "version": "7.20.5",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
-            "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.20.7",
-                "@babel/types": "^7.20.7",
-                "@types/babel__generator": "*",
-                "@types/babel__template": "*",
-                "@types/babel__traverse": "*"
-            }
-        },
-        "node_modules/@types/babel__generator": {
-            "version": "7.27.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
-            "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__template": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
-            "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/parser": "^7.1.0",
-                "@babel/types": "^7.0.0"
-            }
-        },
-        "node_modules/@types/babel__traverse": {
-            "version": "7.28.0",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
-            "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/types": "^7.28.2"
-            }
         },
         "node_modules/@types/body-parser": {
             "version": "1.19.5",
@@ -1824,16 +1023,6 @@
             "license": "MIT",
             "dependencies": {
                 "@types/minimatch": "^5.1.2",
-                "@types/node": "*"
-            }
-        },
-        "node_modules/@types/graceful-fs": {
-            "version": "4.1.9",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.9.tgz",
-            "integrity": "sha512-olP3sd1qOEe5dXTSaFvQG+02VdRXcdytWLAZsAq1PecU8uqQAhkrnbli7DagjtXKW/Bl7YJbUsa8MPcuc8LHEQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
                 "@types/node": "*"
             }
         },
@@ -1929,13 +1118,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/stack-utils": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
-            "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/@types/yargs": {
             "version": "17.0.35",
             "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.35.tgz",
@@ -2004,6 +1186,12 @@
                 "node": ">=0.4.0"
             }
         },
+        "node_modules/aes-js": {
+            "version": "4.0.0-beta.5",
+            "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+            "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+            "license": "MIT"
+        },
         "node_modules/agent-base": {
             "version": "7.1.4",
             "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -2049,6 +1237,7 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
             "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "normalize-path": "^3.0.0",
@@ -2064,16 +1253,6 @@
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
             "dev": true,
             "license": "MIT"
-        },
-        "node_modules/argparse": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "sprintf-js": "~1.0.2"
-            }
         },
         "node_modules/array-flatten": {
             "version": "1.1.1",
@@ -2111,119 +1290,21 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/babel-jest": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/babel-jest/-/babel-jest-29.7.0.tgz",
-            "integrity": "sha512-BrvGY3xZSwEcCzKvKsCi2GgHqDqsYkOP4/by5xCgIwGXQxIEh+8ew3gmrE1y7XRR6LHZIj6yLYnUi/mm2KXKBg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jest/transform": "^29.7.0",
-                "@types/babel__core": "^7.1.14",
-                "babel-plugin-istanbul": "^6.1.1",
-                "babel-preset-jest": "^29.6.3",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.8.0"
-            }
-        },
-        "node_modules/babel-plugin-istanbul": {
-            "version": "6.1.1",
-            "resolved": "https://registry.npmjs.org/babel-plugin-istanbul/-/babel-plugin-istanbul-6.1.1.tgz",
-            "integrity": "sha512-Y1IQok9821cC9onCx5otgFfRm7Lm+I+wwxOx738M/WLPZ9Q42m4IG5W0FNX8WLL2gYMZo3JkuXIH2DOpWM+qwA==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "@babel/helper-plugin-utils": "^7.0.0",
-                "@istanbuljs/load-nyc-config": "^1.0.0",
-                "@istanbuljs/schema": "^0.1.2",
-                "istanbul-lib-instrument": "^5.0.4",
-                "test-exclude": "^6.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/babel-plugin-jest-hoist": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/babel-plugin-jest-hoist/-/babel-plugin-jest-hoist-29.6.3.tgz",
-            "integrity": "sha512-ESAc/RJvGTFEzRwOTT4+lNDk/GNHMkKbNzsvT0qKRfDyyYTskxB5rnU2njIDYVxXCBHHEI1c0YwHob3WaYujOg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/template": "^7.3.3",
-                "@babel/types": "^7.3.3",
-                "@types/babel__core": "^7.1.14",
-                "@types/babel__traverse": "^7.0.6"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/babel-plugin-syntax-hermes-parser": {
-            "version": "0.32.0",
-            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.32.0.tgz",
-            "integrity": "sha512-m5HthL++AbyeEA2FcdwOLfVFvWYECOBObLHNqdR8ceY4TsEdn4LdX2oTvbB2QJSSElE2AWA/b2MXZ/PF/CqLZg==",
+            "version": "0.33.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-hermes-parser/-/babel-plugin-syntax-hermes-parser-0.33.3.tgz",
+            "integrity": "sha512-/Z9xYdaJ1lC0pT9do6TqCqhOSLfZ5Ot8D5za1p+feEfWYupCOfGbhhEXN9r2ZgJtDNUNRw/Z+T2CvAGKBqtqWA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "hermes-parser": "0.32.0"
-            }
-        },
-        "node_modules/babel-preset-current-node-syntax": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/babel-preset-current-node-syntax/-/babel-preset-current-node-syntax-1.2.0.tgz",
-            "integrity": "sha512-E/VlAEzRrsLEb2+dv8yp3bo4scof3l9nR4lrld+Iy5NyVqgVYUJnDAmunkhPMisRI32Qc4iRiz425d8vM++2fg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/plugin-syntax-async-generators": "^7.8.4",
-                "@babel/plugin-syntax-bigint": "^7.8.3",
-                "@babel/plugin-syntax-class-properties": "^7.12.13",
-                "@babel/plugin-syntax-class-static-block": "^7.14.5",
-                "@babel/plugin-syntax-import-attributes": "^7.24.7",
-                "@babel/plugin-syntax-import-meta": "^7.10.4",
-                "@babel/plugin-syntax-json-strings": "^7.8.3",
-                "@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-numeric-separator": "^7.10.4",
-                "@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-                "@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-                "@babel/plugin-syntax-top-level-await": "^7.14.5"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0 || ^8.0.0-0"
-            }
-        },
-        "node_modules/babel-preset-jest": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-29.6.3.tgz",
-            "integrity": "sha512-0B3bhxR6snWXJZtR/RliHTDPRgn1sNHOR0yVtq/IiQFyuOVjFS+wuio/R4gSNkyYmKmJB4wGZv2NZanmKmTnNA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "babel-plugin-jest-hoist": "^29.6.3",
-                "babel-preset-current-node-syntax": "^1.0.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "peerDependencies": {
-                "@babel/core": "^7.0.0"
+                "hermes-parser": "0.33.3"
             }
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/base64-js": {
@@ -2247,23 +1328,23 @@
             "license": "MIT"
         },
         "node_modules/baseline-browser-mapping": {
-            "version": "2.9.19",
-            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
-            "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
+            "version": "2.10.31",
+            "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.31.tgz",
+            "integrity": "sha512-MujYO3eP72uvmSE0i4wltsodRfIpZATP3jvzRNRGGxgzId7aVocVJJV3nf01qnzzKFGxQVC9bpWxl5cjxTr/7Q==",
             "license": "Apache-2.0",
             "peer": true,
             "bin": {
-                "baseline-browser-mapping": "dist/cli.js"
+                "baseline-browser-mapping": "dist/cli.cjs"
+            },
+            "engines": {
+                "node": ">=6.0.0"
             }
         },
         "node_modules/bignumber.js": {
-            "version": "9.1.1",
-            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.1.tgz",
-            "integrity": "sha512-pHm4LsMJ6lzgNGVfZHjMoO8sdoRhOzOH4MLmY65Jg70bpxCKu5iOHNJyfF6OyvYw7t8Fpf35RuzUyqnQsj8Vig==",
-            "license": "MIT",
-            "engines": {
-                "node": "*"
-            }
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-10.0.2.tgz",
+            "integrity": "sha512-E8Wp9O06QA6lneJ4aRUXKYf/1GIomqUEmUMwtIOMtDxf1U52ffJY+y7JBk/8wRafA8qOIqLnXQGqonYXZdBnFQ==",
+            "license": "MIT"
         },
         "node_modules/binary-extensions": {
             "version": "2.3.0",
@@ -2279,9 +1360,9 @@
             }
         },
         "node_modules/bn.js": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
-            "integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
+            "version": "5.2.3",
+            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.3.tgz",
+            "integrity": "sha512-EAcmnPkxpntVL+DS7bO1zhcZNvCkxqtkd0ZY53h06GNQ3DEkkGZ/gKgmDv6DdZQGj9BgfSPKtJJ7Dp1GPP8f7w==",
             "license": "MIT"
         },
         "node_modules/body-parser": {
@@ -2327,6 +1408,7 @@
             "version": "1.1.12",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
             "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^1.0.0",
@@ -2345,16 +1427,10 @@
                 "node": ">=8"
             }
         },
-        "node_modules/brorand": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
-            "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w==",
-            "license": "MIT"
-        },
         "node_modules/browserslist": {
-            "version": "4.28.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
-            "integrity": "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==",
+            "version": "4.28.2",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+            "integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2372,11 +1448,11 @@
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "baseline-browser-mapping": "^2.9.0",
-                "caniuse-lite": "^1.0.30001759",
-                "electron-to-chromium": "^1.5.263",
-                "node-releases": "^2.0.27",
-                "update-browserslist-db": "^1.2.0"
+                "baseline-browser-mapping": "^2.10.12",
+                "caniuse-lite": "^1.0.30001782",
+                "electron-to-chromium": "^1.5.328",
+                "node-releases": "^2.0.36",
+                "update-browserslist-db": "^1.2.3"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -2465,19 +1541,22 @@
             }
         },
         "node_modules/camelcase": {
-            "version": "5.3.1",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-            "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
             "license": "MIT",
             "peer": true,
             "engines": {
-                "node": ">=6"
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001767",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001767.tgz",
-            "integrity": "sha512-34+zUAMhSH+r+9eKmYG+k2Rpt8XttfE4yXAjoZvkAPs15xcYQhyBYdalJ65BzivAvGRMViEjy6oKr/S91loekQ==",
+            "version": "1.0.30001793",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
+            "integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
             "funding": [
                 {
                     "type": "opencollective",
@@ -2596,9 +1675,9 @@
             }
         },
         "node_modules/chromium-edge-launcher": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.2.0.tgz",
-            "integrity": "sha512-JfJjUnq25y9yg4FABRRVPmBGWPZZi+AQXT4mxupb67766/0UlhG8PAZCz6xzEMXTbW3CsSoE8PcCWA49n35mKg==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/chromium-edge-launcher/-/chromium-edge-launcher-0.3.0.tgz",
+            "integrity": "sha512-p03azHlGjtyRvFEee3cyvtsRYdniSkwjkzmM/KmVnqT5d7QkkwpJBhis/zCLMYdQMVJ5tt140TBNqqrZPaWeFA==",
             "license": "Apache-2.0",
             "peer": true,
             "dependencies": {
@@ -2606,25 +1685,15 @@
                 "escape-string-regexp": "^4.0.0",
                 "is-wsl": "^2.2.0",
                 "lighthouse-logger": "^1.0.0",
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
+                "mkdirp": "^1.0.4"
             }
         },
         "node_modules/ci-info": {
-            "version": "3.9.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
-            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
-            "funding": [
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/sibiraj-s"
-                }
-            ],
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
+            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
             "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
+            "peer": true
         },
         "node_modules/cliui": {
             "version": "8.0.1",
@@ -2751,6 +1820,7 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/connect": {
@@ -2990,32 +2060,11 @@
             "license": "MIT"
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.5.286",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.286.tgz",
-            "integrity": "sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==",
+            "version": "1.5.360",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.360.tgz",
+            "integrity": "sha512-GkcBt6YYAw9SxFWn+xVar4cLVGlXVuswwtRLBozi2zp0GjXs4ZnOrqV4zbXzg35n7w81hCkyJNYicgXlVHAmBA==",
             "license": "ISC",
             "peer": true
-        },
-        "node_modules/elliptic": {
-            "version": "6.6.1",
-            "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.6.1.tgz",
-            "integrity": "sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==",
-            "license": "MIT",
-            "dependencies": {
-                "bn.js": "^4.11.9",
-                "brorand": "^1.1.0",
-                "hash.js": "^1.0.0",
-                "hmac-drbg": "^1.0.1",
-                "inherits": "^2.0.4",
-                "minimalistic-assert": "^1.0.1",
-                "minimalistic-crypto-utils": "^1.0.1"
-            }
-        },
-        "node_modules/elliptic/node_modules/bn.js": {
-            "version": "4.12.2",
-            "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.2.tgz",
-            "integrity": "sha512-n4DSx829VRTRByMRGdjQ9iqsN0Bh4OolPsFnaZBLcbi8iXcB+kJ9s7EnRt4wILZNV3kPLHkRVfOc/HvhC3ovDw==",
-            "license": "MIT"
         },
         "node_modules/emoji-regex": {
             "version": "9.2.2",
@@ -3109,20 +2158,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/esprima": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-            "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-            "license": "BSD-2-Clause",
-            "peer": true,
-            "bin": {
-                "esparse": "bin/esparse.js",
-                "esvalidate": "bin/esvalidate.js"
-            },
-            "engines": {
-                "node": ">=4"
-            }
-        },
         "node_modules/etag": {
             "version": "1.8.1",
             "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -3131,6 +2166,79 @@
             "engines": {
                 "node": ">= 0.6"
             }
+        },
+        "node_modules/ethers": {
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+            "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/ethers-io/"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://www.buymeacoffee.com/ricmoo"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@adraffy/ens-normalize": "1.10.1",
+                "@noble/curves": "1.2.0",
+                "@noble/hashes": "1.3.2",
+                "@types/node": "22.7.5",
+                "aes-js": "4.0.0-beta.5",
+                "tslib": "2.7.0",
+                "ws": "8.17.1"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/ethers/node_modules/@noble/curves": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+            "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+            "license": "MIT",
+            "dependencies": {
+                "@noble/hashes": "1.3.2"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/ethers/node_modules/@noble/hashes": {
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+            "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
+            }
+        },
+        "node_modules/ethers/node_modules/@types/node": {
+            "version": "22.7.5",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+            "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+            "license": "MIT",
+            "dependencies": {
+                "undici-types": "~6.19.2"
+            }
+        },
+        "node_modules/ethers/node_modules/tslib": {
+            "version": "2.7.0",
+            "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+            "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+            "license": "0BSD"
+        },
+        "node_modules/ethers/node_modules/undici-types": {
+            "version": "6.19.8",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+            "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+            "license": "MIT"
         },
         "node_modules/event-target-shim": {
             "version": "5.0.1",
@@ -3237,13 +2345,6 @@
             "integrity": "sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==",
             "license": "MIT"
         },
-        "node_modules/fast-json-stable-stringify": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-            "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "license": "MIT",
-            "peer": true
-        },
         "node_modules/fast-safe-stringify": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
@@ -3318,20 +2419,6 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT"
         },
-        "node_modules/find-up": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-            "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/flow-enums-runtime": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/flow-enums-runtime/-/flow-enums-runtime-0.0.6.tgz",
@@ -3382,17 +2469,11 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "license": "ISC",
-            "peer": true
-        },
         "node_modules/fsevents": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
             "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -3453,16 +2534,6 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
-            }
-        },
-        "node_modules/get-package-type": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/get-package-type/-/get-package-type-0.1.0.tgz",
-            "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8.0.0"
             }
         },
         "node_modules/get-proto": {
@@ -3555,16 +2626,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/hash.js": {
-            "version": "1.1.7",
-            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
-            "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
-            "license": "MIT",
-            "dependencies": {
-                "inherits": "^2.0.3",
-                "minimalistic-assert": "^1.0.1"
-            }
-        },
         "node_modules/hasown": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -3584,38 +2645,27 @@
             "license": "MIT"
         },
         "node_modules/hermes-compiler": {
-            "version": "0.14.0",
-            "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-0.14.0.tgz",
-            "integrity": "sha512-clxa193o+GYYwykWVFfpHduCATz8fR5jvU7ngXpfKHj+E9hr9vjLNtdLSEe8MUbObvVexV3wcyxQ00xTPIrB1Q==",
+            "version": "250829098.0.10",
+            "resolved": "https://registry.npmjs.org/hermes-compiler/-/hermes-compiler-250829098.0.10.tgz",
+            "integrity": "sha512-TcRlZ0/TlyfJqquRFAWoyElVNnkdYRi/sEp4/Qy8/GYxjg8j2cS9D4MjuaQ+qimkmLN7AmO+44IznRf06mAr0w==",
             "license": "MIT",
             "peer": true
         },
         "node_modules/hermes-estree": {
-            "version": "0.32.0",
-            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.32.0.tgz",
-            "integrity": "sha512-KWn3BqnlDOl97Xe1Yviur6NbgIZ+IP+UVSpshlZWkq+EtoHg6/cwiDj/osP9PCEgFE15KBm1O55JRwbMEm5ejQ==",
+            "version": "0.33.3",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.33.3.tgz",
+            "integrity": "sha512-6kzYZHCk8Fy1Uc+t3HGYyJn3OL4aeqKLTyina4UFtWl8I0kSL7OmKThaiX+Uh2f8nGw3mo4Ifxg0M5Zk3/Oeqg==",
             "license": "MIT",
             "peer": true
         },
         "node_modules/hermes-parser": {
-            "version": "0.32.0",
-            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.32.0.tgz",
-            "integrity": "sha512-g4nBOWFpuiTqjR3LZdRxKUkij9iyveWeuks7INEsMX741f3r9xxrOe8TeQfUxtda0eXmiIFiMQzoeSQEno33Hw==",
+            "version": "0.33.3",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.33.3.tgz",
+            "integrity": "sha512-Yg3HgaG4CqgyowtYjX/FsnPAuZdHOqSMtnbpylbptsQ9nwwSKsy6uRWcGO5RK0EqiX12q8HvDWKgeAVajRO5DA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "hermes-estree": "0.32.0"
-            }
-        },
-        "node_modules/hmac-drbg": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
-            "integrity": "sha512-Tti3gMqLdZfhOQY1Mzf/AanLiqh1WTiJgEj26ZuYQ9fbkLomzGchCws4FyrSd4VkpBfiNhaE1On+lOz894jvXg==",
-            "license": "MIT",
-            "dependencies": {
-                "hash.js": "^1.0.3",
-                "minimalistic-assert": "^1.0.0",
-                "minimalistic-crypto-utils": "^1.0.1"
+                "hermes-estree": "0.33.3"
             }
         },
         "node_modules/http-errors": {
@@ -3701,28 +2751,6 @@
             },
             "engines": {
                 "node": ">=16.x"
-            }
-        },
-        "node_modules/imurmurhash": {
-            "version": "0.1.4",
-            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.8.19"
-            }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "deprecated": "This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
             }
         },
         "node_modules/inherits": {
@@ -3839,43 +2867,6 @@
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
             "license": "ISC"
         },
-        "node_modules/istanbul-lib-coverage": {
-            "version": "3.2.2",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
-            "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/istanbul-lib-instrument": {
-            "version": "5.2.1",
-            "resolved": "https://registry.npmjs.org/istanbul-lib-instrument/-/istanbul-lib-instrument-5.2.1.tgz",
-            "integrity": "sha512-pzqtp31nLv/XFOzXGuvhCb8qhjmTVo5vjVk19XE4CRlSWz0KoeJ3bw9XsA7nOp9YBf4qHjwBxkDzKcME/J29Yg==",
-            "license": "BSD-3-Clause",
-            "peer": true,
-            "dependencies": {
-                "@babel/core": "^7.12.3",
-                "@babel/parser": "^7.14.7",
-                "@istanbuljs/schema": "^0.1.2",
-                "istanbul-lib-coverage": "^3.2.0",
-                "semver": "^6.3.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/istanbul-lib-instrument/node_modules/semver": {
-            "version": "6.3.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-            "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-            "license": "ISC",
-            "peer": true,
-            "bin": {
-                "semver": "bin/semver.js"
-            }
-        },
         "node_modules/jackspeak": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
@@ -3891,100 +2882,10 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
-        "node_modules/jest-environment-node": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-environment-node/-/jest-environment-node-29.7.0.tgz",
-            "integrity": "sha512-DOSwCRqXirTOyheM+4d5YZOrWcdu0LNZ87ewUoywbcb2XR4wKgqiG8vNeYwhjFMbEkfju7wx2GYH0P2gevGvFw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jest/environment": "^29.7.0",
-                "@jest/fake-timers": "^29.7.0",
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-mock": "^29.7.0",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
         "node_modules/jest-get-type": {
             "version": "29.6.3",
             "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-29.6.3.tgz",
             "integrity": "sha512-zrteXnqYxfQh7l5FHyL38jL39di8H8rHoecLH3JNxH3BwOrBsNeabdap5e0I23lD4HHI8W5VFBZqG4Eaq5LNcw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-haste-map": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-haste-map/-/jest-haste-map-29.7.0.tgz",
-            "integrity": "sha512-fP8u2pyfqx0K1rGn1R9pyE0/KTn+G7PxktWidOBTqFPLYX0b9ksaMFkhK5vrS3DVun09pckLdlx90QthlW7AmA==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/graceful-fs": "^4.1.3",
-                "@types/node": "*",
-                "anymatch": "^3.0.3",
-                "fb-watchman": "^2.0.0",
-                "graceful-fs": "^4.2.9",
-                "jest-regex-util": "^29.6.3",
-                "jest-util": "^29.7.0",
-                "jest-worker": "^29.7.0",
-                "micromatch": "^4.0.4",
-                "walker": "^1.0.8"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            },
-            "optionalDependencies": {
-                "fsevents": "^2.3.2"
-            }
-        },
-        "node_modules/jest-message-util": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-29.7.0.tgz",
-            "integrity": "sha512-GBEV4GRADeP+qtB2+6u61stea8mGcOT4mCtrYISZwfu9/ISHFJ/5zOMXYbpBE9RsS5+Gb63DW4FgmnKJ79Kf6w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@babel/code-frame": "^7.12.13",
-                "@jest/types": "^29.6.3",
-                "@types/stack-utils": "^2.0.0",
-                "chalk": "^4.0.0",
-                "graceful-fs": "^4.2.9",
-                "micromatch": "^4.0.4",
-                "pretty-format": "^29.7.0",
-                "slash": "^3.0.0",
-                "stack-utils": "^2.0.3"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-mock": {
-            "version": "29.7.0",
-            "resolved": "https://registry.npmjs.org/jest-mock/-/jest-mock-29.7.0.tgz",
-            "integrity": "sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "@jest/types": "^29.6.3",
-                "@types/node": "*",
-                "jest-util": "^29.7.0"
-            },
-            "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-regex-util": {
-            "version": "29.6.3",
-            "resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-29.6.3.tgz",
-            "integrity": "sha512-KJJBsRCyyLNWCNBOvZyRDnAIfUiRJ8v+hOBQYGn8gDyF3UegwiP4gwRR3/SDa42g1YbVycTidUF3rKjyLFDWbg==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -4009,6 +2910,22 @@
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
             }
         },
+        "node_modules/jest-util/node_modules/ci-info": {
+            "version": "3.9.0",
+            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
+            "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/sibiraj-s"
+                }
+            ],
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/jest-validate": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-29.7.0.tgz",
@@ -4025,19 +2942,6 @@
             },
             "engines": {
                 "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-            }
-        },
-        "node_modules/jest-validate/node_modules/camelcase": {
-            "version": "6.3.0",
-            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
-            "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/jest-worker": {
@@ -4097,32 +3001,12 @@
             "integrity": "sha512-wpM/wi20Tl+3ifTyi0RdDckS4YTD4Lf953mBRrpG8547T7hInHNPEj8+ck4gB8VDcGyeAWFK++Wb/fU1BeavKQ==",
             "license": "BSD-3-Clause"
         },
-        "node_modules/js-sha3": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz",
-            "integrity": "sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==",
-            "license": "MIT"
-        },
         "node_modules/js-tokens": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
             "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/js-yaml": {
-            "version": "3.14.2",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-            "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "argparse": "^1.0.7",
-                "esprima": "^4.0.0"
-            },
-            "bin": {
-                "js-yaml": "bin/js-yaml.js"
-            }
         },
         "node_modules/jsc-safe-url": {
             "version": "0.2.4",
@@ -4200,19 +3084,6 @@
             "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
             "license": "MIT",
             "peer": true
-        },
-        "node_modules/locate-path": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-            "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "p-locate": "^4.1.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
         },
         "node_modules/lodash.camelcase": {
             "version": "4.3.0",
@@ -4336,46 +3207,45 @@
             }
         },
         "node_modules/metro": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro/-/metro-0.83.3.tgz",
-            "integrity": "sha512-+rP+/GieOzkt97hSJ0MrPOuAH/jpaS21ZDvL9DJ35QYRDlQcwzcvUlGUf79AnQxq/2NPiS/AULhhM4TKutIt8Q==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro/-/metro-0.84.4.tgz",
+            "integrity": "sha512-8ETTubqfD6ornDy2zYDvRcKnVDOXdFJsjetYDBsY4oAsb6NJkiwFR+FaMESyGppFmQUyBQA4H4sFGxzcQSGtFA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/code-frame": "^7.24.7",
+                "@babel/code-frame": "^7.29.0",
                 "@babel/core": "^7.25.2",
-                "@babel/generator": "^7.25.0",
-                "@babel/parser": "^7.25.3",
-                "@babel/template": "^7.25.0",
-                "@babel/traverse": "^7.25.3",
-                "@babel/types": "^7.25.2",
-                "accepts": "^1.3.7",
-                "chalk": "^4.0.0",
+                "@babel/generator": "^7.29.1",
+                "@babel/parser": "^7.29.0",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
+                "accepts": "^2.0.0",
                 "ci-info": "^2.0.0",
                 "connect": "^3.6.5",
                 "debug": "^4.4.0",
                 "error-stack-parser": "^2.0.6",
                 "flow-enums-runtime": "^0.0.6",
                 "graceful-fs": "^4.2.4",
-                "hermes-parser": "0.32.0",
+                "hermes-parser": "0.35.0",
                 "image-size": "^1.0.2",
                 "invariant": "^2.2.4",
                 "jest-worker": "^29.7.0",
                 "jsc-safe-url": "^0.2.2",
                 "lodash.throttle": "^4.1.1",
-                "metro-babel-transformer": "0.83.3",
-                "metro-cache": "0.83.3",
-                "metro-cache-key": "0.83.3",
-                "metro-config": "0.83.3",
-                "metro-core": "0.83.3",
-                "metro-file-map": "0.83.3",
-                "metro-resolver": "0.83.3",
-                "metro-runtime": "0.83.3",
-                "metro-source-map": "0.83.3",
-                "metro-symbolicate": "0.83.3",
-                "metro-transform-plugins": "0.83.3",
-                "metro-transform-worker": "0.83.3",
-                "mime-types": "^2.1.27",
+                "metro-babel-transformer": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-cache-key": "0.84.4",
+                "metro-config": "0.84.4",
+                "metro-core": "0.84.4",
+                "metro-file-map": "0.84.4",
+                "metro-resolver": "0.84.4",
+                "metro-runtime": "0.84.4",
+                "metro-source-map": "0.84.4",
+                "metro-symbolicate": "0.84.4",
+                "metro-transform-plugins": "0.84.4",
+                "metro-transform-worker": "0.84.4",
+                "mime-types": "^3.0.1",
                 "nullthrows": "^1.1.1",
                 "serialize-error": "^2.1.0",
                 "source-map": "^0.5.6",
@@ -4387,93 +3257,111 @@
                 "metro": "src/cli.js"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-babel-transformer": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.83.3.tgz",
-            "integrity": "sha512-1vxlvj2yY24ES1O5RsSIvg4a4WeL7PFXgKOHvXTXiW0deLvQr28ExXj6LjwCCDZ4YZLhq6HddLpZnX4dEdSq5g==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-babel-transformer/-/metro-babel-transformer-0.84.4.tgz",
+            "integrity": "sha512-rvCfz8snl9h20VcvpOHxZuHP1SlAkv4HXbzw7nyyVwu6Eqo5PRerbakQ9XmUCOsRy70spJ37O+G1TK8oMzo48g==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.25.2",
                 "flow-enums-runtime": "^0.0.6",
-                "hermes-parser": "0.32.0",
+                "hermes-parser": "0.35.0",
+                "metro-cache-key": "0.84.4",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
+            }
+        },
+        "node_modules/metro-babel-transformer/node_modules/hermes-estree": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+            "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
+            "license": "MIT",
+            "peer": true
+        },
+        "node_modules/metro-babel-transformer/node_modules/hermes-parser": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+            "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hermes-estree": "0.35.0"
             }
         },
         "node_modules/metro-cache": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.83.3.tgz",
-            "integrity": "sha512-3jo65X515mQJvKqK3vWRblxDEcgY55Sk3w4xa6LlfEXgQ9g1WgMh9m4qVZVwgcHoLy0a2HENTPCCX4Pk6s8c8Q==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-cache/-/metro-cache-0.84.4.tgz",
+            "integrity": "sha512-gpcFQdSLUwUCk71saKoE64jLFbx2nwTfVCcPSULMNT8QYq0p1eZZE29Jvd0HtT/UlhC3ZOutLxJME5xqD2JUZg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "exponential-backoff": "^3.1.1",
                 "flow-enums-runtime": "^0.0.6",
                 "https-proxy-agent": "^7.0.5",
-                "metro-core": "0.83.3"
+                "metro-core": "0.84.4"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-cache-key": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.83.3.tgz",
-            "integrity": "sha512-59ZO049jKzSmvBmG/B5bZ6/dztP0ilp0o988nc6dpaDsU05Cl1c/lRf+yx8m9WW/JVgbmfO5MziBU559XjI5Zw==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-cache-key/-/metro-cache-key-0.84.4.tgz",
+            "integrity": "sha512-wVO79aGrkYImpnaVS4+d5RrRBRPX31QtvKB3wKGBuiNSznduZTQHzsrJZRroFJSwnygrzdsGUtDQPuqqFjFdvw==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-config": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.83.3.tgz",
-            "integrity": "sha512-mTel7ipT0yNjKILIan04bkJkuCzUUkm2SeEaTads8VfEecCh+ltXchdq6DovXJqzQAXuR2P9cxZB47Lg4klriA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-config/-/metro-config-0.84.4.tgz",
+            "integrity": "sha512-PMotGDjXcXLWo2TMRH+VR99phFNgYTwqh4OoieIKK3yTJa1Jmkl+fZJxDO0jfBvNF+WESHciHvpNuBtXaF3B0Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "connect": "^3.6.5",
                 "flow-enums-runtime": "^0.0.6",
                 "jest-validate": "^29.7.0",
-                "metro": "0.83.3",
-                "metro-cache": "0.83.3",
-                "metro-core": "0.83.3",
-                "metro-runtime": "0.83.3",
+                "metro": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-core": "0.84.4",
+                "metro-runtime": "0.84.4",
                 "yaml": "^2.6.1"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-core": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.83.3.tgz",
-            "integrity": "sha512-M+X59lm7oBmJZamc96usuF1kusd5YimqG/q97g4Ac7slnJ3YiGglW5CsOlicTR5EWf8MQFxxjDoB6ytTqRe8Hw==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-core/-/metro-core-0.84.4.tgz",
+            "integrity": "sha512-HONpWC5LGXZn3ffkd4Hu6AIrfE7j4Z0g0wMo/goV24WOB3lhuFZ40KgvaDiSw8iyQHloMYay5N/wPX+z8oN/PQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6",
                 "lodash.throttle": "^4.1.1",
-                "metro-resolver": "0.83.3"
+                "metro-resolver": "0.84.4"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-file-map": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.83.3.tgz",
-            "integrity": "sha512-jg5AcyE0Q9Xbbu/4NAwwZkmQn7doJCKGW0SLeSJmzNB9Z24jBe0AL2PHNMy4eu0JiKtNWHz9IiONGZWq7hjVTA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-file-map/-/metro-file-map-0.84.4.tgz",
+            "integrity": "sha512-KSVDi/u60hKPx++NLu3MTIvyjzNoJnFAF8PQFxaj1jiSka/wjw+Ua6sNuJ0TDHQv+7AAoFQxeMgaRAe8Yic5wQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -4488,13 +3376,13 @@
                 "walker": "^1.0.7"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-minify-terser": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.83.3.tgz",
-            "integrity": "sha512-O2BmfWj6FSfzBLrNCXt/rr2VYZdX5i6444QJU0fFoc7Ljg+Q+iqebwE3K0eTvkI6TRjELsXk1cjU+fXwAR4OjQ==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-minify-terser/-/metro-minify-terser-0.84.4.tgz",
+            "integrity": "sha512-5qpbaVOMC7CPitIpuewzVeGw7E+C3ykbv2mqTjQLl85Z3annSVGlSCTcsZjqXZzjupfK4Ztj3dDc4kc44NZwtQ==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -4502,26 +3390,26 @@
                 "terser": "^5.15.0"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-resolver": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.83.3.tgz",
-            "integrity": "sha512-0js+zwI5flFxb1ktmR///bxHYg7OLpRpWZlBBruYG8OKYxeMP7SV0xQ/o/hUelrEMdK4LJzqVtHAhBm25LVfAQ==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-resolver/-/metro-resolver-0.84.4.tgz",
+            "integrity": "sha512-1qLgbxQ5ZGhhutuPot1Yp348ofDsATL2WkrHF65TobqTT9K3P9qJXw38bomk7ncp5B7OYMfWwtyBZo1lCV792A==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-runtime": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.83.3.tgz",
-            "integrity": "sha512-JHCJb9ebr9rfJ+LcssFYA2x1qPYuSD/bbePupIGhpMrsla7RCwC/VL3yJ9cSU+nUhU4c9Ixxy8tBta+JbDeZWw==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-runtime/-/metro-runtime-0.84.4.tgz",
+            "integrity": "sha512-Jibypds4g7AhzdRKY+kDoj51s5EXMwgyp5ddtlreDAsWefMdOx+agWqgm0H2XSZ/ueanHHVM89fnf5OJnlxa8Q==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
@@ -4529,41 +3417,40 @@
                 "flow-enums-runtime": "^0.0.6"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-source-map": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.83.3.tgz",
-            "integrity": "sha512-xkC3qwUBh2psVZgVavo8+r2C9Igkk3DibiOXSAht1aYRRcztEZNFtAMtfSB7sdO2iFMx2Mlyu++cBxz/fhdzQg==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-source-map/-/metro-source-map-0.84.4.tgz",
+            "integrity": "sha512-jbWkPxIesVuo1IWkvezmMJld6iu8nD62GsrZiV6jP37AOdbo4OBq1FJ+qkOg8sV05wAHB//jAbziuW0SlJfW4g==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@babel/traverse": "^7.25.3",
-                "@babel/traverse--for-generate-function-map": "npm:@babel/traverse@^7.25.3",
-                "@babel/types": "^7.25.2",
+                "@babel/traverse": "^7.29.0",
+                "@babel/types": "^7.29.0",
                 "flow-enums-runtime": "^0.0.6",
                 "invariant": "^2.2.4",
-                "metro-symbolicate": "0.83.3",
+                "metro-symbolicate": "0.84.4",
                 "nullthrows": "^1.1.1",
-                "ob1": "0.83.3",
+                "ob1": "0.84.4",
                 "source-map": "^0.5.6",
                 "vlq": "^1.0.0"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-symbolicate": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.83.3.tgz",
-            "integrity": "sha512-F/YChgKd6KbFK3eUR5HdUsfBqVsanf5lNTwFd4Ca7uuxnHgBC3kR/Hba/RGkenR3pZaGNp5Bu9ZqqP52Wyhomw==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-symbolicate/-/metro-symbolicate-0.84.4.tgz",
+            "integrity": "sha512-OnfpacxUqGPZQ27t8qK9mFa7uqHIlVWeqRqkCbvMvreEBiamEeOn8krKtcwgP5M4cYDPwuSmCTopHMVthqG4zA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6",
                 "invariant": "^2.2.4",
-                "metro-source-map": "0.83.3",
+                "metro-source-map": "0.84.4",
                 "nullthrows": "^1.1.1",
                 "source-map": "^0.5.6",
                 "vlq": "^1.0.0"
@@ -4572,58 +3459,141 @@
                 "metro-symbolicate": "src/index.js"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-transform-plugins": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.83.3.tgz",
-            "integrity": "sha512-eRGoKJU6jmqOakBMH5kUB7VitEWiNrDzBHpYbkBXW7C5fUGeOd2CyqrosEzbMK5VMiZYyOcNFEphvxk3OXey2A==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-transform-plugins/-/metro-transform-plugins-0.84.4.tgz",
+            "integrity": "sha512-kehr6HbAecqD0/a3xLXobELdPaAmRAl8bel0qagPF4vhZtux93nS8S4eq2kgKt6J2GnQpVjSoW1PXdst04mwow==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.25.2",
-                "@babel/generator": "^7.25.0",
-                "@babel/template": "^7.25.0",
-                "@babel/traverse": "^7.25.3",
+                "@babel/generator": "^7.29.1",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.29.0",
                 "flow-enums-runtime": "^0.0.6",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/metro-transform-worker": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.83.3.tgz",
-            "integrity": "sha512-Ztekew9t/gOIMZX1tvJOgX7KlSLL5kWykl0Iwu2cL2vKMKVALRl1hysyhUw0vjpAvLFx+Kfq9VLjnHIkW32fPA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/metro-transform-worker/-/metro-transform-worker-0.84.4.tgz",
+            "integrity": "sha512-W1IYMvvXTu4MxYr7d9h7CeG2vpIr3bmLLIavkPY4O1ilzDrvS8z/NEe6y+pC44Ff7raMXQgYSfdqDUwN/i39gg==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "@babel/core": "^7.25.2",
-                "@babel/generator": "^7.25.0",
-                "@babel/parser": "^7.25.3",
-                "@babel/types": "^7.25.2",
+                "@babel/generator": "^7.29.1",
+                "@babel/parser": "^7.29.0",
+                "@babel/types": "^7.29.0",
                 "flow-enums-runtime": "^0.0.6",
-                "metro": "0.83.3",
-                "metro-babel-transformer": "0.83.3",
-                "metro-cache": "0.83.3",
-                "metro-cache-key": "0.83.3",
-                "metro-minify-terser": "0.83.3",
-                "metro-source-map": "0.83.3",
-                "metro-transform-plugins": "0.83.3",
+                "metro": "0.84.4",
+                "metro-babel-transformer": "0.84.4",
+                "metro-cache": "0.84.4",
+                "metro-cache-key": "0.84.4",
+                "metro-minify-terser": "0.84.4",
+                "metro-source-map": "0.84.4",
+                "metro-transform-plugins": "0.84.4",
                 "nullthrows": "^1.1.1"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
-        "node_modules/metro/node_modules/ci-info": {
+        "node_modules/metro/node_modules/accepts": {
             "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
-            "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==",
+            "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+            "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "mime-types": "^3.0.0",
+                "negotiator": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/metro/node_modules/hermes-estree": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.35.0.tgz",
+            "integrity": "sha512-xVx5Opwy8Oo1I5yGpVRhCvWL/iV3M+ylksSKVNlxxD90cpDpR/AR1jLYqK8HWihm065a6UI3HeyAmYzwS8NOOg==",
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/metro/node_modules/hermes-parser": {
+            "version": "0.35.0",
+            "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.35.0.tgz",
+            "integrity": "sha512-9JLjeHxBx8T4CAsydZR49PNZUaix+WpQJwu9p2010lu+7Kwl6D/7wYFFJxoz+aXkaaClp9Zfg6W6/zVlSJORaA==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "hermes-estree": "0.35.0"
+            }
+        },
+        "node_modules/metro/node_modules/mime-db": {
+            "version": "1.54.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+            "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/metro/node_modules/mime-types": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+            "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "mime-db": "^1.54.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/metro/node_modules/negotiator": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+            "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">= 0.6"
+            }
+        },
+        "node_modules/metro/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/micromatch": {
             "version": "4.0.8",
@@ -4672,18 +3642,6 @@
                 "node": ">= 0.6"
             }
         },
-        "node_modules/minimalistic-assert": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-            "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
-            "license": "ISC"
-        },
-        "node_modules/minimalistic-crypto-utils": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
-            "integrity": "sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==",
-            "license": "MIT"
-        },
         "node_modules/minimatch": {
             "version": "10.2.4",
             "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.4.tgz",
@@ -4730,10 +3688,10 @@
             }
         },
         "node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "license": "ISC",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
             }
@@ -4774,9 +3732,9 @@
             "peer": true
         },
         "node_modules/node-releases": {
-            "version": "2.0.27",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
-            "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+            "version": "2.0.44",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.44.tgz",
+            "integrity": "sha512-5WUyunoPMsvvEhS8AxHtRzP+oA8UCkJ7YRxatWKjngndhDGLiqEVAQKWjFAiAiuL8zMRGzGSJxFnLetoa43qGQ==",
             "license": "MIT",
             "peer": true
         },
@@ -4826,6 +3784,7 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
             "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
@@ -4839,16 +3798,16 @@
             "peer": true
         },
         "node_modules/ob1": {
-            "version": "0.83.3",
-            "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.83.3.tgz",
-            "integrity": "sha512-egUxXCDwoWG06NGCS5s5AdcpnumHKJlfd3HH06P3m9TEMwwScfcY35wpQxbm9oHof+dM/lVH9Rfyu1elTVelSA==",
+            "version": "0.84.4",
+            "resolved": "https://registry.npmjs.org/ob1/-/ob1-0.84.4.tgz",
+            "integrity": "sha512-eJXMpz4aQHXF/YBB9ddqZDIS+ooO91hObo9FoW/xBkr54/zCwYYCDqT/O54vNo8kOkWs5Ou/y28NgdrV0edQNA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
                 "flow-enums-runtime": "^0.0.6"
             },
             "engines": {
-                "node": ">=20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             }
         },
         "node_modules/object-inspect": {
@@ -4910,45 +3869,6 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
-        "node_modules/p-limit": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-            "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "p-try": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/p-locate": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-            "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "p-limit": "^2.2.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/p-try": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-            "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/package-json-from-dist": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -4964,26 +3884,6 @@
                 "node": ">= 0.8"
             }
         },
-        "node_modules/path-exists": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-            "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/path-key": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
@@ -4994,16 +3894,16 @@
             }
         },
         "node_modules/path-scurry": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.1.tgz",
-            "integrity": "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
             "license": "BlueOak-1.0.0",
             "dependencies": {
                 "lru-cache": "^11.0.0",
                 "minipass": "^7.1.2"
             },
             "engines": {
-                "node": "20 || >=22"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
@@ -5095,16 +3995,6 @@
             "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
             "license": "MIT"
         },
-        "node_modules/pirates": {
-            "version": "4.0.7",
-            "resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
-            "integrity": "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">= 6"
-            }
-        },
         "node_modules/pretty-format": {
             "version": "29.7.0",
             "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-29.7.0.tgz",
@@ -5160,9 +4050,9 @@
             }
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.0.1.tgz",
+            "integrity": "sha512-NWWCCscLjs+cOKF/s/XVNFRW7Yih0fdH+9brffR5NZCy8k42yRdl5KlWKMVXuI1vfCoy4o1z80XR/W/QUb3V3w==",
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
             "dependencies": {
@@ -5287,9 +4177,9 @@
             }
         },
         "node_modules/react": {
-            "version": "19.2.4",
-            "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
-            "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
+            "version": "19.2.6",
+            "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+            "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
             "license": "MIT",
             "peer": true,
             "engines": {
@@ -5307,6 +4197,28 @@
                 "ws": "^7"
             }
         },
+        "node_modules/react-devtools-core/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=8.3.0"
+            },
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
+            },
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/react-is": {
             "version": "18.3.1",
             "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -5315,35 +4227,31 @@
             "peer": true
         },
         "node_modules/react-native": {
-            "version": "0.83.1",
-            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.83.1.tgz",
-            "integrity": "sha512-mL1q5HPq5cWseVhWRLl+Fwvi5z1UO+3vGOpjr+sHFwcUletPRZ5Kv+d0tUfqHmvi73/53NjlQqX1Pyn4GguUfA==",
+            "version": "0.85.3",
+            "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.85.3.tgz",
+            "integrity": "sha512-HN/fGC+3nZVcDNcw7gfbM/DuqZAvI9Mz+/SxuhODaua4JY0BPzhfTzWXRyTR4mRgMHmShTPpH2PYMTxvZrsdZA==",
             "license": "MIT",
             "peer": true,
             "dependencies": {
-                "@jest/create-cache-key-function": "^29.7.0",
-                "@react-native/assets-registry": "0.83.1",
-                "@react-native/codegen": "0.83.1",
-                "@react-native/community-cli-plugin": "0.83.1",
-                "@react-native/gradle-plugin": "0.83.1",
-                "@react-native/js-polyfills": "0.83.1",
-                "@react-native/normalize-colors": "0.83.1",
-                "@react-native/virtualized-lists": "0.83.1",
+                "@react-native/assets-registry": "0.85.3",
+                "@react-native/codegen": "0.85.3",
+                "@react-native/community-cli-plugin": "0.85.3",
+                "@react-native/gradle-plugin": "0.85.3",
+                "@react-native/js-polyfills": "0.85.3",
+                "@react-native/normalize-colors": "0.85.3",
+                "@react-native/virtualized-lists": "0.85.3",
                 "abort-controller": "^3.0.0",
                 "anser": "^1.4.9",
                 "ansi-regex": "^5.0.0",
-                "babel-jest": "^29.7.0",
-                "babel-plugin-syntax-hermes-parser": "0.32.0",
+                "babel-plugin-syntax-hermes-parser": "0.33.3",
                 "base64-js": "^1.5.1",
                 "commander": "^12.0.0",
                 "flow-enums-runtime": "^0.0.6",
-                "glob": "^7.1.1",
-                "hermes-compiler": "0.14.0",
+                "hermes-compiler": "250829098.0.10",
                 "invariant": "^2.2.4",
-                "jest-environment-node": "^29.7.0",
                 "memoize-one": "^5.0.0",
-                "metro-runtime": "^0.83.3",
-                "metro-source-map": "^0.83.3",
+                "metro-runtime": "^0.84.3",
+                "metro-source-map": "^0.84.3",
                 "nullthrows": "^1.1.1",
                 "pretty-format": "^29.7.0",
                 "promise": "^8.3.0",
@@ -5353,6 +4261,7 @@
                 "scheduler": "0.27.0",
                 "semver": "^7.1.3",
                 "stacktrace-parser": "^0.1.10",
+                "tinyglobby": "^0.2.15",
                 "whatwg-fetch": "^3.0.0",
                 "ws": "^7.5.10",
                 "yargs": "^17.6.2"
@@ -5361,28 +4270,32 @@
                 "react-native": "cli.js"
             },
             "engines": {
-                "node": ">= 20.19.4"
+                "node": "^20.19.4 || ^22.13.0 || ^24.3.0 || >= 25.0.0"
             },
             "peerDependencies": {
+                "@react-native/jest-preset": "0.85.3",
                 "@types/react": "^19.1.1",
-                "react": "^19.2.0"
+                "react": "^19.2.3"
             },
             "peerDependenciesMeta": {
+                "@react-native/jest-preset": {
+                    "optional": true
+                },
                 "@types/react": {
                     "optional": true
                 }
             }
         },
         "node_modules/react-native-get-random-values": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-1.11.0.tgz",
-            "integrity": "sha512-4BTbDbRmS7iPdhYLRcz3PGFIpFJBwNZg9g42iwa2P6FOv9vZj/xJc678RZXnLNZzd0qd7Q3CCF6Yd+CU2eoXKQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/react-native-get-random-values/-/react-native-get-random-values-2.0.0.tgz",
+            "integrity": "sha512-wx7/aPqsUIiWsG35D+MsUJd8ij96e3JKddklSdrdZUrheTx89gPtz3Q2yl9knBArj5u26Cl23T88ai+Q0vypdQ==",
             "license": "MIT",
             "dependencies": {
                 "fast-base64-decode": "^1.0.0"
             },
             "peerDependencies": {
-                "react-native": ">=0.56"
+                "react-native": ">=0.81"
             }
         },
         "node_modules/react-native/node_modules/ansi-regex": {
@@ -5395,39 +4308,26 @@
                 "node": ">=8"
             }
         },
-        "node_modules/react-native/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
+        "node_modules/react-native/node_modules/ws": {
+            "version": "7.5.10",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "license": "MIT",
             "peer": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
             "engines": {
-                "node": "*"
+                "node": ">=8.3.0"
             },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/react-native/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
+            "peerDependencies": {
+                "bufferutil": "^4.0.1",
+                "utf-8-validate": "^5.0.2"
             },
-            "engines": {
-                "node": "*"
+            "peerDependenciesMeta": {
+                "bufferutil": {
+                    "optional": true
+                },
+                "utf-8-validate": {
+                    "optional": true
+                }
             }
         },
         "node_modules/react-refresh": {
@@ -5478,16 +4378,6 @@
                 "node": ">=0.10.0"
             }
         },
-        "node_modules/resolve-from": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
-            "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/rfc4648": {
             "version": "1.5.3",
             "resolved": "https://registry.npmjs.org/rfc4648/-/rfc4648-1.5.3.tgz",
@@ -5495,55 +4385,39 @@
             "license": "MIT"
         },
         "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "deprecated": "Rimraf versions prior to v4 are no longer supported",
-            "license": "ISC",
-            "peer": true,
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-6.1.2.tgz",
+            "integrity": "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "glob": "^7.1.3"
+                "glob": "^13.0.0",
+                "package-json-from-dist": "^1.0.1"
             },
             "bin": {
-                "rimraf": "bin.js"
+                "rimraf": "dist/esm/bin.mjs"
+            },
+            "engines": {
+                "node": "20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/rimraf/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
-            "peer": true,
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
             },
             "engines": {
-                "node": "*"
+                "node": "18 || 20 || >=22"
             },
             "funding": {
                 "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/rimraf/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
             }
         },
         "node_modules/safe-buffer": {
@@ -5816,16 +4690,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/sonic-boom": {
             "version": "4.2.0",
             "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
@@ -5879,36 +4743,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">= 10.x"
-            }
-        },
-        "node_modules/sprintf-js": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-            "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-            "license": "BSD-3-Clause",
-            "peer": true
-        },
-        "node_modules/stack-utils": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-2.0.6.tgz",
-            "integrity": "sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "escape-string-regexp": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/stack-utils/node_modules/escape-string-regexp": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
-            "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/stackframe": {
@@ -6062,9 +4896,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.46.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.46.0.tgz",
-            "integrity": "sha512-jTwoImyr/QbOWFFso3YoU3ik0jBBDJ6JTOQiy/J2YxVJdZCc+5u7skhNwiOR3FQIygFqVUPHl7qbbxtjW2K3Qg==",
+            "version": "5.47.1",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.47.1.tgz",
+            "integrity": "sha512-tPbLXTI6ohPASb/1YViL428oEHu6/qv1OxqYnfaonVCFHqx4+wCd95pHrQWsL5X4pl90CTyW9piSAsS2L0VoMw==",
             "license": "BSD-2-Clause",
             "peer": true,
             "dependencies": {
@@ -6087,56 +4921,6 @@
             "license": "MIT",
             "peer": true
         },
-        "node_modules/test-exclude": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz",
-            "integrity": "sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "@istanbuljs/schema": "^0.1.2",
-                "glob": "^7.1.4",
-                "minimatch": "^3.0.4"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/test-exclude/node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-            "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
-        },
-        "node_modules/test-exclude/node_modules/minimatch": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-            "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "brace-expansion": "^1.1.7"
-            },
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/thread-stream": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
@@ -6152,6 +4936,54 @@
             "integrity": "sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==",
             "license": "MIT",
             "peer": true
+        },
+        "node_modules/tinyglobby": {
+            "version": "0.2.16",
+            "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+            "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "fdir": "^6.5.0",
+                "picomatch": "^4.0.4"
+            },
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinyglobby/node_modules/fdir": {
+            "version": "6.5.0",
+            "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+            "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12.0.0"
+            },
+            "peerDependencies": {
+                "picomatch": "^3 || ^4"
+            },
+            "peerDependenciesMeta": {
+                "picomatch": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/tinyglobby/node_modules/picomatch": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+            "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/jonschlinkert"
+            }
         },
         "node_modules/tmpl": {
             "version": "1.0.5",
@@ -6246,16 +5078,6 @@
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
             "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
             "license": "Unlicense"
-        },
-        "node_modules/type-detect": {
-            "version": "4.0.8",
-            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
-            "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=4"
-            }
         },
         "node_modules/type-fest": {
             "version": "0.7.1",
@@ -6515,39 +5337,17 @@
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
         },
-        "node_modules/write-file-atomic": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.2.tgz",
-            "integrity": "sha512-7KxauUdBmSdWnmpaGFg+ppNjKF8uNLry8LyzjauQDOVONfFLNKrKvQOxZ/VuTIcS/gge/YNahf5RIIQWTSarlg==",
-            "license": "ISC",
-            "peer": true,
-            "dependencies": {
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
-            },
-            "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
-            }
-        },
-        "node_modules/write-file-atomic/node_modules/signal-exit": {
-            "version": "3.0.7",
-            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-            "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-            "license": "ISC",
-            "peer": true
-        },
         "node_modules/ws": {
-            "version": "7.5.10",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-            "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+            "version": "8.17.1",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+            "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
             "license": "MIT",
-            "peer": true,
             "engines": {
-                "node": ">=8.3.0"
+                "node": ">=10.0.0"
             },
             "peerDependencies": {
                 "bufferutil": "^4.0.1",
-                "utf-8-validate": "^5.0.2"
+                "utf-8-validate": ">=5.0.2"
             },
             "peerDependenciesMeta": {
                 "bufferutil": {
@@ -6575,9 +5375,9 @@
             "peer": true
         },
         "node_modules/yaml": {
-            "version": "2.8.3",
-            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
-            "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+            "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
             "license": "ISC",
             "peer": true,
             "bin": {

--- a/tck/package.json
+++ b/tck/package.json
@@ -12,13 +12,15 @@
     "license": "ISC",
     "repository": "https://github.com/hiero-ledger/hiero-sdk-js",
     "dependencies": {
-        "@hiero-ledger/sdk": "2.79.0-beta.12",
+        "@hiero-ledger/proto": "^2.30.0",
+        "@hiero-ledger/sdk": "2.84.0",
         "ansi-regex": "6.2.2",
         "ansi-styles": "6.2.3",
         "body-parser": "1.20.3",
         "express": "4.22.1",
         "glob": "11.0.3",
         "json-rpc-2.0": "1.7.0",
+        "long": "^5.3.1",
         "lossless-json": "1.0.5",
         "strip-ansi": "7.1.2"
     },

--- a/tck/params/fee-estimate.ts
+++ b/tck/params/fee-estimate.ts
@@ -1,0 +1,30 @@
+import { BaseParams } from "./base";
+
+/**
+ * HIP-1261 fee estimation modes.
+ * - STATE: estimate using the transaction plus the mirror node's latest known state.
+ * - INTRINSIC: estimate from the payload alone (default per the spec).
+ */
+export type FeeEstimateModeName = "STATE" | "INTRINSIC";
+
+/**
+ * Transaction types supported by the TCK fee-estimate endpoint.
+ * v1 covers the JS SDK PR #3478 scenarios plus a couple of common types.
+ */
+export type FeeEstimateTransactionType =
+    | "AccountCreate"
+    | "TransferCrypto"
+    | "TokenCreate"
+    | "TokenMint"
+    | "TopicCreate"
+    | "TopicMessageSubmit"
+    | "ContractCreate"
+    | "FileCreate"
+    | "FileAppend";
+
+export interface ExecuteFeeEstimateQueryParams extends BaseParams {
+    readonly mode?: FeeEstimateModeName;
+    readonly highVolumeThrottle?: number;
+    readonly transactionType: FeeEstimateTransactionType;
+    readonly transactionParams?: Record<string, any>;
+}

--- a/tck/response/fee-estimate.ts
+++ b/tck/response/fee-estimate.ts
@@ -1,0 +1,33 @@
+/**
+ * Response types for the HIP-1261 fee estimation endpoint.
+ *
+ * All tinycent values are stringified Long values to preserve precision,
+ * matching the existing TCK convention for balances/supplies.
+ */
+
+export interface FeeExtraResponse {
+    readonly name: string;
+    readonly included: number;
+    readonly count: number;
+    readonly charged: number;
+    readonly feePerUnit: string;
+    readonly subtotal: string;
+}
+
+export interface FeeEstimateComponentResponse {
+    readonly base: string;
+    readonly extras: FeeExtraResponse[];
+}
+
+export interface NetworkFeeResponse {
+    readonly multiplier: number;
+    readonly subtotal: string;
+}
+
+export interface FeeEstimateQueryResponse {
+    readonly highVolumeMultiplier: string;
+    readonly networkFee: NetworkFeeResponse;
+    readonly nodeFee: FeeEstimateComponentResponse;
+    readonly serviceFee: FeeEstimateComponentResponse;
+    readonly total: string;
+}


### PR DESCRIPTION
## Summary
Wires `FeeEstimateQuery` (HIP-1261) into the TCK JSON-RPC server (`tck/`) so the hiero-sdk-tck network-service suite can drive it.

- New `executeFeeEstimateQuery` method dispatches on `transactionType`, builds the inner transaction via the existing `build*` helpers (plus local builders for `FileCreate` / `FileAppend` / `ContractCreate`), wraps it in a `FeeEstimateQuery`, and returns a JSON breakdown (`networkFee`, `nodeFee`, `serviceFee`, `total`, `highVolumeMultiplier`).
- Supported `transactionType` values in v1: `AccountCreate`, `TransferCrypto`, `TokenCreate`, `TokenMint`, `TopicCreate`, `TopicMessageSubmit`, `ContractCreate`, `FileCreate`, `FileAppend`.
- Bumps `@hiero-ledger/sdk` to `2.84.0` (first published version with `FeeEstimateQuery`) and declares `@hiero-ledger/proto` and `long` as direct deps — `tck/`'s package.json was previously relying on npm transitive hoisting for these, which broke when the dep graph shifted.
- Exports `buildCreateToken` from `methods/token.ts` so the new method can reuse it.

Spec + tests live on the TCK side: https://github.com/hiero-ledger/hiero-sdk-tck/pull/649

## Test plan
- [x] `npx tsc --noEmit` clean from `tck/`
- [x] `npm start` boots the server cleanly
- [ ] hiero-sdk-tck network-service suite green once the upstream mirror node `FeeEstimationService` race is fixed (see TCK PR for details)

Closes #4086
