### PR TITLE
test: fix and re-enable 'can set network name on custom network'

### DIFF
--- a/test/integration/ClientIntegrationTest.js
+++ b/test/integration/ClientIntegrationTest.js
@@ -79,15 +79,15 @@ describe("ClientIntegration", function () {
         expect(error).to.be.an("Error");
     });
 
-    // TODO(2023-11-01 NK) - test is consistently failing and should be enabled once fixed.
-
-    it.skip("can set network name on custom network", async function () {
+    it("can set network name on custom network", async function () {
         expect(clientTestnet.ledgerId).to.be.equal(LedgerId.TESTNET);
         expect(clientPreviewNet.ledgerId).to.be.equal(LedgerId.PREVIEWNET);
 
         await clientTestnet.setNetwork(clientPreviewNet.network);
 
-        expect(clientTestnet.ledgerId).to.be.null;
+        // `setNetwork` only replaces the node map — it does not touch the
+        // ledger ID; switching ledgers requires an explicit `setLedgerId`
+        expect(clientTestnet.ledgerId).to.be.equal(LedgerId.TESTNET);
 
         clientTestnet.setLedgerId("previewnet");
 


### PR DESCRIPTION
## Description

Closes #4262 — fixes and re-enables `it.skip("can set network name on custom network")` in `test/integration/ClientIntegrationTest.js`, disabled since November 2023 (`TODO(2023-11-01 NK)`, introduced in #2289).

### Root cause

The test asserted that `clientTestnet.ledgerId` becomes `null` after `await clientTestnet.setNetwork(clientPreviewNet.network)`. That expectation is stale: `Client.setNetwork` only replaces the node map and deliberately does **not** clear `_ledgerId` — the ledger ID persists until it is explicitly changed via `setLedgerId`. This is the correct contract, because clearing the ledger ID on every `setNetwork` call would silently break entity ID checksum validation for users who refresh their node list on the same network. So the `to.be.null` assertion could never pass — the test wasn't flaky, it was deterministically wrong.

### What this PR changes

- Replaces the `expect(clientTestnet.ledgerId).to.be.null` assertion with `expect(clientTestnet.ledgerId).to.be.equal(LedgerId.TESTNET)`, with a comment documenting the `setNetwork` vs `setLedgerId` contract.
- Removes the `it.skip` and the 2023 TODO comment.

### Verification

The test body makes no network calls (`ledgerId`, `setNetwork`, and `setLedgerId` are all client-side state), so the exact test sequence was executed standalone against the current source:

```
1. testnet ledgerId === LedgerId.TESTNET       → true
2. previewnet ledgerId === LedgerId.PREVIEWNET → true
3. after setNetwork, ledgerId                  → "testnet" (not null — old assertion fails, new one passes)
4. after setLedgerId("previewnet"), ledgerId === LedgerId.PREVIEWNET → true
```

All four assertions of the re-enabled test pass. Prettier passes.
