### PR TITLE
fix: add browser condition to package exports to fix esbuild browser bundling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,17 +16,26 @@
     },
     "browser": {
         "./lib/index.js": "./lib/browser.js",
+        "./lib/index.cjs": "./lib/browser.cjs",
         "./lib/network/AddressBookQuery.js": "./lib/network/AddressBookQueryWeb.js",
+        "./lib/network/AddressBookQuery.cjs": "./lib/network/AddressBookQueryWeb.cjs",
         "./lib/encoding/hex.js": "./lib/encoding/hex.browser.js",
+        "./lib/encoding/hex.cjs": "./lib/encoding/hex.browser.cjs",
         "./lib/encoding/utf8.js": "./lib/encoding/utf8.browser.js",
+        "./lib/encoding/utf8.cjs": "./lib/encoding/utf8.browser.cjs",
         "./lib/cryptography/sha384.js": "./lib/cryptography/sha384.browser.js",
+        "./lib/cryptography/sha384.cjs": "./lib/cryptography/sha384.browser.cjs",
         "crypto": false
     },
     "exports": {
         "./package.json": "./package.json",
         ".": {
-            "react-native": "./lib/native.js",
             "types": "./lib/index.d.ts",
+            "react-native": "./lib/native.js",
+            "browser": {
+                "import": "./lib/browser.js",
+                "require": "./lib/browser.cjs"
+            },
             "import": "./lib/index.js",
             "require": "./lib/index.cjs"
         }


### PR DESCRIPTION
## Description

Fixes #2173 — the SDK could not be bundled for the browser with esbuild (and tools built on it) since 2024.

### Root cause

`exports["."]` in `package.json` has no `browser` condition. Bundlers that resolve strictly through the `exports` map pick the `import` target — `lib/index.js`, the **Node.js** entry — when bundling for the browser, and then fail on `fs`/`util`/`tls`/`net` imports and `@grpc/grpc-js` (33 resolution errors with raw esbuild, exactly the trace reported in #2173).

The legacy top-level `browser` field (which maps `./lib/index.js` → `./lib/browser.js`) is **not consulted for entry resolution once `exports` matches**. Some bundlers (e.g. current Vite) apply the legacy field as a fallback and mask the problem — raw esbuild does not, which is why this only bites esbuild-based setups.

### What this PR changes (`package.json` only)

1. **Adds a `browser` condition to `exports["."]`** with both module formats:
   ```json
   "browser": {
       "import": "./lib/browser.js",
       "require": "./lib/browser.cjs"
   }
   ```
   Placed after `react-native` so React Native resolution keeps precedence.
2. **Wires the `.cjs` browser variants into the legacy `browser` field** (`index`, `AddressBookQuery`, `hex`, `utf8`, `sha384` → their `*.browser.cjs` counterparts). The build already produces these files but they were never referenced — this mirrors exactly what the `react-native` field already does for its `.native.cjs` variants, and makes CJS consumers bundled for the browser get the browser implementations too.
3. **Moves `types` first in `exports["."]`** — conditions are order-sensitive and TypeScript requires `types` first (reported as an error by `publint`).

### Verification

All bundler tests were run against real `pnpm pack` tarballs (sdk + proto + cryptography), not workspace symlinks:

| Scenario | Before | After |
| --- | --- | --- |
| esbuild `--platform=browser`, ESM consumer | 33 resolution errors (`fs`, `util`, `tls`, `net`, grpc-js) | Bundles clean and **executes**; `WebClient`, `hex.browser.js`, SubtleCrypto `sha384.browser.js` in bundle; zero `NodeClient` references |
| esbuild `--platform=browser`, CJS consumer (`require`) | same failure | Bundles via `browser.cjs` graph and executes; `WebClient` resolved |
| Vite 7.3.6 production build | worked only via legacy-field fallback | passes, browser entry bundled |
| webpack 5 (`target: web`) | worked via legacy field | passes, browser entry bundled, output executes |
| Node.js ESM import | `NodeClient` | `NodeClient` (unchanged) |
| Node.js CJS require | `NodeClient` | `NodeClient` (unchanged) |
| React Native condition precedence | `react-native` first | unchanged (still ahead of `browser`) |
| `publint` on packed tarball | 1 error (`types` ordering) | 0 errors (2 pre-existing warnings remain, unrelated) |

`prettier --check package.json` is clean.

### Notes

- The published `@hashgraph/sdk` (latest) has the same gap, so this fixes the problem going forward for `@hiero-ledger/sdk` releases.
- Bundlers with no `exports` support at all (webpack 4 era) still resolve `module` → `./src/index.js` and remain broken; pointing `module` at `./lib/index.js` would fix those too but is left out to keep this change minimal — can be a follow-up if desired.

## Checklist

- [x] Reproduced the original issue on `main` before the change
- [x] Verified fix against esbuild (ESM + CJS), Vite 7, webpack 5 using packed tarballs
- [x] Verified no regression for Node.js ESM/CJS and React Native condition ordering
- [x] `prettier --check` clean, `publint` clean
