### PR TITLE
fix: revert "chore(deps): bump @noble/curves from 1.8.1 to 2.2.0"

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,7 @@ updates:
           - dependency-name: "*"
             update-types:
                 ["version-update:semver-minor", "version-update:semver-patch"]
+          # @noble/curves v2+ is ESM-only and breaks the CommonJS (lib/*.cjs)
+          # build of @hiero-ledger/cryptography — see #4259
+          - dependency-name: "@noble/curves"
+            versions: [">=2.0.0"]

--- a/common_js_test/Taskfile.yml
+++ b/common_js_test/Taskfile.yml
@@ -23,4 +23,8 @@ tasks:
         deps:
             - install
         cmds:
+            # Strict CJS smoke test: modern Node can require() ESM natively, which
+            # hides ESM-only dependencies sneaking into the lib/*.cjs builds. The
+            # flag restores strict behavior (what ts-node and Node <20.19 enforce).
+            - node --no-experimental-require-module -e "const { PrivateKey } = require('@hiero-ledger/sdk'); PrivateKey.generateED25519().sign(new Uint8Array([1])); PrivateKey.generateECDSA().sign(new Uint8Array([1])); console.log('strict CJS smoke test OK');"
             - ./node_modules/.bin/mocha --exit --inline-diffs -r @babel/register -r chai/register-expect.js "src/test.js" --timeout 120000

