### PR TITLE
fix: drop deprecated endTime from FreezeTransaction

### DIFF
--- a/src/system/FreezeTransaction.js
+++ b/src/system/FreezeTransaction.js
@@ -143,36 +143,38 @@ export default class FreezeTransaction extends Transaction {
             body.freeze
         );
 
+        const freezeTransaction = new FreezeTransaction({
+            startTime:
+                freeze.startHour != null && freeze.startMin != null
+                    ? {
+                          hour: freeze.startHour,
+                          minute: freeze.startMin,
+                      }
+                    : undefined,
+            startTimestamp:
+                freeze.startTime != null
+                    ? Timestamp._fromProtobuf(freeze.startTime)
+                    : undefined,
+            updateFileId:
+                freeze.updateFile != null
+                    ? FileId._fromProtobuf(freeze.updateFile)
+                    : undefined,
+            fileHash: freeze.fileHash != null ? freeze.fileHash : undefined,
+            freezeType:
+                freeze.freezeType != null
+                    ? FreezeType._fromCode(freeze.freezeType)
+                    : undefined,
+        });
+
+        if (freeze.endHour != null && freeze.endMin != null) {
+            freezeTransaction._endTime = {
+                hour: freeze.endHour,
+                minute: freeze.endMin,
+            };
+        }
+
         return Transaction._fromProtobufTransactions(
-            new FreezeTransaction({
-                startTime:
-                    freeze.startHour != null && freeze.startMin != null
-                        ? {
-                              hour: freeze.startHour,
-                              minute: freeze.startMin,
-                          }
-                        : undefined,
-                endTime:
-                    freeze.endHour != null && freeze.endMin != null
-                        ? {
-                              hour: freeze.endHour,
-                              minute: freeze.endMin,
-                          }
-                        : undefined,
-                startTimestamp:
-                    freeze.startTime != null
-                        ? Timestamp._fromProtobuf(freeze.startTime)
-                        : undefined,
-                updateFileId:
-                    freeze.updateFile != null
-                        ? FileId._fromProtobuf(freeze.updateFile)
-                        : undefined,
-                fileHash: freeze.fileHash != null ? freeze.fileHash : undefined,
-                freezeType:
-                    freeze.freezeType != null
-                        ? FreezeType._fromCode(freeze.freezeType)
-                        : undefined,
-            }),
+            freezeTransaction,
             transactions,
             signedTransactions,
             transactionIds,
@@ -232,22 +234,26 @@ export default class FreezeTransaction extends Transaction {
     }
 
     /**
-     * @deprecated
+     * @deprecated The network ignores this field and there is no replacement.
      * @returns {?HourMinute}
      */
     get endTime() {
-        console.warn("`FreezeTransaction.endTime` is deprecated");
+        console.warn(
+            "`FreezeTransaction.endTime` is deprecated: the network ignores this field and there is no replacement",
+        );
         return this._endTime;
     }
 
     /**
-     * @deprecated
+     * @deprecated The network ignores this field and there is no replacement.
      * @param {number | string} endHourOrString
      * @param {?number} endMinute
      * @returns {FreezeTransaction}
      */
     setEndTime(endHourOrString, endMinute) {
-        console.warn("`FreezeTransaction.endTime` is deprecated");
+        console.warn(
+            "`FreezeTransaction.endTime` is deprecated: the network ignores this field and there is no replacement",
+        );
         this._requireNotFrozen();
         if (typeof endHourOrString === "string") {
             const split = endHourOrString.split(":");


### PR DESCRIPTION
**Description**:

1. `_fromProtobuf` reconstructed a `FreezeTransaction` by passing `endTime` through the public constructor path, which fired the
  `endTime is deprecated` console warning for any user simply deserializing a transaction — even though they never touched the field.
2. The deprecation messages and JSDoc said only `@deprecated`, giving users no reason or migration path.

**Related issue(s)**:
#4067
Fixes
#4067

**Notes for reviewer**:
<!-- Provide logs, performance numbers or screenshots of the new functionality -->

**Checklist**

- [x] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)
