### PR TITLE
fix(deps): remove duplicate lru-cache entry from pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9256,10 +9256,6 @@ packages:
     resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
     engines: {node: 20 || >=22}
 
-  lru-cache@11.5.2:
-    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
-    engines: {node: 20 || >=22}
-
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
 
@@ -24997,8 +24993,6 @@ snapshots:
       tslib: 2.8.1
 
   lru-cache@10.4.3: {}
-
-  lru-cache@11.5.2: {}
 
   lru-cache@11.5.2: {}
 


### PR DESCRIPTION
## Problem

Flagged by @Jexsie on #4300: the lockfile got a duplicate that made pnpm ignore it and blow up eslint in `packages/proto`.

The merge of #4300 (chromedriver `150.0.0` -> `151.0.2`) duplicated the `lru-cache@11.5.2` entry in **both** the `packages:` and `snapshots:` sections of `pnpm-lock.yaml` (1+1 -> 2+2 occurrences).

Duplicate YAML keys make pnpm treat the lockfile as invalid and fall back to a **full fresh resolution**. That silently re-resolves transitive dependencies to different versions (e.g. `tldts 7.4.10 -> 7.4.2`, `postcss 8.5.23 -> 8.5.19`, `ip-address 10.4.0 -> 10.2.0`) and breaks eslint in `packages/proto`.

## Fix

Surgically remove only the two duplicate `lru-cache@11.5.2` blocks (6 lines), preserving every intended locked version.

## Verification

- Duplicate-key scan of the lockfile: none remain.
- `pnpm@9.15.5 install --lockfile-only` (the exact version CI uses) on the fixed lockfile produces **zero further changes** — the deduped lockfile is valid and fully consistent with all workspace manifests, so CI's `pnpm i` is a clean no-op instead of re-resolving.
- `eslint` in `packages/proto` runs clean.