### PR TITLE
test: isolate node unit tests to fix flaky gRPC mocks and align Solo defaults with CI

### DIFF
--- a/scripts/solo-lib.js
+++ b/scripts/solo-lib.js
@@ -5,8 +5,8 @@ import path from "node:path";
 import { spawn, spawnSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
 
-export const DEFAULT_CONSENSUS_NODE_VERSION = "v0.74.0";
-export const DEFAULT_MIRROR_NODE_VERSION = "v0.156.0";
+export const DEFAULT_CONSENSUS_NODE_VERSION = "v0.73.0";
+export const DEFAULT_MIRROR_NODE_VERSION = "v0.153.0";
 export const DEFAULT_NUM_NODES = 1;
 export const DEFAULT_HBAR_AMOUNT = 10000000;
 

--- a/test/vitest-node.config.ts
+++ b/test/vitest-node.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
         include: ["test/unit/**/*.js"],
         exclude: ["test/unit/Mocker.js", "test/unit/browser/*"],
         testTimeout: 120000,
-        isolate: false,
+        isolate: true,
         coverage: {
             include: ["src/**/*.js"],
             exclude: [


### PR DESCRIPTION
## What

Two small, self-contained reliability/dev-parity fixes:

1. **Fix flaky node unit tests** — `test/vitest-node.config.ts`: `isolate: false` → `isolate: true`.
2. **Align local Solo defaults with CI** — `scripts/solo-lib.js`: consensus `v0.74.0` → `v0.73.0`, mirror `v0.156.0` → `v0.153.0`.

## 1. Flaky unit tests

`task test:unit:node` (and its `:codecov` variant that CI runs) intermittently fails in `NodeChannel`, `NodeMirrorChannel`, and the `*Mocking` suites. Two root causes, both stemming from `isolate: false` under parallel file execution:

- Files using `vi.mock("@grpc/grpc-js")` share a worker's module registry; the mock registration **races** across concurrently-running files, so tests fall through to the real network (`connect ECONNREFUSED …`, `Client` mock called `0` times).
- `Mocker.js`-based suites start real gRPC servers on **fixed ports** and collide when run concurrently (`RST_STREAM with code 0`, max-attempts).

It flakes more on high-core machines (more parallelism) and less on low-core CI runners — which is why past PRs needed maintainer re-runs.

**Fix:** run test files isolated. Verified locally (12 cores):

| | Result | Time |
|---|---|---|
| `isolate: false` (before) | 4–15 flaky failures, non-deterministic | ~54s (bloated by 10s `waitForReady` timeout stalls) |
| `isolate: true` (after) | **149 files / 1882 tests green, 4× in a row** | **~13.5s** |

Isolation is a strict improvement here — it's also *faster*, since it removes the timeout stalls the failures caused. All files pass, so nothing relied on cross-file shared state. Because CI reads this same config (no `--isolate` flag is possible in the fixed command), the fix reaches CI as well.

## 2. Solo version alignment

`task solo:setup` defaults to consensus `v0.74.0` / mirror `v0.156.0` (from #4173), but CI (`build.yml`, `hiero-solo-action`) provisions consensus **`v0.73.0`** (`hieroVersion`) / mirror **`v0.153.0`**. This makes local Solo diverge from CI. Locally, `v0.74.0` rejects every `ContractCreate` with `INVALID_TRANSACTION_BODY` (reproducible with minimal plain-SDK calls, all deploy paths), while contract flows work on CI's `v0.73.0`. This change makes plain `task solo:setup` reproduce CI.

### Open question for reviewers
This realigns the scripts *down* to CI's versions, reverting #4173's bump. If the intent of #4173 was to move ahead of CI deliberately, the preferable direction may be to bump **CI up to v0.74.0/v0.156.0** instead. Happy to flip this to whichever direction you prefer.
