### PR TITLE
fix(eslint): consume eslint-plugin-n v18 flat config directly

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -7,6 +7,10 @@ const { fixupConfigRules, fixupPluginRules } = require("@eslint/compat");
 const tsParser = require("@typescript-eslint/parser");
 const typescriptEslint = require("@typescript-eslint/eslint-plugin");
 const deprecation = require("eslint-plugin-deprecation");
+// eslint-plugin-n v18+ is ESM-only and no longer resolvable through
+// FlatCompat's "plugin:n/recommended" string, so consume its flat config
+// directly. `.default` unwraps the ESM namespace returned by require().
+const nodePlugin = require("eslint-plugin-n").default;
 const js = require("@eslint/js");
 
 const { FlatCompat } = require("@eslint/eslintrc");
@@ -37,19 +41,21 @@ module.exports = defineConfig([
             },
         },
 
-        extends: fixupConfigRules(
-            compat.extends(
-                "eslint:recommended",
-                "plugin:@typescript-eslint/eslint-recommended",
-                "plugin:@typescript-eslint/recommended",
-                "plugin:@typescript-eslint/recommended-requiring-type-checking",
-                "plugin:jsdoc/recommended",
-                "plugin:import/errors",
-                "plugin:import/typescript",
-                "plugin:n/recommended",
-                "plugin:compat/recommended",
+        extends: [
+            ...fixupConfigRules(
+                compat.extends(
+                    "eslint:recommended",
+                    "plugin:@typescript-eslint/eslint-recommended",
+                    "plugin:@typescript-eslint/recommended",
+                    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+                    "plugin:jsdoc/recommended",
+                    "plugin:import/errors",
+                    "plugin:import/typescript",
+                    "plugin:compat/recommended",
+                ),
             ),
-        ),
+            nodePlugin.configs["flat/recommended"],
+        ],
 
         plugins: {
             "@typescript-eslint": fixupPluginRules(typescriptEslint),

--- a/packages/cryptography/eslint.config.cjs
+++ b/packages/cryptography/eslint.config.cjs
@@ -8,6 +8,10 @@ const tsParser = require("@typescript-eslint/parser");
 const typescriptEslint = require("@typescript-eslint/eslint-plugin");
 const deprecation = require("eslint-plugin-deprecation");
 const vitest = require("@vitest/eslint-plugin");
+// eslint-plugin-n v18+ is ESM-only and no longer resolvable through
+// FlatCompat's "plugin:n/recommended" string, so consume its flat config
+// directly. `.default` unwraps the ESM namespace returned by require().
+const nodePlugin = require("eslint-plugin-n").default;
 const js = require("@eslint/js");
 
 const { FlatCompat } = require("@eslint/eslintrc");
@@ -25,18 +29,23 @@ const baseExtends = [
     "plugin:jsdoc/recommended",
     "plugin:import/errors",
     "plugin:import/typescript",
-    "plugin:n/recommended",
     "plugin:compat/recommended",
 ];
 
-const srcExtends = fixupConfigRules(
-    compat.extends(
-        ...baseExtends,
-        "plugin:@typescript-eslint/recommended-requiring-type-checking",
+const srcExtends = [
+    ...fixupConfigRules(
+        compat.extends(
+            ...baseExtends,
+            "plugin:@typescript-eslint/recommended-requiring-type-checking",
+        ),
     ),
-);
+    nodePlugin.configs["flat/recommended"],
+];
 
-const testExtends = fixupConfigRules(compat.extends(...baseExtends));
+const testExtends = [
+    ...fixupConfigRules(compat.extends(...baseExtends)),
+    nodePlugin.configs["flat/recommended"],
+];
 
 const sharedRules = {
     "@typescript-eslint/explicit-function-return-type": "off",

--- a/packages/proto/eslint.config.cjs
+++ b/packages/proto/eslint.config.cjs
@@ -6,6 +6,10 @@ const { fixupConfigRules, fixupPluginRules } = require("@eslint/compat");
 
 const tsParser = require("@typescript-eslint/parser");
 const typescriptEslint = require("@typescript-eslint/eslint-plugin");
+// eslint-plugin-n v18+ is ESM-only and no longer resolvable through
+// FlatCompat's "plugin:n/recommended" string, so consume its flat config
+// directly. `.default` unwraps the ESM namespace returned by require().
+const nodePlugin = require("eslint-plugin-n").default;
 const js = require("@eslint/js");
 
 const { FlatCompat } = require("@eslint/eslintrc");
@@ -40,19 +44,21 @@ module.exports = defineConfig([
             },
         },
 
-        extends: fixupConfigRules(
-            compat.extends(
-                "eslint:recommended",
-                "plugin:@typescript-eslint/eslint-recommended",
-                "plugin:@typescript-eslint/recommended",
-                "plugin:@typescript-eslint/recommended-requiring-type-checking",
-                "plugin:jsdoc/recommended",
-                "plugin:import/errors",
-                "plugin:import/typescript",
-                "plugin:n/recommended",
-                "plugin:compat/recommended",
+        extends: [
+            ...fixupConfigRules(
+                compat.extends(
+                    "eslint:recommended",
+                    "plugin:@typescript-eslint/eslint-recommended",
+                    "plugin:@typescript-eslint/recommended",
+                    "plugin:@typescript-eslint/recommended-requiring-type-checking",
+                    "plugin:jsdoc/recommended",
+                    "plugin:import/errors",
+                    "plugin:import/typescript",
+                    "plugin:compat/recommended",
+                ),
             ),
-        ),
+            nodePlugin.configs["flat/recommended"],
+        ],
 
         plugins: {
             "@typescript-eslint": fixupPluginRules(typescriptEslint),


### PR DESCRIPTION
## What

Companion fix for #4131 (the Dependabot bump of `eslint-plugin-n` 17 → 18). Targets the Dependabot branch so the bump can land green.

## Why

`eslint-plugin-n` v18 migrated to **ESM-only**. `@eslint/eslintrc`'s `FlatCompat` can no longer resolve the legacy `"plugin:n/recommended"` shareable-config string, so every config that extends it fails to load. On #4131 this surfaces as a hard failure in `proto:build` — which cascades into Build / Test / Integration / examples across Node 22 & 24:

```
ESLint couldn't find the config "plugin:n/recommended" to extend from.
The config "plugin:n/recommended" was referenced from the config file in "".
task: Failed to run task "proto:build": exit status 201
```

## How

In all three flat configs (`eslint.config.cjs`, `packages/proto/eslint.config.cjs`, `packages/cryptography/eslint.config.cjs`):

- `require("eslint-plugin-n").default` (`.default` unwraps the ESM namespace returned by `require()`),
- drop `"plugin:n/recommended"` from the `FlatCompat` extends list,
- append `nodePlugin.configs["flat/recommended"]` to the flat-config `extends` array.

The plugin's flat config registers itself under the `n` namespace, so the existing `n/no-unsupported-features/*` rule overrides continue to apply unchanged.

## Verification

Ran ESLint exactly as the Taskfiles do — all clean (0 errors; only pre-existing jsdoc warnings):

- root: `npx eslint "src/**/*.js"`
- proto: `npx eslint --config eslint.config.cjs "src/*.js"`
- cryptography: `npx eslint --config eslint.config.cjs "src/**/*.js" "test/unit/**/*.js"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)