### PR TITLE
chore(deps): bump renovatebot/github-action from 46.1.14 to 46.1.15

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -28,7 +28,7 @@ jobs:
           submodules: recursive
 
       - name: Self-hosted Renovate
-        uses: renovatebot/github-action@693b9ef15eec82123529a37c782242f091365961 # v46.1.14
+        uses: renovatebot/github-action@8217b3fc286df088d7c27f3255fe8414463bc0fd # v46.1.15
         with:
           configurationFile: .github/renovate.json
           token: ${{ secrets.RENOVATE_TOKEN }}


### PR DESCRIPTION
## Summary

Bumps `renovatebot/github-action` from **v46.1.14** to **v46.1.15** in `.github/workflows/renovate.yml` (Self-hosted Renovate step), pinned by commit SHA:

- `693b9ef15eec82123529a37c782242f091365961` (v46.1.14) → `8217b3fc286df088d7c27f3255fe8414463bc0fd` (v46.1.15)

Mirrors Dependabot PR #4147. Patch-level bump, no configuration changes.