### PR TITLE
chore(deps): bump actions/setup-java from 5.2.0 to 5.5.0

### DIFF
--- a/.github/workflows/react_native.yml
+++ b/.github/workflows/react_native.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: "zulu"
           java-version: "8"
@@ -92,7 +92,7 @@ jobs:
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
       - name: Setup Java
-        uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           distribution: "zulu"
           java-version: "8"


### PR DESCRIPTION
Bumps [actions/setup-java](https://github.com/actions/setup-java) from **5.2.0** (`be666c2`) to **5.5.0** (`0f481fc`) in `.github/workflows/react_native.yml` (both `Setup Java` steps).

Mirrors Dependabot PR #4222. SHA-pinned to the v5.5.0 commit; a GitHub Actions version bump with no lockfile change.

See the [v5.2.0...v5.5.0 changelog](https://github.com/actions/setup-java/compare/v5.2.0...v5.5.0).