### PR TITLE
test: add `NativeChannel` unit tests

### DIFF
--- a/src/channel/NativeChannel.js
+++ b/src/channel/NativeChannel.js
@@ -175,6 +175,7 @@ export default class NativeChannel extends Channel {
                         HttpStatus._fromValue(response.status),
                     );
                     callback(error, null);
+                    return;
                 }
 
                 const blob = await response.blob();

--- a/test/unit/NativeChannel.js
+++ b/test/unit/NativeChannel.js
@@ -1,0 +1,487 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { vi } from "vitest";
+import GrpcServiceError from "../../src/grpc/GrpcServiceError.js";
+import GrpcStatus from "../../src/grpc/GrpcStatus.js";
+import HttpError from "../../src/http/HttpError.js";
+import NativeChannel from "../../src/channel/NativeChannel.js";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+/**
+ * builds a mock fetch Response
+ * @param {number} status
+ * @param {Record<string, string|null>} grpcHeaders
+ * @param {Blob} [blob]
+ */
+function mockResponse(status, grpcHeaders = {}, blob = new Blob()) {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        headers: { get: (key) => grpcHeaders[key] ?? null },
+        blob: vi.fn().mockResolvedValue(blob),
+    };
+}
+
+/**
+ * creates a valid gRPC-web framed payload encoded as a data URL
+ * The frame: 1 byte type (0x00) + 4 bytes length + payload
+ * @param {Uint8Array} payload
+ * @returns {string}
+ */
+function makeDataUrl(payload) {
+    const frame = new Uint8Array(5 + payload.length);
+    frame[0] = 0; // data frame
+
+    new DataView(frame.buffer).setUint32(1, payload.length);
+    frame.set(payload, 5);
+
+    const base64 = btoa(String.fromCharCode(...frame));
+    return `data:application/octet-stream;base64,${base64}`;
+}
+
+describe("NativeChannel", function () {
+    beforeEach(function () {
+        vi.clearAllMocks();
+        vi.restoreAllMocks();
+        vi.stubGlobal(
+            "FileReader",
+            class {
+                readAsDataURL() {
+                    queueMicrotask(() => this.onloadend?.());
+                }
+            },
+        );
+    });
+
+    // Constructor
+    describe("constructor", function () {
+        it("should store the address", function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            expect(channel._address).to.equal("mainnet.example.com:443");
+        });
+
+        it("should initialize _isReady to false", function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            expect(channel._isReady).to.equal(false);
+        });
+
+        it("should accept an optional grpcDeadline", function () {
+            const channel = new NativeChannel("mainnet.example.com:443", 5000);
+            expect(channel._grpcDeadline).to.equal(5000);
+        });
+    });
+
+    // close()
+    describe("close", function () {
+        it("should not throw and return undefined", function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            const result = channel.close();
+            expect(result).to.be.undefined;
+        });
+    });
+
+    // _waitForReady
+    describe("_waitForReady", function () {
+        it("should return immediately when _isReady is true (cached)", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const deadline = new Date(Date.now() + 10000);
+            await channel._waitForReady(deadline);
+
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it("should use https for non-localhost addresses", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockResolvedValue(
+                mockResponse(200, { "grpc-status": "0" }),
+            );
+
+            const deadline = new Date(Date.now() + 10000);
+            await channel._waitForReady(deadline);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "https://mainnet.example.com:443",
+                expect.objectContaining({ method: "POST" }),
+            );
+        });
+
+        it("should use http for localhost addresses", async function () {
+            const channel = new NativeChannel("localhost:50211");
+            mockFetch.mockResolvedValue(
+                mockResponse(200, { "grpc-status": "0" }),
+            );
+
+            const deadline = new Date(Date.now() + 10000);
+            await channel._waitForReady(deadline);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://localhost:50211",
+                expect.objectContaining({ method: "POST" }),
+            );
+        });
+
+        it("should use http for 127.0.0.1 addresses", async function () {
+            const channel = new NativeChannel("127.0.0.1:50211");
+            mockFetch.mockResolvedValue(
+                mockResponse(200, { "grpc-status": "0" }),
+            );
+
+            const deadline = new Date(Date.now() + 10000);
+            await channel._waitForReady(deadline);
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://127.0.0.1:50211",
+                expect.objectContaining({ method: "POST" }),
+            );
+        });
+
+        it("should throw GrpcServiceError(Timeout) when deadline is in the past", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            const deadline = new Date(Date.now() - 1000);
+
+            await expect(channel._waitForReady(deadline)).rejects.toSatisfy(
+                (err) => {
+                    return (
+                        err instanceof GrpcServiceError &&
+                        err.status === GrpcStatus.Timeout
+                    );
+                },
+            );
+
+            expect(mockFetch).not.toHaveBeenCalled();
+        });
+
+        it("should set _isReady to true when response has grpc-status header", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockResolvedValue(
+                mockResponse(200, { "grpc-status": "0" }),
+            );
+
+            const deadline = new Date(Date.now() + 10000);
+            await channel._waitForReady(deadline);
+
+            expect(channel._isReady).to.equal(true);
+        });
+
+        it("should set _isReady to true when response has grpc-message header", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockResolvedValue(
+                mockResponse(200, { "grpc-message": "OK" }),
+            );
+
+            const deadline = new Date(Date.now() + 10000);
+            await channel._waitForReady(deadline);
+
+            expect(channel._isReady).to.equal(true);
+        });
+
+        it("should throw GrpcServiceError(Unavailable) when 200 but no gRPC headers", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const deadline = new Date(Date.now() + 10000);
+
+            await expect(channel._waitForReady(deadline)).rejects.toSatisfy(
+                (err) => {
+                    return (
+                        err instanceof GrpcServiceError &&
+                        err.status === GrpcStatus.Unavailable
+                    );
+                },
+            );
+        });
+
+        it("should throw GrpcServiceError(Timeout) on AbortError", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            const abortError = new Error("The operation was aborted");
+            abortError.name = "AbortError";
+            mockFetch.mockRejectedValue(abortError);
+
+            const deadline = new Date(Date.now() + 10000);
+
+            await expect(channel._waitForReady(deadline)).rejects.toSatisfy(
+                (err) => {
+                    return (
+                        err instanceof GrpcServiceError &&
+                        err.status === GrpcStatus.Timeout
+                    );
+                },
+            );
+        });
+
+        it("should re-throw GrpcServiceError unchanged", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            const grpcError = new GrpcServiceError(GrpcStatus.Unavailable);
+            mockFetch.mockRejectedValue(grpcError);
+
+            const deadline = new Date(Date.now() + 10000);
+
+            await expect(channel._waitForReady(deadline)).rejects.toEqual(
+                grpcError,
+            );
+        });
+
+        it("should throw GrpcServiceError(Unavailable) on generic network error", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockRejectedValue(new TypeError("Failed to fetch"));
+
+            const deadline = new Date(Date.now() + 10000);
+
+            await expect(channel._waitForReady(deadline)).rejects.toSatisfy(
+                (err) => {
+                    return (
+                        err instanceof GrpcServiceError &&
+                        err.status === GrpcStatus.Unavailable
+                    );
+                },
+            );
+        });
+    });
+
+    // _createUnaryClient
+    describe("_createUnaryClient", function () {
+        it("should build the correct URL with service and method name", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const dataUrl = makeDataUrl(new Uint8Array([10, 20, 30]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1, 2, 3]),
+                    () => resolve(),
+                );
+            });
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "https://mainnet.example.com:443/proto.CryptoService/cryptoGetBalance",
+                expect.objectContaining({ method: "POST" }),
+            );
+        });
+
+        it("should use http for localhost in URL construction", async function () {
+            const channel = new NativeChannel("localhost:50211");
+            channel._isReady = true;
+
+            const dataUrl = makeDataUrl(new Uint8Array([1]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            await new Promise((resolve) => {
+                rpcImpl({ name: "cryptoGetBalance" }, new Uint8Array([1]), () =>
+                    resolve(),
+                );
+            });
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://localhost:50211/proto.CryptoService/cryptoGetBalance",
+                expect.any(Object),
+            );
+        });
+
+        it("should callback with HttpError on non-OK response", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const dataUrl = makeDataUrl(new Uint8Array([1]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(503, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const err = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (e) => resolve(e),
+                );
+            });
+
+            expect(err).to.be.instanceOf(HttpError);
+        });
+
+        it("should decode response with application/octet-stream prefix", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const payload = new Uint8Array([42, 43, 44]);
+            const dataUrl = makeDataUrl(payload);
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const response = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (_e, r) => resolve(r),
+                );
+            });
+
+            expect(response).to.be.instanceOf(Uint8Array);
+            expect([...response]).to.deep.equal([42, 43, 44]);
+        });
+
+        it("should decode response with application/grpc-web+proto prefix", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const payload = new Uint8Array([55, 66, 77]);
+            const frame = new Uint8Array(5 + payload.length);
+            frame[0] = 0;
+            new DataView(frame.buffer).setUint32(1, payload.length);
+            frame.set(payload, 5);
+            const base64Str = btoa(String.fromCharCode(...frame));
+            const dataUrl = `data:application/grpc-web+proto;base64,${base64Str}`;
+
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const response = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (_e, r) => resolve(r),
+                );
+            });
+
+            expect(response).to.be.instanceOf(Uint8Array);
+            expect([...response]).to.deep.equal([55, 66, 77]);
+        });
+
+        it("should throw Error when response has unknown prefix", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = "data:text/plain;base64,AAAA";
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const err = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (e) => resolve(e),
+                );
+            });
+
+            expect(err).to.be.instanceOf(Error);
+            expect(err.message).to.include(
+                "Expected response data to be base64 encode",
+            );
+        });
+
+        it("should propagate GrpcServiceError from _waitForReady via callback", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            // _isReady is false, so _waitForReady will be called
+
+            // Make deadline expire immediately by using a very short deadline
+            const originalDeadline = channel._grpcDeadline;
+            channel._grpcDeadline = -1000; // force deadline in the past
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const err = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (e) => resolve(e),
+                );
+            });
+
+            expect(err).to.be.instanceOf(GrpcServiceError);
+            expect(err.status).to.equal(GrpcStatus.Timeout);
+
+            channel._grpcDeadline = originalDeadline;
+        });
+
+        it("should propagate non-GrpcServiceError via callback", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            mockFetch.mockRejectedValue(new TypeError("Network failure"));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const err = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (e) => resolve(e),
+                );
+            });
+
+            expect(err).to.be.instanceOf(TypeError);
+            expect(err.message).to.equal("Network failure");
+        });
+    });
+});

