### PR TITLE
chore(solo): bump default consensus and mirror node versions

### DIFF
--- a/scripts/solo-lib.js
+++ b/scripts/solo-lib.js
@@ -5,8 +5,8 @@ import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-export const DEFAULT_CONSENSUS_NODE_VERSION = "v0.69.1";
-export const DEFAULT_MIRROR_NODE_VERSION = "v0.145.2";
+export const DEFAULT_CONSENSUS_NODE_VERSION = "v0.74.0";
+export const DEFAULT_MIRROR_NODE_VERSION = "v0.156.0";
 export const DEFAULT_NUM_NODES = 1;
 export const DEFAULT_HBAR_AMOUNT = 10000000;
 


### PR DESCRIPTION
## Summary

Bumps the `task solo:setup` defaults in `scripts/solo-lib.js` to the versions the current Solo build targets:

| | before | after |
|---|---|---|
| consensus node | `v0.69.1` | `v0.74.0` |
| mirror node | `v0.145.2` | `v0.156.0` |

## Why

With current Solo, `task solo:setup` fails — the consensus node pod runs but never reaches ACTIVE, and Solo times out (`Node 'node1' is not ACTIVE [attempt = 300/300]`). The node crashes on startup:

```
ERROR java.lang.IllegalArgumentException: Port must be greater than or equal to 1
  at com.hedera.node.app.blocks.impl.streaming.BlockNodeConfiguration.<init>
  at ...BlockNodeConnectionManager.extractBlockNodesConfigurations
```

Solo gates the `block-nodes.json` port field name on consensus version: `>= 0.69.0` emits `streamingPort`/`servicePort`, otherwise the legacy `port` field. The old default `v0.69.1` lands in the new-schema bucket, but the v0.69.1 node binary still reads the legacy `port` field — so it parses the port as `0` and aborts before going ACTIVE.

`v0.74.0` (Solo's own default consensus version) uses the new schema, so Solo's output and the node agree. Mirror node is bumped to the matching `v0.156.0` (Solo's default) to keep a known-good pair.