### PR TITLE
chore(deps): bump codecov/codecov-action from 6.0.1 to 7.0.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,7 +256,7 @@ jobs:
           path: .
 
       - name: Upload Coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: >-


### PR DESCRIPTION
## Summary

Bumps `codecov/codecov-action` from **v6.0.1** to **v7.0.0** in `.github/workflows/build.yml` (Upload Coverage to Codecov step), pinned by commit SHA:

- `e79a6962e0d4c0c17b229090214935d2e33f8354` (v6.0.1) → `fb8b3582c8e4def4969c97caa2f19720cb33a72f` (v7.0.0)

Mirrors Dependabot PR #4144.

### Notable in v7.0.0
Per the [release notes](https://github.com/codecov/codecov-action/releases/tag/v7.0.0): due to keybase migration issues, the `codecovsecurity` account was deleted and signing now uses the `codecovsecops` account with the original GPG key. No workflow input changes are required.