--- a/test/unit/NativeChannel.js
+++ b/test/unit/NativeChannel.js
@@ -244,6 +244,58 @@ describe("NativeChannel", function () {
                 },
             );
         });
+
+        it("should throw GrpcServiceError(Unavailable) on non-200 status", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockResolvedValue(mockResponse(404, {}));
+
+            const deadline = new Date(Date.now() + 10000);
+
+            await expect(channel._waitForReady(deadline)).rejects.toSatisfy(
+                (err) => {
+                    return (
+                        err instanceof GrpcServiceError &&
+                        err.status === GrpcStatus.Unavailable
+                    );
+                },
+            );
+        });
+
+        it("should send correct headers and body in health check request", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockResolvedValue(
+                mockResponse(200, { "grpc-status": "0" }),
+            );
+
+            const deadline = new Date(Date.now() + 10000);
+            await channel._waitForReady(deadline);
+
+            const call = mockFetch.mock.calls[0];
+            const options = call[1];
+            expect(options.headers["content-type"]).to.equal(
+                "application/grpc-web-text",
+            );
+            expect(options.headers["x-grpc-web"]).to.equal("1");
+            expect(options.headers["x-user-agent"]).to.be.a("string");
+            expect(options.signal).to.be.instanceOf(AbortSignal);
+        });
+
+        it("should clear timeout on successful response", async function () {
+            vi.useFakeTimers();
+            const channel = new NativeChannel("mainnet.example.com:443");
+            mockFetch.mockResolvedValue(
+                mockResponse(200, { "grpc-status": "0" }),
+            );
+
+            const deadline = new Date(Date.now() + 10000);
+            const promise = channel._waitForReady(deadline);
+
+            await vi.runAllTimersAsync();
+            await promise;
+
+            expect(channel._isReady).to.equal(true);
+            vi.useRealTimers();
+        });
     });
 
     // _createUnaryClient
