### PR TITLE
feat: native sign(key) for Ethereum transaction data (#4152, story 1)

### DIFF
--- a/src/EthereumTransactionData.js
+++ b/src/EthereumTransactionData.js
@@ -46,6 +46,68 @@ export default class EthereumTransactionData {
 
     // eslint-disable-next-line jsdoc/require-returns-check
     /**
+     * Sign this transaction data with the given ECDSA (secp256k1) key,
+     * populating the signature fields (`r`, `s` and the recovery component) on
+     * this instance.
+     *
+     * Throws if `key` is not an ECDSA key.
+     *
+     * @param {import("./PrivateKey.js").default} key
+     * @returns {EthereumTransactionData}
+     */
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    sign(key) {
+        throw new Error("not implemented");
+    }
+
+    /**
+     * Shared ECDSA signing logic for every envelope variant. Signs the given
+     * unsigned message — the type-prefixed RLP payload for typed envelopes, or
+     * the bare RLP payload for legacy — and returns the signature components.
+     *
+     * Detection of a non-ECDSA key happens via the recovery-id computation
+     * rather than a key-type or length check: an Ed25519 signature is also 64
+     * bytes, so a length check alone is insufficient. If a valid recovery id
+     * cannot be derived, signing fails.
+     *
+     * @protected
+     * @param {import("./PrivateKey.js").default} key
+     * @param {Uint8Array} message
+     * @returns {{ r: Uint8Array, s: Uint8Array, recoveryId: number }}
+     */
+    _signMessage(key, message) {
+        const signature = key.sign(message);
+        const r = signature.subarray(0, 32);
+        const s = signature.subarray(32, 64);
+        const recoveryId = key.getRecoveryId(r, s, message);
+        return { r, s, recoveryId };
+    }
+
+    /**
+     * Encode a small non-negative integer as a minimal big-endian byte array
+     * (no leading zeros; zero becomes empty bytes), matching Ethereum's RLP
+     * integer encoding.
+     *
+     * @protected
+     * @param {number} value
+     * @returns {Uint8Array}
+     */
+    _numberToBytes(value) {
+        if (value <= 0) {
+            return new Uint8Array();
+        }
+
+        const bytes = [];
+        let remaining = value;
+        while (remaining > 0) {
+            bytes.unshift(remaining & 0xff);
+            remaining = Math.floor(remaining / 256);
+        }
+        return new Uint8Array(bytes);
+    }
+
+    // eslint-disable-next-line jsdoc/require-returns-check
+    /**
      * @returns {string}
      */
     toString() {

--- a/src/EthereumTransactionDataEip1559.js
+++ b/src/EthereumTransactionDataEip1559.js
@@ -136,6 +136,35 @@ export default class EthereumTransactionDataEip1559 extends EthereumTransactionD
     }
 
     /**
+     * Sign this transaction data with the given ECDSA (secp256k1) key,
+     * populating `recId`, `r` and `s`. Throws if `key` is not an ECDSA key.
+     *
+     * @param {import("./PrivateKey.js").default} key
+     * @returns {EthereumTransactionDataEip1559}
+     */
+    sign(key) {
+        const encoded = encodeRlp([
+            this.chainId,
+            this.nonce,
+            this.maxPriorityGas,
+            this.maxGas,
+            this.gasLimit,
+            this.to,
+            this.value,
+            this.callData,
+            this.accessList,
+        ]);
+        const message = hex.decode("02" + encoded.substring(2));
+
+        const { r, s, recoveryId } = this._signMessage(key, message);
+        this.r = r;
+        this.s = s;
+        this.recId = this._numberToBytes(recoveryId);
+
+        return this;
+    }
+
+    /**
      * @returns {string}
      */
     toString() {

--- a/src/EthereumTransactionDataEip2930.js
+++ b/src/EthereumTransactionDataEip2930.js
@@ -131,6 +131,34 @@ export default class EthereumTransactionDataEip2930 extends EthereumTransactionD
     }
 
     /**
+     * Sign this transaction data with the given ECDSA (secp256k1) key,
+     * populating `recId`, `r` and `s`. Throws if `key` is not an ECDSA key.
+     *
+     * @param {import("./PrivateKey.js").default} key
+     * @returns {EthereumTransactionDataEip2930}
+     */
+    sign(key) {
+        const encoded = encodeRlp([
+            this.chainId,
+            this.nonce,
+            this.gasPrice,
+            this.gasLimit,
+            this.to,
+            this.value,
+            this.callData,
+            this.accessList,
+        ]);
+        const message = hex.decode("01" + encoded.substring(2));
+
+        const { r, s, recoveryId } = this._signMessage(key, message);
+        this.r = r;
+        this.s = s;
+        this.recId = this._numberToBytes(recoveryId);
+
+        return this;
+    }
+
+    /**
      * @returns {string}
      */
     toString() {

--- a/src/EthereumTransactionDataEip7702.js
+++ b/src/EthereumTransactionDataEip7702.js
@@ -170,6 +170,36 @@ export default class EthereumTransactionDataEip7702 extends EthereumTransactionD
     }
 
     /**
+     * Sign this transaction data with the given ECDSA (secp256k1) key,
+     * populating `recId`, `r` and `s`. Throws if `key` is not an ECDSA key.
+     *
+     * @param {import("./PrivateKey.js").default} key
+     * @returns {EthereumTransactionDataEip7702}
+     */
+    sign(key) {
+        const encoded = encodeRlp([
+            this.chainId,
+            this.nonce,
+            this.maxPriorityGas,
+            this.maxGas,
+            this.gasLimit,
+            this.to,
+            this.value,
+            this.callData,
+            this.accessList,
+            this.authorizationList,
+        ]);
+        const message = hex.decode("04" + encoded.substring(2));
+
+        const { r, s, recoveryId } = this._signMessage(key, message);
+        this.r = r;
+        this.s = s;
+        this.recId = this._numberToBytes(recoveryId);
+
+        return this;
+    }
+
+    /**
      * @returns {string}
      */
     toString() {

--- a/src/EthereumTransactionDataLegacy.js
+++ b/src/EthereumTransactionDataLegacy.js
@@ -93,6 +93,36 @@ export default class EthereumTransactionDataLegacy extends EthereumTransactionDa
     }
 
     /**
+     * Sign this transaction data with the given ECDSA (secp256k1) key,
+     * populating `v`, `r` and `s`. Throws if `key` is not an ECDSA key.
+     *
+     * The unsigned, non-type-prefixed RLP payload is signed and `v` is stored
+     * as `27 + recoveryId` (pre-EIP-155).
+     *
+     * @param {import("./PrivateKey.js").default} key
+     * @returns {EthereumTransactionDataLegacy}
+     */
+    sign(key) {
+        const message = hex.decode(
+            encodeRlp([
+                this.nonce,
+                this.gasPrice,
+                this.gasLimit,
+                this.to,
+                this.value,
+                this.callData,
+            ]),
+        );
+
+        const { r, s, recoveryId } = this._signMessage(key, message);
+        this.r = r;
+        this.s = s;
+        this.v = this._numberToBytes(27 + recoveryId);
+
+        return this;
+    }
+
+    /**
      * @returns {string}
      */
     toString() {

--- a/test/unit/EthereumTransactionData.js
+++ b/test/unit/EthereumTransactionData.js
@@ -1,6 +1,7 @@
 import * as hex from "../../src/encoding/hex.js";
-import { EthereumTransactionData } from "../../src/index.js";
+import { EthereumTransactionData, PrivateKey } from "../../src/index.js";
 import { encodeRlp, decodeRlp } from "ethers";
+import EthereumTransactionDataLegacy from "../../src/EthereumTransactionDataLegacy.js";
 import EthereumTransactionDataEip2930 from "../../src/EthereumTransactionDataEip2930.js";
 import EthereumTransactionDataEip1559 from "../../src/EthereumTransactionDataEip1559.js";
 import EthereumTransactionDataEip7702 from "../../src/EthereumTransactionDataEip7702.js";
@@ -498,6 +499,202 @@ describe("EthereumTransactionData", function () {
             );
             expect(hex.encode(decoded.authorizationList[1][1])).to.equal(
                 hex.encode(authorizationList[1][1]),
+            );
+        });
+    });
+
+    describe("sign", function () {
+        const chainId = hex.decode("012a");
+        const nonce = hex.decode("02");
+        const gasPrice = hex.decode("2f");
+        const maxPriorityGas = hex.decode("2f");
+        const maxGas = hex.decode("2f");
+        const gasLimit = hex.decode("018000");
+        const to = hex.decode("7e3a9eaf9bcc39e2ffa38eb30bf7a93feacbc181");
+        const value = hex.decode("0de0b6b3a7640000");
+        const callData = hex.decode("123456");
+        const accessList = [];
+        const authorizationList = [];
+        // Unsigned placeholders, overwritten by sign()
+        const empty = new Uint8Array();
+
+        function buildLegacy() {
+            return new EthereumTransactionDataLegacy({
+                nonce,
+                gasPrice,
+                gasLimit,
+                to,
+                value,
+                callData,
+                v: empty,
+                r: empty,
+                s: empty,
+            });
+        }
+
+        function buildEip2930() {
+            return new EthereumTransactionDataEip2930({
+                chainId,
+                nonce,
+                gasPrice,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+                recId: empty,
+                r: empty,
+                s: empty,
+            });
+        }
+
+        function buildEip1559() {
+            return new EthereumTransactionDataEip1559({
+                chainId,
+                nonce,
+                maxPriorityGas,
+                maxGas,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+                recId: empty,
+                r: empty,
+                s: empty,
+            });
+        }
+
+        function buildEip7702() {
+            return new EthereumTransactionDataEip7702({
+                chainId,
+                nonce,
+                maxPriorityGas,
+                maxGas,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+                authorizationList,
+                recId: empty,
+                r: empty,
+                s: empty,
+            });
+        }
+
+        /**
+         * Asserts that `data.r`/`data.s` form a valid ECDSA signature for `key`
+         * over the given unsigned message, and that they are 32 bytes each.
+         */
+        function expectValidSignature(key, data, message) {
+            expect(data.r).to.be.instanceOf(Uint8Array);
+            expect(data.s).to.be.instanceOf(Uint8Array);
+            expect(data.r.length).to.equal(32);
+            expect(data.s.length).to.equal(32);
+
+            const signature = new Uint8Array(64);
+            signature.set(data.r, 0);
+            signature.set(data.s, 32);
+            expect(key.publicKey.verify(message, signature)).to.be.true;
+        }
+
+        it("legacy sign() sets v = 27 + recoveryId and a recoverable r/s", function () {
+            const key = PrivateKey.generateECDSA();
+            const data = buildLegacy();
+
+            expect(data.sign(key)).to.equal(data);
+
+            const message = hex.decode(
+                encodeRlp([nonce, gasPrice, gasLimit, to, value, callData]),
+            );
+            expectValidSignature(key, data, message);
+            expect(data.v.length).to.equal(1);
+            expect(data.v[0]).to.be.oneOf([27, 28]);
+        });
+
+        it("EIP-2930 sign() sets recId and a recoverable r/s", function () {
+            const key = PrivateKey.generateECDSA();
+            const data = buildEip2930();
+
+            expect(data.sign(key)).to.equal(data);
+
+            const encoded = encodeRlp([
+                chainId,
+                nonce,
+                gasPrice,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+            ]);
+            const message = hex.decode("01" + encoded.substring(2));
+            expectValidSignature(key, data, message);
+            const recId = data.recId.length === 0 ? 0 : data.recId[0];
+            expect(recId).to.be.oneOf([0, 1]);
+        });
+
+        it("EIP-1559 sign() sets recId and a recoverable r/s", function () {
+            const key = PrivateKey.generateECDSA();
+            const data = buildEip1559();
+
+            expect(data.sign(key)).to.equal(data);
+
+            const encoded = encodeRlp([
+                chainId,
+                nonce,
+                maxPriorityGas,
+                maxGas,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+            ]);
+            const message = hex.decode("02" + encoded.substring(2));
+            expectValidSignature(key, data, message);
+            const recId = data.recId.length === 0 ? 0 : data.recId[0];
+            expect(recId).to.be.oneOf([0, 1]);
+        });
+
+        it("EIP-7702 sign() sets recId and a recoverable r/s", function () {
+            const key = PrivateKey.generateECDSA();
+            const data = buildEip7702();
+
+            expect(data.sign(key)).to.equal(data);
+
+            const encoded = encodeRlp([
+                chainId,
+                nonce,
+                maxPriorityGas,
+                maxGas,
+                gasLimit,
+                to,
+                value,
+                callData,
+                accessList,
+                authorizationList,
+            ]);
+            const message = hex.decode("04" + encoded.substring(2));
+            expectValidSignature(key, data, message);
+            const recId = data.recId.length === 0 ? 0 : data.recId[0];
+            expect(recId).to.be.oneOf([0, 1]);
+        });
+
+        it("throws when signing with a non-ECDSA (Ed25519) key", function () {
+            const key = PrivateKey.generateED25519();
+
+            expect(() => buildLegacy().sign(key)).to.throw();
+            expect(() => buildEip2930().sign(key)).to.throw();
+            expect(() => buildEip1559().sign(key)).to.throw();
+            expect(() => buildEip7702().sign(key)).to.throw();
+        });
+
+        it("base EthereumTransactionData.sign() is abstract", function () {
+            const base = new EthereumTransactionData({ callData });
+            expect(() => base.sign(PrivateKey.generateECDSA())).to.throw(
+                "not implemented",
             );
         });
     });


