### PR TITLE
chore(deps-dev): bump chromedriver from 149.0.1 to 150.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
         "babel-plugin-dynamic-import-node": "2.3.3",
         "babel-plugin-module-rewrite": "0.2.0",
         "c8": "11.0.0",
-        "chromedriver": "149.0.1",
+        "chromedriver": "150.0.0",
         "codecov": "3.8.3",
         "dotenv": "17.2.3",
         "dpdm": "4.2.0",

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -104,7 +104,7 @@
         "babel-plugin-dynamic-import-node": "2.3.3",
         "babel-plugin-module-rewrite": "0.2.0",
         "c8": "11.0.0",
-        "chromedriver": "149.0.1",
+        "chromedriver": "150.0.0",
         "codecov": "3.8.3",
         "dpdm": "4.2.0",
         "eslint": "9.26.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -161,8 +161,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       chromedriver:
-        specifier: 149.0.1
-        version: 149.0.1(debug@4.4.1)
+        specifier: 150.0.0
+        version: 150.0.0(debug@4.4.1)
       codecov:
         specifier: 3.8.3
         version: 3.8.3
@@ -767,8 +767,8 @@ importers:
         specifier: 11.0.0
         version: 11.0.0
       chromedriver:
-        specifier: 149.0.1
-        version: 149.0.1(debug@4.4.1)
+        specifier: 150.0.0
+        version: 150.0.0(debug@4.4.1)
       codecov:
         specifier: 3.8.3
         version: 3.8.3
@@ -6079,8 +6079,8 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  chromedriver@149.0.1:
-    resolution: {integrity: sha512-mAIzz2KZzl/zwgWklkFzYCGK3Ub3yU25JAM1qOcT1aB4p0dMXJxqu8naI/NwI8eGKqX/2OFN87KXmFqmcvmPvA==}
+  chromedriver@150.0.0:
+    resolution: {integrity: sha512-MhHObBXNUOxJFzHuwRC+BXRFJNJgbgIr+y7B/MB++QioxbHz2R3Zj4WyJJVGqkjZyoVAF4zc46egxJ1GSFG7+w==}
     engines: {node: '>=22'}
     hasBin: true
 
@@ -20214,7 +20214,7 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  chromedriver@149.0.1(debug@4.4.1):
+  chromedriver@150.0.0(debug@4.4.1):
     dependencies:
       '@testim/chrome-version': 1.1.4
       adm-zip: 0.5.17


### PR DESCRIPTION
Bumps `chromedriver` from `149.0.1` to `150.0.0` in the root `package.json` and `packages/cryptography`.

Mirrors Dependabot PR #4210, but with a **minimal** lockfile update. Dependabot regenerated `pnpm-lock.yaml` with a different pnpm version (~948/401 lines of unrelated churn). Here it was regenerated with the CI-pinned **pnpm 9.15.5** (`lockfileVersion 9.0`), so the diff is **7/7 lines** — only the `chromedriver` specifier and resolution change.

- `pnpm install --frozen-lockfile` reports "Lockfile is up to date" — manifest and lockfile are consistent.
- Note: chromedriver 150 requires `node >=22`; CI runs Node 22 and 24, so this is satisfied.