@@ -310,6 +362,106 @@ describe("NativeChannel", function () {
                 "http://localhost:50211/proto.CryptoService/cryptoGetBalance",
                 expect.any(Object),
             );
+        });
+
+        it("should use http for 127.0.0.1 in URL construction", async function () {
+            const channel = new NativeChannel("127.0.0.1:50211");
+            channel._isReady = true;
+
+            const dataUrl = makeDataUrl(new Uint8Array([1]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            await new Promise((resolve) => {
+                rpcImpl({ name: "cryptoGetBalance" }, new Uint8Array([1]), () =>
+                    resolve(),
+                );
+            });
+
+            expect(mockFetch).toHaveBeenCalledWith(
+                "http://127.0.0.1:50211/proto.CryptoService/cryptoGetBalance",
+                expect.any(Object),
+            );
+        });
+
+        it("should send correct request headers", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const dataUrl = makeDataUrl(new Uint8Array([1]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            await new Promise((resolve) => {
+                rpcImpl({ name: "cryptoGetBalance" }, new Uint8Array([1]), () =>
+                    resolve(),
+                );
+            });
+
+            const options = mockFetch.mock.calls[0][1];
+            expect(options.headers["content-type"]).to.equal(
+                "application/grpc-web-text",
+            );
+            expect(options.headers["x-accept-content-transfer-encoding"]).to.equal(
+                "base64",
+            );
+            expect(options.headers["x-grpc-web"]).to.equal("1");
+            expect(options.headers["x-user-agent"]).to.be.a("string");
+        });
+
+        it("should encode request body as base64-framed data", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const dataUrl = makeDataUrl(new Uint8Array([1]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([10, 20]),
+                    () => resolve(),
+                );
+            });
+
+            const body = mockFetch.mock.calls[0][1].body;
+            // body should be a non-empty base64 string
+            expect(body).to.be.a("string");
+            expect(body.length).to.be.greaterThan(0);
         });
 
         it("should callback with HttpError exactly once on non-OK response", async function () {
@@ -490,6 +642,128 @@ describe("NativeChannel", function () {
 
             expect(err).to.be.instanceOf(TypeError);
             expect(err.message).to.equal("Network failure");
+        });
+
+        it("should callback with error when FileReader.onerror fires", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        queueMicrotask(() =>
+                            this.onerror?.(new Error("read failed")),
+                        );
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const err = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (e) => resolve(e),
+                );
+            });
+
+            expect(err).to.be.instanceOf(Error);
+        });
+
+        it("should call _waitForReady then proceed on success when not ready", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            // _isReady is false initially
+
+            const dataUrl = makeDataUrl(new Uint8Array([99]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            // First call is health check, second is the actual RPC
+            mockFetch
+                .mockResolvedValueOnce(
+                    mockResponse(200, { "grpc-status": "0" }),
+                )
+                .mockResolvedValueOnce(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const response = await new Promise((resolve) => {
+                rpcImpl(
+                    { name: "cryptoGetBalance" },
+                    new Uint8Array([1]),
+                    (_e, r) => resolve(r),
+                );
+            });
+
+            expect(mockFetch).toHaveBeenCalledTimes(2);
+            expect(channel._isReady).to.equal(true);
+            expect(response).to.be.instanceOf(Uint8Array);
+            expect([...response]).to.deep.equal([99]);
+        });
+
+        it("should not call _waitForReady again once ready", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const dataUrl = makeDataUrl(new Uint8Array([1]));
+            vi.stubGlobal(
+                "FileReader",
+                class {
+                    readAsDataURL() {
+                        this.result = dataUrl;
+                        queueMicrotask(() => this.onloadend?.());
+                    }
+                },
+            );
+
+            mockFetch.mockResolvedValue(mockResponse(200, {}));
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            await new Promise((resolve) => {
+                rpcImpl({ name: "cryptoGetBalance" }, new Uint8Array([1]), () =>
+                    resolve(),
+                );
+            });
+
+            // Only one fetch call — the RPC itself, no health check
+            expect(mockFetch).toHaveBeenCalledTimes(1);
+            expect(mockFetch.mock.calls[0][0]).to.include("/proto.CryptoService/");
+        });
+
+        it("should not attempt response decoding on non-OK response", async function () {
+            const channel = new NativeChannel("mainnet.example.com:443");
+            channel._isReady = true;
+
+            const resp = mockResponse(502, {});
+            mockFetch.mockResolvedValue(resp);
+
+            const rpcImpl = channel._createUnaryClient("CryptoService");
+
+            const callback = vi.fn();
+            rpcImpl(
+                { name: "cryptoGetBalance" },
+                new Uint8Array([1]),
+                callback,
+            );
+
+            await new Promise((resolve) => setTimeout(resolve, 50));
+
+            // blob() should never be called when response is not ok
+            expect(resp.blob).not.toHaveBeenCalled();
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).to.be.instanceOf(HttpError);
         });
     });
 });