--- a/packages/cryptography/package.json
+++ b/packages/cryptography/package.json
@@ -43,7 +43,7 @@
     ],
     "dependencies": {
         "@noble/ciphers": "1.2.1",
-        "@noble/curves": "2.2.0",
+        "@noble/curves": "1.8.1",
         "@noble/hashes": "1.8.0",
         "@scure/base": "1.2.4",
         "@scure/bip32": "1.6.2",

--- a/packages/cryptography/src/EcdsaPublicKey.js
+++ b/packages/cryptography/src/EcdsaPublicKey.js
@@ -1,4 +1,4 @@
-import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { secp256k1 } from "@noble/curves/secp256k1";
 import Key from "./Key.js";
 import BadKeyError from "./BadKeyError.js";
 import { arrayEqual } from "./util/array.js";
@@ -73,10 +73,10 @@ export default class EcdsaPublicKey extends Key {
                 break;
             default: // Uncompressed DER public keys
                 try {
-                    const keyPair = secp256k1.Point.fromBytes(
+                    const keyPair = secp256k1.ProjectivePoint.fromHex(
                         data.subarray(derPrefixBytes.length),
                     );
-                    ecdsaPublicKeyBytes = keyPair.toBytes(true); // Compressed format
+                    ecdsaPublicKeyBytes = keyPair.toRawBytes(true); // Compressed format
                 } catch (error) {
                     throw new BadKeyError(
                         `cannot decode ECDSA public key from this DER format`,
@@ -153,9 +153,9 @@ export default class EcdsaPublicKey extends Key {
      * @returns {string}
      */
     toEthereumAddress() {
-        const publicKey = secp256k1.Point.fromBytes(this._keyData).toBytes(
-            false,
-        );
+        const publicKey = secp256k1.ProjectivePoint.fromHex(
+            this._keyData,
+        ).toRawBytes(false);
         const hash = hex.decode(
             keccak256(`0x${hex.encode(publicKey.subarray(1))}`),
         );

--- a/packages/cryptography/src/Ed25519PrivateKey.js
+++ b/packages/cryptography/src/Ed25519PrivateKey.js
@@ -1,6 +1,6 @@
 import BadKeyError from "./BadKeyError.js";
 import Ed25519PublicKey from "./Ed25519PublicKey.js";
-import { ed25519 } from "@noble/curves/ed25519.js";
+import { ed25519 } from "@noble/curves/ed25519";
 import * as hex from "./encoding/hex.js";
 import * as random from "./primitive/random.js";
 import * as slip10 from "./primitive/slip10.js";

--- a/packages/cryptography/src/Ed25519PublicKey.js
+++ b/packages/cryptography/src/Ed25519PublicKey.js
@@ -1,6 +1,6 @@
 import Key from "./Key.js";
 import BadKeyError from "./BadKeyError.js";
-import { ed25519 } from "@noble/curves/ed25519.js";
+import { ed25519 } from "@noble/curves/ed25519";
 import { arrayEqual } from "./util/array.js";
 import * as hex from "./encoding/hex.js";
 

--- a/packages/cryptography/src/primitive/ecdsa.js
+++ b/packages/cryptography/src/primitive/ecdsa.js
@@ -1,6 +1,6 @@
 import { keccak256 } from "./keccak.js";
 import * as hex from "../encoding/hex.js";
-import { secp256k1 } from "@noble/curves/secp256k1.js";
+import { secp256k1 } from "@noble/curves/secp256k1";
 import { equalBytes } from "./utils.js";
 
 /**
@@ -11,7 +11,7 @@ import { equalBytes } from "./utils.js";
  * @returns {KeyPair}
  */
 export function generate() {
-    const privateKey = secp256k1.utils.randomSecretKey();
+    const privateKey = secp256k1.utils.randomPrivateKey();
     const publicKey = secp256k1.getPublicKey(privateKey, true);
 
     return {
@@ -77,7 +77,9 @@ export function getFullPublicKey(data) {
 export function sign(keydata, message) {
     const msg = hex.encode(message);
     const data = hex.decode(keccak256(`0x${msg}`));
-    return secp256k1.sign(data, keydata, { prehash: false });
+    const signature = secp256k1.sign(data, keydata);
+
+    return signature.toCompactRawBytes();
 }
 
 /**
@@ -97,7 +99,10 @@ export function verify(keydata, message, signature) {
     const msg = hex.encode(message);
     const data = hex.decode(keccak256(`0x${msg}`));
 
-    return secp256k1.verify(signature, data, keydata, { prehash: false });
+    const r = BigInt("0x" + hex.encode(signature.subarray(0, 32)));
+    const s = BigInt("0x" + hex.encode(signature.subarray(32, 64)));
+
+    return secp256k1.verify({ r, s }, data, keydata);
 }
 
 /**
@@ -112,12 +117,12 @@ export function getRecoveryId(privateKey, signature, message) {
 
     for (let recovery = 0; recovery < 4; recovery++) {
         try {
-            const sig = secp256k1.Signature.fromBytes(
-                signature,
-                "compact",
-            ).addRecoveryBit(recovery);
+            const sig =
+                secp256k1.Signature.fromCompact(signature).addRecoveryBit(
+                    recovery,
+                );
 
-            const recovered = sig.recoverPublicKey(hash).toBytes(false);
+            const recovered = sig.recoverPublicKey(hash).toRawBytes(false);
 
             if (equalBytes(recovered, expectedPubKey)) {
                 return recovery;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -657,8 +657,8 @@ importers:
         specifier: 1.2.1
         version: 1.2.1
       '@noble/curves':
-        specifier: 2.2.0
-        version: 2.2.0
+        specifier: 1.8.1
+        version: 1.8.1
       '@noble/hashes':
         specifier: 1.8.0
         version: 1.8.0
@@ -3442,10 +3442,6 @@ packages:
   '@noble/curves@1.8.1':
     resolution: {integrity: sha512-warwspo+UYUPep0Q+vtdVB4Ugn8GGQj8iyB3gnRWsztmUHTI3S1nhdiWNsPUGL0vud7JlRRk1XEu7Lq1KGTnMQ==}
     engines: {node: ^14.21.3 || >=16}
-
-  '@noble/curves@2.2.0':
-    resolution: {integrity: sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ==}
-    engines: {node: '>= 20.19.0'}
 
   '@noble/hashes@1.3.2':
     resolution: {integrity: sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==}
@@ -17305,10 +17301,6 @@ snapshots:
   '@noble/curves@1.8.1':
     dependencies:
       '@noble/hashes': 1.7.1
-
-  '@noble/curves@2.2.0':
-    dependencies:
-      '@noble/hashes': 2.2.0
 
   '@noble/hashes@1.3.2': {}
 


### PR DESCRIPTION
## Description

Reverts #4239 (commit ef7580ab), restoring `@noble/curves` **1.8.1** in `packages/cryptography`, and adds guards so this class of break cannot recur silently.

### Why

`@noble/curves` v2 is **ESM-only** — `"type": "module"` and its exports map has no `require` condition. Our CJS build (`lib/*.cjs`, produced by Babel) transpiles `import ... from "@noble/curves/ed25519.js"` into `require(...)`, which throws at load time:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module @noble/curves@2.2.0/ed25519.js
from @hiero-ledger/cryptography@1.20.0/lib/Ed25519PublicKey.cjs not supported.
```

This breaks CommonJS consumers of `@hiero-ledger/sdk@2.86.1` / `@hiero-ledger/cryptography@1.20.0` running under **ts-node** or **Node < 20.19** (native `require(esm)` in newer Node masks it elsewhere).

It was caught by the nightly [SDK TCK Regression in hiero-consensus-node](https://github.com/hiero-ledger/hiero-consensus-node/actions/runs/29881093619/job/88804320755): the TCK sdk-server (ts-node, CJS mode) resolves `@hiero-ledger/sdk@^2.85.0` → 2.86.1, crashed on startup, and all 122 TCK tests failed with `ECONNREFUSED 127.0.0.1:8544`.

### Why CI did not catch it

The `Common JS` workflow runs on Node 22/24, where `require()` of ESM works natively — so `require("@hiero-ledger/sdk")` succeeded in CI while ts-node and older Node consumers crash.

### Changes

- **Revert** `@noble/curves` to 1.8.1 (sources byte-identical to pre-#4239 state; minimal lockfile change validated with `pnpm install --frozen-lockfile`)
- **Strict CJS smoke test** in `common_js_test`: `node --no-experimental-require-module -e "require(…sdk…)"` + key generation/signing — reproduces the exact TCK failure on the broken state, passes with the revert
- **Dependabot ignore** for `@noble/curves >=2.0.0` so the same bump is not re-proposed until the CJS build strategy supports ESM-only deps

### Verification

- CJS smoke test: fails with `ERR_REQUIRE_ESM` on current main, passes with this branch
- Unit tests: cryptography 169/169, SDK 1896/1896 passing
- `pnpm install --frozen-lockfile` passes with the updated lockfile

### Related Issues

- Fixes the SDK TCK Regression failure in the nightly CITR Ext Test Suite (consensus-node run 29881093619)