### PR TITLE
feat(TCK): add version JSON-RPC method to report the SDK under test

### DIFF
--- a/tck/methods/sdk.ts
+++ b/tck/methods/sdk.ts
@@ -1,4 +1,5 @@
 import { Client, AccountId } from "@hiero-ledger/sdk";
+import { version as SDK_VERSION } from "@hiero-ledger/sdk/package.json";
 
 import { sdk } from "../sdk_data";
 import { SdkResponse } from "../response/sdk";
@@ -21,6 +22,15 @@ interface SetOperatorParams {
 }
 
 export default {
+    /**
+     * Reports the SDK name and version under test, read from the installed
+     * @hiero-ledger/sdk package. Lets TCK runs record which SDK build served
+     * them (see hiero-ledger/hiero-sdk-tck#663).
+     *
+     * @returns The SDK name and version, e.g. "hiero-sdk-js 2.84.0"
+     */
+    version: (): string => `hiero-sdk-js ${SDK_VERSION}`,
+
     /**
      * Sets up a Hedera client for a test session.
      * Supports concurrent test execution by creating isolated client instances per session.

--- a/tck/tsconfig.json
+++ b/tck/tsconfig.json
@@ -39,7 +39,7 @@
         // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
         // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
         // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-        // "resolveJsonModule": true,                        /* Enable importing .json files. */
+        "resolveJsonModule": true /* Enable importing .json files. */,
         // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
         // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
 


### PR DESCRIPTION
## Summary

Adds a `version` JSON-RPC method to the TCK server (`tck/`) so every TCK run can record which SDK build actually served it.

```json
{ "jsonrpc": "2.0", "id": 1, "method": "version" }
```
→
```json
{ "jsonrpc": "2.0", "id": 1, "result": "hiero-sdk-js 2.84.0" }
```

Resolves hiero-ledger/hiero-sdk-tck#663.

## Motivation

During the BNCE 0.75 E2E validation runs (2026-07-14), the freshly started TCK server crashed with `EADDRINUSE` and both runs were silently served by a stale leftover server instance — and there was no way to tell afterwards which SDK version had been under test. hiero-ledger/hiero-sdk-tck#662 added a preflight to the TCK that queries `version` at suite start and stamps the result into the run log and `mochawesome-report/run-info.json`; until servers implement the method, every run records `did not report a version`.

## Implementation notes

- The version is read from the **installed** `@hiero-ledger/sdk` package (`@hiero-ledger/sdk/package.json`, an explicitly exported subpath), not from the repo checkout — so it reports the SDK build actually serving requests even when `tck/package.json` pins a different version than the repo (currently 2.84.0 vs 2.86.0). `src/version.js`'s `SDK_VERSION` was not used because it is build-injected and reads `"DEV"` when the server runs from source.
- `resolveJsonModule` is enabled in `tck/tsconfig.json` (was already scaffolded as a comment) for the typed import.

## Testing

- `tsc --noEmit` clean; prettier clean.
- Server run locally (`ts-node server.ts`): `version` returns `hiero-sdk-js 2.84.0`; existing methods (e.g. `generateKey`) unaffected.
- End-to-end with the hiero-sdk-tck preflight from hiero-ledger/hiero-sdk-tck#662 pointed at this server — the run banner stamps:
  ```
  SDK server version  : hiero-sdk-js 2.84.0
  ```