--- a/test/unit/NativeChannel.js
+++ b/test/unit/NativeChannel.js
@@ -312,7 +312,7 @@ describe("NativeChannel", function () {
             );
         });
 
-        it("should callback with HttpError on non-OK response", async function () {
+        it("should callback with HttpError exactly once on non-OK response", async function () {
             const channel = new NativeChannel("mainnet.example.com:443");
             channel._isReady = true;
 
@@ -331,15 +331,19 @@ describe("NativeChannel", function () {
 
             const rpcImpl = channel._createUnaryClient("CryptoService");
 
-            const err = await new Promise((resolve) => {
-                rpcImpl(
-                    { name: "cryptoGetBalance" },
-                    new Uint8Array([1]),
-                    (e) => resolve(e),
-                );
-            });
+            const callback = vi.fn();
+            rpcImpl(
+                { name: "cryptoGetBalance" },
+                new Uint8Array([1]),
+                callback,
+            );
 
-            expect(err).to.be.instanceOf(HttpError);
+            // Allow all microtasks/promises to settle
+            await new Promise((resolve) => setTimeout(resolve, 50));
+
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback.mock.calls[0][0]).to.be.instanceOf(HttpError);
+            expect(callback.mock.calls[0][1]).to.be.null;
         });
 
         it("should decode response with application/octet-stream prefix", async function () {

--- a/test/unit/NativeChannel.js
+++ b/test/unit/NativeChannel.js
@@ -1,13 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import { vi } from "vitest";
+import { afterAll, vi } from "vitest";
 import GrpcServiceError from "../../src/grpc/GrpcServiceError.js";
 import GrpcStatus from "../../src/grpc/GrpcStatus.js";
 import HttpError from "../../src/http/HttpError.js";
 import NativeChannel from "../../src/channel/NativeChannel.js";
 
 const mockFetch = vi.fn();
-vi.stubGlobal("fetch", mockFetch);
 
 /**
  * builds a mock fetch Response
@@ -42,9 +41,14 @@ function makeDataUrl(payload) {
 }
 
 describe("NativeChannel", function () {
+    afterAll(function () {
+        vi.unstubAllGlobals();
+    });
+
     beforeEach(function () {
         vi.clearAllMocks();
         vi.restoreAllMocks();
+        vi.stubGlobal("fetch", mockFetch);
         vi.stubGlobal(
             "FileReader",
             class {


### PR DESCRIPTION
**Description**:

Adds comprehensive unit tests for `NativeChannel` (React Native / non-Node gRPC-web transport layer)
* Added an early `return` statement after the error callback in `NativeChannel` to prevent further execution when an error occurs
* Add unit test file `test/unit/NativeChannel.js` with 23 test cases
* Cover constructor initialization and `grpcDeadline` handling
* Cover `_waitForReady` readiness probing including protocol selection (http vs https), deadline enforcement, gRPC header detection, and error classification
* Cover `_createUnaryClient` URL construction, HTTP error propagation, gRPC-web frame decoding (both `application/octet-stream` and `application/grpc-web+proto`), and error passthrough
* Verify correct mapping to `GrpcServiceError` statuses (Timeout, Unavailable) and `HttpError`

**Related issue(s)**:

Fixes https://github.com/hiero-ledger/hiero-sdk-js/issues/4013 and https://github.com/hiero-ledger/hiero-sdk-js/issues/4237

**Notes for reviewer**:


**Checklist**

- [ ] Documented (Code comments, README, etc.)
- [x] Tested (unit, integration, etc.)