### PR DESCRIPTION
## Description

First PR in the [#4152](https://github.com/hiero-ledger/hiero-sdk-js/issues/4152) series — brings the JS SDK toward parity with the cross-SDK [Native Ethereum Transaction Data](https://github.com/hiero-ledger/sdk-collaboration-hub/blob/main/proposals/native-ethereum-transaction-data.md) proposal.

This PR implements **Story 1 — the native signing core**: a `sign(key)` method on `EthereumTransactionData` and all four envelope variants (Legacy, EIP-2930, EIP-1559, EIP-7702).

## Changes

- **Shared signing helper** (`_signMessage`) on the abstract base class: ECDSA-signs the unsigned RLP payload (type-prefixed for typed envelopes) and derives the recovery id.
- **Non-ECDSA rejection** is detected via the recovery-id computation rather than a key-type or length check — an Ed25519 signature is also 64 bytes, so a length check alone is insufficient.
- **Recovery component storage**: Legacy stores `v = 27 + recoveryId` (pre-EIP-155); typed envelopes store the raw recovery id in `recId`.
- All additive — existing byte/tuple fields remain the source of truth; no breaking changes.
- Unit tests cover a recoverable signature per envelope, the non-ECDSA rejection path, and the abstract-base `not implemented` guard.

## Follow-ups (same series, separate PRs)

- Story 2+3+4: additive typed accessors + structured `AccessListItem` / `Authorization` (HIP-1340) views.
- Story 5: `EthereumTransaction.setEthereumData(data)` overload + never-submit-unsigned guard + e2e integration tests.

## Checklist

- [x] Unit tests added and passing
- [x] `prettier --check` clean
- [x] `eslint` clean (no new errors)