### PR TITLE
chore(deps): bump expo-symbols from 56.0.5 to 57.0.0

### DIFF
--- a/examples/react-native-example/package.json
+++ b/examples/react-native-example/package.json
@@ -28,7 +28,7 @@
     "expo-router": "~56.2.8",
     "expo-splash-screen": "~56.0.10",
     "expo-status-bar": "~56.0.4",
-    "expo-symbols": "~56.0.5",
+    "expo-symbols": "~57.0.0",
     "expo-system-ui": "~56.0.5",
     "expo-web-browser": "~56.0.5",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -439,8 +439,8 @@ importers:
         specifier: ~56.0.4
         version: 56.0.4(expo@56.0.8)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-symbols:
-        specifier: ~56.0.5
-        version: 56.0.5(expo-font@56.0.5)(expo@56.0.8)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+        specifier: ~57.0.0
+        version: 57.0.0(expo-font@56.0.5)(expo@56.0.8)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       expo-system-ui:
         specifier: ~56.0.5
         version: 56.0.5(expo@56.0.8)(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))
@@ -7426,6 +7426,14 @@ packages:
 
   expo-symbols@56.0.5:
     resolution: {integrity: sha512-RIukH0Xo80C7RU8qreipL2SPy2Py+Km8JFPbCmbPQpHkM3DW9Znlmg6VfhzbtUOlO5EuNSF0lAJ3l2VJi6qYrw==}
+    peerDependencies:
+      expo: '*'
+      expo-font: '*'
+      react: '*'
+      react-native: '*'
+
+  expo-symbols@57.0.0:
+    resolution: {integrity: sha512-pLjyiSqOV8NEqs2LqVZmF0cS1j90XoeT2oHbFciVjW7DiV7cP34SGLUgeDsOWY54QkWFR5p2Gz9LZWM8eBsSkA==}
     peerDependencies:
       expo: '*'
       expo-font: '*'
@@ -22306,6 +22314,15 @@ snapshots:
     optional: true
 
   expo-symbols@56.0.5(expo-font@56.0.5)(expo@56.0.8)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@expo-google-fonts/material-symbols': 0.4.38
+      expo: 56.0.8(@babel/core@7.26.10)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(expo-router@56.2.8)(react-dom@19.1.0(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native-worklets@0.5.1(@babel/core@7.26.10)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      expo-font: 56.0.5(expo@56.0.8)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0)
+      sf-symbols-typescript: 2.2.0
+
+  expo-symbols@57.0.0(expo-font@56.0.5)(expo@56.0.8)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
     dependencies:
       '@expo-google-fonts/material-symbols': 0.4.38
       expo: 56.0.8(@babel/core@7.26.10)(@expo/dom-webview@55.0.3)(@expo/metro-runtime@6.1.2)(expo-router@56.2.8)(react-dom@19.1.0(react@19.1.0))(react-native-web@0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native-worklets@0.5.1(@babel/core@7.26.10)(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.26.10)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)


### PR DESCRIPTION
Bumps `expo-symbols` from `~56.0.5` to `~57.0.0` in `examples/react-native-example`.

Mirrors Dependabot PR #4211, but with a **minimal** lockfile update. Dependabot regenerated `pnpm-lock.yaml` with a different pnpm version, producing ~869/348 lines of unrelated churn (e.g. downgrading `eslint@9.39.2`→`9.26.0` and `@babel/core@7.26.10`→`7.23.3` across the tree). Here the lockfile was regenerated with the CI-pinned **pnpm 9.15.5** (`lockfileVersion 9.0`), so the diff is **19/2 lines** — only the `expo-symbols` specifier and its subtree change.

- `expo-symbols@57.0.0` resolved for `react-native-example`; the `react-native-example-legacy` example keeps `56.0.5`.
- `pnpm install --frozen-lockfile` reports "Lockfile is up to date" — manifest and lockfile are consistent.